### PR TITLE
Add bias gradient computation support in backward kernel

### DIFF
--- a/csrc/src/flash_bwd_kernel.h
+++ b/csrc/src/flash_bwd_kernel.h
@@ -129,7 +129,7 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
     // Regarding 128 * params.b see a comment in mha_varlen_bwd about padding of dq_accum and softmax_d
     const index_t row_offset_dpsum = (params.unpadded_lse? bidh * (params.total_q + 128 * params.b) + binfo.q_offset(params.seqlen_q_rounded, 1, bidb) + 128 * bidb: (bidb * params.h + bidh) * params.seqlen_q_rounded) + (m_block_max - 1) * kBlockM;
 
-    // Golobal memory tensor configuration
+    // Global memory tensor configuration
     Tensor gQ = make_tensor(
         make_gmem_ptr(reinterpret_cast<Element *>(params.q_ptr) + row_offset_q),
         Shape<Int<kBlockM>, Int<kHeadDim>>{},

--- a/csrc/src/flash_fwd_kernel.h
+++ b/csrc/src/flash_fwd_kernel.h
@@ -143,7 +143,7 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
     const index_t row_offset_p = ((bidb * params.h + bidh) * params.seqlen_q_rounded
         + m_block * kBlockM) * params.seqlen_k_rounded + (n_block_max - 1) * kBlockN;
 
-    // Golobal memory tensor configuration
+    // Global memory tensor configuration
     Tensor mQ = make_tensor(
         make_gmem_ptr(reinterpret_cast<Element*>(params.q_ptr) + binfo.q_offset(params.q_batch_stride, params.q_row_stride, bidb)),
         make_shape(binfo.actual_seqlen_q, params.h, params.d),


### PR DESCRIPTION
Introduce bias gradient computation in the backward kernel, including dedicated offset calculations and tensor configurations. Enhance tensor declarations and memory layouts to support improved backward pass functionality.