### PR TITLE
Add specialized CUDA kernels for multi-head attention with various head dimensions

### DIFF
--- a/csrc/src/flash_fwd_hdim128_bf16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_hdim128_bf16_causal_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 128, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim128<cutlass::bfloat16_t, true>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim128_bf16_sm80.cu
+++ b/csrc/src/flash_fwd_hdim128_bf16_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 128, false>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim128<cutlass::bfloat16_t, false>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim128_fp16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_hdim128_fp16_causal_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::half_t, 128, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim128<cutlass::half_t, true>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim128_fp16_sm80.cu
+++ b/csrc/src/flash_fwd_hdim128_fp16_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::half_t, 128, false>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim128<cutlass::half_t, false>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim192_bf16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_hdim192_bf16_causal_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 192, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim192<cutlass::bfloat16_t, true>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim192_bf16_sm80.cu
+++ b/csrc/src/flash_fwd_hdim192_bf16_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 192, false>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim192<cutlass::bfloat16_t, false>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim192_fp16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_hdim192_fp16_causal_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::half_t, 192, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim192<cutlass::half_t, true>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim192_fp16_sm80.cu
+++ b/csrc/src/flash_fwd_hdim192_fp16_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::half_t, 192, false>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim192<cutlass::half_t, false>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim256_bf16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_hdim256_bf16_causal_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 256, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim256<cutlass::bfloat16_t, true>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim256_bf16_sm80.cu
+++ b/csrc/src/flash_fwd_hdim256_bf16_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 256, false>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim256<cutlass::bfloat16_t, false>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim256_fp16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_hdim256_fp16_causal_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::half_t, 256, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim256<cutlass::half_t, true>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim256_fp16_sm80.cu
+++ b/csrc/src/flash_fwd_hdim256_fp16_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::half_t, 256, false>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim256<cutlass::half_t, false>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim32_bf16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_hdim32_bf16_causal_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 32, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim32<cutlass::bfloat16_t, true>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim32_bf16_sm80.cu
+++ b/csrc/src/flash_fwd_hdim32_bf16_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 32, false>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim32<cutlass::bfloat16_t, false>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim32_fp16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_hdim32_fp16_causal_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::half_t, 32, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim32<cutlass::half_t, true>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim32_fp16_sm80.cu
+++ b/csrc/src/flash_fwd_hdim32_fp16_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::half_t, 32, false>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim32<cutlass::half_t, false>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim64_bf16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_hdim64_bf16_causal_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 64, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim64<cutlass::bfloat16_t, true>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim64_bf16_sm80.cu
+++ b/csrc/src/flash_fwd_hdim64_bf16_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 64, false>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim64<cutlass::bfloat16_t, false>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim64_fp16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_hdim64_fp16_causal_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::half_t, 64, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim64<cutlass::half_t, true>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim64_fp16_sm80.cu
+++ b/csrc/src/flash_fwd_hdim64_fp16_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::half_t, 64, false>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim64<cutlass::half_t, false>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim96_bf16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_hdim96_bf16_causal_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 96, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim96<cutlass::bfloat16_t, true>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim96_bf16_sm80.cu
+++ b/csrc/src/flash_fwd_hdim96_bf16_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 96, false>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim96<cutlass::bfloat16_t, false>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim96_fp16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_hdim96_fp16_causal_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::half_t, 96, true>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim96<cutlass::half_t, true>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_hdim96_fp16_sm80.cu
+++ b/csrc/src/flash_fwd_hdim96_fp16_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::half_t, 96, false>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim96<cutlass::half_t, false>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim128_bf16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim128_bf16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 128, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim128_bf16_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim128_bf16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 128, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim128_fp16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim128_fp16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 128, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim128_fp16_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim128_fp16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 128, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim192_bf16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim192_bf16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 192, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim192_bf16_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim192_bf16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 192, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim192_fp16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim192_fp16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 192, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim192_fp16_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim192_fp16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 192, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim256_bf16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim256_bf16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 256, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim256_bf16_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim256_bf16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 256, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim256_fp16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim256_fp16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 256, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim256_fp16_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim256_fp16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 256, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim32_bf16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim32_bf16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 32, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim32_bf16_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim32_bf16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 32, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim32_fp16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim32_fp16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 32, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim32_fp16_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim32_fp16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 32, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim64_bf16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim64_bf16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 64, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim64_bf16_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim64_bf16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 64, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim64_fp16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim64_fp16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 64, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim64_fp16_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim64_fp16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 64, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim96_bf16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim96_bf16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 96, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim96_bf16_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim96_bf16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 96, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim96_fp16_causal_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim96_fp16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 96, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/flash_fwd_split_hdim96_fp16_sm80.cu
+++ b/csrc/src/flash_fwd_split_hdim96_fp16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Jingze Shi and Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 96, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/src/generate_kernels.py
+++ b/csrc/src/generate_kernels.py
@@ -1,6 +1,5 @@
 import argparse
 import itertools
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
@@ -53,7 +52,7 @@ class Kernel:
     sm: int
     dtype: str
     head_dim: int
-    is_causal: str
+    is_causal: bool
     direction: str
 
     @property
@@ -61,7 +60,7 @@ class Kernel:
         template_funcs = {
             "fwd": get_fwd_template,
             # "bwd": get_bwd_template,
-            # "fwd_split": get_fwd_split_template
+            "fwd_split": get_fwd_split_template
         }
         template_func = template_funcs[self.direction]
         return template_func().format(
@@ -75,7 +74,8 @@ class Kernel:
         return f"flash_{self.direction}_hdim{self.head_dim}_{self.dtype}_{'causal_' if self.is_causal == 'true' else ''}sm{self.sm}.cu"
 
 def get_all_kernels() -> List[Kernel]:
-    for direction in ["fwd"]: #, "fwd_split", "bwd"]:
+    # for direction in ["fwd", "fwd_split", "bwd"]:
+    for direction in ["fwd", "fwd_split"]:
         for dtype, head_dim, is_causal, sm in itertools.product(DTYPE_MAP.keys(), HEAD_DIMENSIONS, IS_CAUSAL, SM):
             yield Kernel(sm=sm, dtype=dtype, head_dim=head_dim, is_causal=is_causal, direction=direction)
 

--- a/csrc/src/generate_kernels.py
+++ b/csrc/src/generate_kernels.py
@@ -52,7 +52,7 @@ class Kernel:
     sm: int
     dtype: str
     head_dim: int
-    is_causal: bool
+    is_causal: str
     direction: str
 
     @property

--- a/csrc/src/generate_kernels.py
+++ b/csrc/src/generate_kernels.py
@@ -2,7 +2,7 @@ import argparse
 import itertools
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional, Generator
 
 DTYPE_MAP = {
     "fp16": "cutlass::half_t",
@@ -73,7 +73,7 @@ class Kernel:
     def filename(self) -> str:
         return f"flash_{self.direction}_hdim{self.head_dim}_{self.dtype}_{'causal_' if self.is_causal == 'true' else ''}sm{self.sm}.cu"
 
-def get_all_kernels() -> List[Kernel]:
+def get_all_kernels() -> Generator[Kernel, None, None]:
     # for direction in ["fwd", "fwd_split", "bwd"]:
     for direction in ["fwd", "fwd_split"]:
         for dtype, head_dim, is_causal, sm in itertools.product(DTYPE_MAP.keys(), HEAD_DIMENSIONS, IS_CAUSAL, SM):


### PR DESCRIPTION
Introduce dedicated CUDA kernel implementations for causal multi-head attention across multiple head dimensions and precision types. Separate files improve compilation performance by reducing template instantiation overhead.