### PR TITLE
Corrects ZOH tensor dimension comment

### DIFF
--- a/csrc/src/flash.h
+++ b/csrc/src/flash.h
@@ -46,7 +46,7 @@ struct QKV_params {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 struct ZOH_params {
-    void *__restrict__ zoh_ptr;                 // ZOH states tensor [batch_size, num_kv_heads, key_len]
+    void *__restrict__ zoh_ptr;                 // ZOH states tensor [batch_size, num_kv_heads, query_len, key_len]
     void * __restrict__ active_mask_ptr;        // Active mask tensor [batch_size, num_kv_heads, query_len, key_len]
 
     // The stride of the zero-hold states and active mask tensors.


### PR DESCRIPTION
Updates the comment for the ZOH states tensor to accurately reflect its 4D structure with query_len dimension, ensuring documentation matches the actual tensor shape used in the implementation.