### PR TITLE
Adds conditional softcap switch macro

### DIFF
--- a/csrc/src/static_switch.h
+++ b/csrc/src/static_switch.h
@@ -46,6 +46,16 @@
   #define EVENK_SWITCH BOOL_SWITCH
 #endif
 
+#ifdef FLASHATTENTION_DISABLE_SOFTCAP
+  #define SOFTCAP_SWITCH(COND, CONST_NAME, ...)   \
+  [&] {                                         \
+    constexpr static bool CONST_NAME = false;    \
+    return __VA_ARGS__();                       \
+  }()
+#else
+  #define SOFTCAP_SWITCH BOOL_SWITCH
+#endif
+
 #define FP16_SWITCH(COND, ...)               \
   [&] {                                      \
     if (COND) {                              \


### PR DESCRIPTION
Introduces a new SOFTCAP_SWITCH macro that can be conditionally disabled via the FLASHATTENTION_DISABLE_SOFTCAP preprocessor flag.

When the flag is defined, the macro forces the condition to false, effectively disabling softcap functionality. Otherwise, it defaults to the standard BOOL_SWITCH behavior.