### PR TITLE
Adds column stride parameters to ZOH_params struct

### DIFF
--- a/csrc/src/flash.h
+++ b/csrc/src/flash.h
@@ -56,6 +56,8 @@ struct ZOH_params {
     index_t active_mask_head_stride;            // Stride between heads of active mask
     index_t zoh_row_stride;                     // Stride between rows of ZOH states
     index_t active_mask_row_stride;             // Stride between rows of active mask
+    index_t zoh_col_stride;                     // Stride between columns of ZOH states
+    index_t active_mask_col_stride;             // Stride between columns of active mask
 
     // The keep window size.
     int keep_window_size;                       // Number of tokens to keep in top-k (0 means don't apply top-k)


### PR DESCRIPTION
Extends the parameter structure to support column-wise memory layout by adding stride fields for both ZOH states and active mask data.

Enables more flexible memory access patterns and improves compatibility with different tensor layouts.