### PR TITLE
Simplify attention mask and bias parameter naming

### DIFF
--- a/csrc/src/block_info.h
+++ b/csrc/src/block_info.h
@@ -36,14 +36,14 @@ struct BlockInfo {
     }
 
     template <typename index_t>
-    __forceinline__ __device__ index_t attn_mask_offset(const index_t batch_stride, int row_stride, const int col_stride, const int bidb) const {
+    __forceinline__ __device__ index_t mask_offset(const index_t batch_stride, int row_stride, const int col_stride, const int bidb) const {
         index_t offset = sum_s_q == -1 ? bidb * batch_stride : uint32_t(sum_s_q) * row_stride;
         sum_s_k == -1 ? offset += leftpad_k * col_stride : offset += uint32_t(sum_s_k + leftpad_k) * col_stride;
         return offset;
     }
 
     template <typename index_t>
-    __forceinline__ __device__ index_t attn_bias_offset(const index_t batch_stride, const int row_stride, const int col_stride, const int bidb
+    __forceinline__ __device__ index_t bias_offset(const index_t batch_stride, const int row_stride, const int col_stride, const int bidb
     ) const {
         index_t offset = sum_s_q == -1 ? bidb * batch_stride : uint32_t(sum_s_q) * row_stride;
         sum_s_k == -1 ? offset += leftpad_k * col_stride : offset += uint32_t(sum_s_k + leftpad_k) * col_stride;

--- a/csrc/src/block_info.h
+++ b/csrc/src/block_info.h
@@ -36,15 +36,14 @@ struct BlockInfo {
     }
 
     template <typename index_t>
-    __forceinline__ __device__ index_t mask_offset(const index_t batch_stride, int row_stride, const int col_stride, const int bidb) const {
+    __forceinline__ __device__ index_t mask_offset(const index_t batch_stride, const index_t row_stride, const index_t col_stride, const int bidb) const {
         index_t offset = sum_s_q == -1 ? bidb * batch_stride : uint32_t(sum_s_q) * row_stride;
         sum_s_k == -1 ? offset += leftpad_k * col_stride : offset += uint32_t(sum_s_k + leftpad_k) * col_stride;
         return offset;
     }
 
     template <typename index_t>
-    __forceinline__ __device__ index_t bias_offset(const index_t batch_stride, const int row_stride, const int col_stride, const int bidb
-    ) const {
+    __forceinline__ __device__ index_t bias_offset(const index_t batch_stride, const index_t row_stride, const index_t col_stride, const int bidb) const {
         index_t offset = sum_s_q == -1 ? bidb * batch_stride : uint32_t(sum_s_q) * row_stride;
         sum_s_k == -1 ? offset += leftpad_k * col_stride : offset += uint32_t(sum_s_k + leftpad_k) * col_stride;
         return offset;

--- a/csrc/src/flash.h
+++ b/csrc/src/flash.h
@@ -46,28 +46,25 @@ struct QKV_params {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 struct Mask_params {
-    void * __restrict__ attn_mask_ptr;      // Attention mask tensor [batch_size, num_kv_heads, query_len, key_len]
+    void * __restrict__ mask_ptr;       // Attention mask tensor [batch_size, num_kv_heads, query_len, key_len]
 
     // The stride of the attention mask tensors.
-    index_t attn_mask_batch_stride;         // Stride between batches of attention mask
-    index_t attn_mask_head_stride;          // Stride between heads of attention mask
-    index_t attn_mask_row_stride;           // Stride between rows of attention mask
-    index_t attn_mask_col_stride;           // Stride between columns of attention mask
-
-    // The keep window size.
-    int keep_window_size;                   // Number of tokens to keep in top-k
+    index_t mask_batch_stride;          // Stride between batches of attention mask
+    index_t mask_head_stride;           // Stride between heads of attention mask
+    index_t mask_row_stride;            // Stride between rows of attention mask
+    index_t mask_col_stride;            // Stride between columns of attention mask
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 struct Bias_params {
-    void *__restrict__ attn_bias_ptr;       // Attention bias tensor [batch_size, num_kv_heads, query_len, key_len]
+    void *__restrict__ bias_ptr;        // Attention bias tensor [batch_size, num_kv_heads, query_len, key_len]
 
     // The stride of the attention bias tensor.
-    index_t attn_bias_batch_stride;         // Stride between batches of attention bias
-    index_t attn_bias_head_stride;          // Stride between heads of attention bias
-    index_t attn_bias_row_stride;           // Stride between rows of attention bias
-    index_t attn_bias_col_stride;           // Stride between columns of attention bias
+    index_t bias_batch_stride;          // Stride between batches of attention bias
+    index_t bias_head_stride;           // Stride between heads of attention bias
+    index_t bias_row_stride;            // Stride between rows of attention bias
+    index_t bias_col_stride;            // Stride between columns of attention bias
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Remove redundant prefixes from attention mask and bias parameters to enhance code readability and consistency. Eliminate unused parameters to streamline the interface across the flash attention API.