### PR TITLE
Remove paper citation and author information from README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,6 @@
 
 </div>
 
-**Trainable Dynamic Mask Sparse Attention**
-
-> Jingze Shi, Yifan Wu, Bingheng Wu, Yiran Peng, Liangdong Wang, Guang Liu, Yuyu Luo
-
-> Paper: https://huggingface.co/papers/2508.02124
 
 ![Flash-DMA Banner](assets/flash_dmattn_banner.png)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -9,11 +9,6 @@
 
 </div>
 
-**可训练的动态掩码稀疏注意力**
-
-> Jingze Shi, Yifan Wu, Bingheng Wu, Yiran Peng, Liangdong Wang, Guang Liu, Yuyu Luo
-
-> 论文: https://huggingface.co/papers/2508.02124
 
 ![Flash-DMA Banner](assets/flash_dmattn_banner.png)
 


### PR DESCRIPTION
Eliminate references to the research paper and author credits in both English and Chinese README files to streamline documentation and focus on implementation.