### PR TITLE
Removes unused template parameter from DynamicMask

### DIFF
--- a/csrc/src/mask.h
+++ b/csrc/src/mask.h
@@ -20,7 +20,7 @@ namespace FLASH_NAMESPACE {
 
 using namespace cute;
 
-template <bool Is_causal, int kNThreads>
+template <bool Is_causal>
 struct DynamicMask {
     const int max_seqlen_k, max_seqlen_q;
     const int keep_window_size;


### PR DESCRIPTION
Simplifies the template signature by removing the kNThreads parameter that was not being used within the struct definition, reducing template complexity without affecting functionality.