### PR TITLE
Temporarily disables Split-KV feature

### DIFF
--- a/csrc/flash_api.cpp
+++ b/csrc/flash_api.cpp
@@ -256,6 +256,7 @@ std::tuple<at::Tensor, at::Tensor> set_params_splitkv(
     }
 
     // Temporarily disable Split-KV, because some bugs are still being fixed.
+    // See: https://github.com/SmallDoges/flash-dmattn/issues/47
     // Regardless of how it is set externally, always set num_splits back to 1.
     // This is to avoid the extra memory overhead of Split-KV.
     params.num_splits = 1;


### PR DESCRIPTION
#47 
Forces num_splits to 1 and resets accumulator tensors to avoid memory overhead while bugs in the Split-KV implementation are being fixed.

This ensures stability by bypassing the problematic feature until issues are resolved.