### PR TITLE
Remove unused CUDA generator includes for improved build performance

### DIFF
--- a/csrc/flash_api.cpp
+++ b/csrc/flash_api.cpp
@@ -7,8 +7,6 @@
 #include <torch/nn/functional.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
-#include <ATen/cuda/CUDAGeneratorImpl.h>  // For at::Generator and at::PhiloxCudaState
-#include <ATen/cuda/detail/UnpackRaw.cuh> // For at::cuda::philox::unpack
 
 #include <cutlass/numeric_types.h>
 

--- a/csrc/src/flash.h
+++ b/csrc/src/flash.h
@@ -9,8 +9,6 @@
 #include <cuda.h>
 #include <vector>
 
-#include <ATen/cuda/CUDAGeneratorImpl.h> // For at::Generator and at::PhiloxCudaState
-
 namespace FLASH_NAMESPACE {
 constexpr int TOTAL_DIM = 0;
 constexpr int H_DIM = 1;


### PR DESCRIPTION
Eliminate unnecessary ATen CUDA generator imports to reduce compilation dependencies and enhance build efficiency.