### PR TITLE
Refactor attention mask and bias structures for clarity

### DIFF
--- a/benchmarks/benchmark_forward_equivalence.py
+++ b/benchmarks/benchmark_forward_equivalence.py
@@ -232,20 +232,20 @@ def dynamic_mask_attention_cuda(
 
     # Call the CUDA implementation using the mha_fwd function signature
     out_tensor = None  # Let the function allocate the output tensor
-    result = flash_dma_cuda.fwd(  # type: ignore
-        query_states,             # q: [batch, seqlen_q, num_heads, head_dim]
-        key_states,               # k: [batch, seqlen_k, num_kv_heads, head_dim]
-        value_states,             # v: [batch, seqlen_k, num_kv_heads, head_dim]
-        zero_hold_states,         # zoh: [batch, num_kv_heads, seqlen_q, seqlen_k] - processed attention mask
-        active_mask,              # active_mask: [batch, num_kv_heads, seqlen_q, seqlen_k]
-        out_tensor,               # out: None to auto-allocate
-        0.0,                      # p_dropout
-        scaling,                  # softmax_scale
-        is_causal,                # is_causal
-        keep_window_size,         # keep_window_size
-        0.0,                      # softcap
-        return_softmax,           # return_softmax
-        None                      # gen (generator)
+    result = flash_dma_cuda.fwd(    # type: ignore
+        query_states,               # q: [batch, seqlen_q, num_heads, head_dim]
+        key_states,                 # k: [batch, seqlen_k, num_kv_heads, head_dim]
+        value_states,               # v: [batch, seqlen_k, num_kv_heads, head_dim]
+        active_mask,                # attn_mask: [batch, num_kv_heads, seqlen_q, seqlen_k]
+        attn_mask,                  # bias: [batch, num_kv_heads, seqlen_q, seqlen_k]
+        out_tensor,                 # out: None to auto-allocate
+        0.0,                        # p_dropout
+        scaling,                    # softmax_scale
+        is_causal,                  # is_causal
+        keep_window_size,           # keep_window_size
+        0.0,                        # softcap
+        return_softmax,             # return_softmax
+        None                        # gen (generator)
     )
     
     attn_outputs = result[0]  # [batch, query_len, num_heads, head_dim]

--- a/csrc/src/block_info.h
+++ b/csrc/src/block_info.h
@@ -36,15 +36,15 @@ struct BlockInfo {
     }
 
     template <typename index_t>
-    __forceinline__ __device__ index_t zoh_offset(const index_t batch_stride, const int row_stride, const int col_stride, const int bidb
-    ) const {
+    __forceinline__ __device__ index_t attn_mask_offset(const index_t batch_stride, int row_stride, const int col_stride, const int bidb) const {
         index_t offset = sum_s_q == -1 ? bidb * batch_stride : uint32_t(sum_s_q) * row_stride;
         sum_s_k == -1 ? offset += leftpad_k * col_stride : offset += uint32_t(sum_s_k + leftpad_k) * col_stride;
         return offset;
     }
 
     template <typename index_t>
-    __forceinline__ __device__ index_t active_mask_offset(const index_t batch_stride, int row_stride, const int col_stride, const int bidb) const {
+    __forceinline__ __device__ index_t attn_bias_offset(const index_t batch_stride, const int row_stride, const int col_stride, const int bidb
+    ) const {
         index_t offset = sum_s_q == -1 ? bidb * batch_stride : uint32_t(sum_s_q) * row_stride;
         sum_s_k == -1 ? offset += leftpad_k * col_stride : offset += uint32_t(sum_s_k + leftpad_k) * col_stride;
         return offset;

--- a/csrc/src/flash.h
+++ b/csrc/src/flash.h
@@ -45,27 +45,34 @@ struct QKV_params {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-struct ZOH_params {
-    void *__restrict__ zoh_ptr;                 // ZOH states tensor [batch_size, num_kv_heads, query_len, key_len]
-    void * __restrict__ active_mask_ptr;        // Active mask tensor [batch_size, num_kv_heads, query_len, key_len]
+struct Mask_params {
+    void * __restrict__ attn_mask_ptr;      // Attention mask tensor [batch_size, num_kv_heads, query_len, key_len]
 
-    // The stride of the zero-hold states and active mask tensors.
-    index_t zoh_batch_stride;                   // Stride between batches of ZOH states
-    index_t active_mask_batch_stride;           // Stride between batches of active mask
-    index_t zoh_head_stride;                    // Stride between heads of ZOH states
-    index_t active_mask_head_stride;            // Stride between heads of active mask
-    index_t zoh_row_stride;                     // Stride between rows of ZOH states
-    index_t active_mask_row_stride;             // Stride between rows of active mask
-    index_t zoh_col_stride;                     // Stride between columns of ZOH states
-    index_t active_mask_col_stride;             // Stride between columns of active mask
+    // The stride of the attention mask tensors.
+    index_t attn_mask_batch_stride;         // Stride between batches of attention mask
+    index_t attn_mask_head_stride;          // Stride between heads of attention mask
+    index_t attn_mask_row_stride;           // Stride between rows of attention mask
+    index_t attn_mask_col_stride;           // Stride between columns of attention mask
 
     // The keep window size.
-    int keep_window_size;                       // Number of tokens to keep in top-k (0 means don't apply top-k)
+    int keep_window_size;                   // Number of tokens to keep in top-k
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-struct Flash_fwd_params : public QKV_params, public ZOH_params {
+struct Bias_params {
+    void *__restrict__ attn_bias_ptr;       // Attention bias tensor [batch_size, num_kv_heads, query_len, key_len]
+
+    // The stride of the attention bias tensor.
+    index_t attn_bias_batch_stride;         // Stride between batches of attention bias
+    index_t attn_bias_head_stride;          // Stride between heads of attention bias
+    index_t attn_bias_row_stride;           // Stride between rows of attention bias
+    index_t attn_bias_col_stride;           // Stride between columns of attention bias
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct Flash_fwd_params : public QKV_params, public Mask_params, public Bias_params {
 
     // The O matrix (output).
     void * __restrict__ o_ptr;

--- a/csrc/src/utils.h
+++ b/csrc/src/utils.h
@@ -500,7 +500,7 @@ __forceinline__ __device__ void copy(
 template <bool Is_even_MN=true, bool Clear_OOB_MN=true,
           typename TiledCopy, typename Engine0, typename Layout0, typename Engine1, typename Layout1,
           typename Engine2, typename Layout2>
-__forceinline__ __device__ void copy_ZOH(
+__forceinline__ __device__ void copy_Mask(
     TiledCopy tiled_copy, Tensor<Engine0, Layout0> const &S,
     Tensor<Engine1, Layout1> &D, Tensor<Engine2, Layout2> const &identity_MN,
     const int max_M=0, const int max_N=0


### PR DESCRIPTION
Enhance code readability and organization by renaming functions and parameters related to attention masks and biases. Separate the ZOH parameters into distinct mask and bias structures, improving clarity in memory management and function signatures. Adjust the CUDA function call to ensure proper parameter alignment.