### PR TITLE
Optimize sparse logic

### DIFF
--- a/benchmarks/backward_performance.py
+++ b/benchmarks/backward_performance.py
@@ -1,0 +1,985 @@
+#!/usr/bin/env python3
+"""
+Backward Performance Benchmark for Dynamic Mask Attention
+
+This script measures and compares the backward pass performance of multiple Dynamic Mask Attention 
+implementations against SDPA baseline across various configurations.
+
+Implementations tested:
+- PyTorch SDPA - Baseline (backward pass)
+- Dynamic Mask Attention CUDA - Custom CUDA kernel implementation (backward pass)
+- Dynamic Mask Attention Triton - Triton kernel implementation (backward pass)
+- Dynamic Mask Attention Flex - Flex Attention implementation (backward pass)
+
+Benchmark includes:
+- Multiple sequence lengths and batch sizes
+- Head count and dimension variations
+- Backward pass throughput and latency measurements
+- Memory usage analysis during backward pass
+- Speedup comparisons across all implementations for gradient computation
+"""
+
+import torch
+import torch.nn.functional as F
+import argparse
+import time
+import gc
+import sys
+
+# Import the compiled CUDA extension
+try:
+    from flash_dmattn.flash_dmattn_interface import flash_dmattn_func
+    print("✅ Successfully imported flash_dmattn interface")
+except ImportError as e:
+    print(f"❌ Failed to import flash_dmattn interface: {e}")
+    print("Please make sure the package is properly installed with: pip install .")
+    # Don't exit here, just warn
+    flash_dmattn_func = None
+
+# Import the Triton implementation
+try:
+    from flash_dmattn.flash_dmattn_triton import triton_dmattn_func
+    print("✅ Successfully imported flash_dmattn_triton")
+except ImportError as e:
+    print(f"❌ Failed to import flash_dmattn_triton: {e}")
+    print("Please make sure the Triton implementation is available.")
+    # Don't exit here, just warn
+    triton_dmattn_func = None
+
+# Import the Flex Attention implementation
+try:
+    from flash_dmattn.flash_dmattn_flex import flex_dmattn_func
+    print("✅ Successfully imported flash_dmattn_flex")
+except ImportError as e:
+    print(f"❌ Failed to import flash_dmattn_flex: {e}")
+    print("Please make sure the Flex Attention implementation is available.")
+    # Don't exit here, just warn
+    flex_dmattn_func = None
+
+
+def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """
+    Equivalent of torch.repeat_interleave(x, dim=1, repeats=n_rep). 
+    Transform from (batch, num_key_value_heads, seqlen, head_dim) 
+    to (batch, num_attention_heads, seqlen, head_dim)
+    """
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+def prepare_dynamic_mask(
+    hidden_states: torch.Tensor,
+    zoh_states: torch.Tensor,
+    keep_window_size: int = 2048,
+    attention_mask: torch.Tensor | None = None,
+):
+    """
+    Calculate dynamic attention mask to mask tokens for sparse attention.
+
+    Combine `zoh_states` with `attention_mask` to generate the final `attn_mask`.
+
+    Args:
+        hidden_states: Input hidden states to determine dtype minimum value
+        zoh_states: zoh_states of shape (batch_size, num_kv_heads, key_sequence_length)
+        keep_window_size: Window size of tokens not dynamically masked
+        attention_mask: Optional attention mask of shape (batch_size, 1, query_len, key_len)
+    
+    Returns:
+        tuple: (attn_bias, attn_mask)
+    """
+    min_dtype = torch.finfo(hidden_states.dtype).min
+    dtype = hidden_states.dtype
+    attn_bias = zoh_states[:, :, None, :].expand(
+        -1, -1, hidden_states.shape[2], -1
+    )  # [batch_size, num_kv_heads, query_len, key_len]
+    
+    if attention_mask is not None:
+        if attention_mask.dtype == torch.bool:
+            attention_mask = torch.where(
+                attention_mask, 
+                torch.tensor(0.0, device=attention_mask.device, dtype=dtype), 
+                min_dtype
+            )
+        attn_bias = attn_bias.masked_fill(
+            attention_mask[:, :, :, : attn_bias.shape[-1]] != 0, min_dtype
+        )
+    
+    if attn_bias.shape[-1] > keep_window_size:
+        topk_values, topk_indices = torch.topk(
+            attn_bias, keep_window_size, dim=-1, largest=True, sorted=False
+        )
+        valid_topk = topk_values != min_dtype
+        attn_mask = torch.zeros_like(attn_bias, dtype=dtype, device=attn_bias.device)
+        attn_mask = attn_mask.scatter(-1, topk_indices, valid_topk.to(dtype))
+        attn_bias = attn_bias.masked_fill(attn_mask == 0.0, min_dtype)
+    else:
+        attn_mask = torch.ones_like(attn_bias, dtype=dtype, device=attn_bias.device)
+    return attn_bias, attn_mask
+
+
+def calculate_zoh_states(value_states, dt_proj, A):
+    """
+    Calculate zoh states for dynamic mask attention.
+    
+    Args:
+        value_states: [batch_size, num_kv_heads, key_len, head_dim]
+        dt_proj: [num_kv_heads, num_kv_heads * head_dim]
+        A: [num_kv_heads]
+        causal_mask: Optional causal mask
+    
+    Returns:
+        zoh_states: [batch_size, num_kv_heads, key_len]
+    """
+    batch_size, _, key_len, _ = value_states.shape
+    
+    # Transpose and reshape value_states, then matrix multiply with dt_proj.T
+    dt_result = torch.matmul(
+        value_states.transpose(-2, -3).reshape(batch_size, key_len, -1), 
+        dt_proj.T
+    )
+    
+    # Apply softplus activation and coefficient A
+    dt_states = torch.exp(F.softplus(dt_result) * A)
+    zoh_states = dt_states.transpose(-1, -2)  # [batch_size, num_kv_heads, key_len]
+
+    return zoh_states
+
+
+def scaled_dot_product_attention_backward(
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    value_states: torch.Tensor,
+    scaling: float,
+    causal_mask: torch.Tensor,
+    is_causal=True,
+):
+    """
+    SDPA baseline backward pass implementation.
+    
+    Args:
+        query_states: [batch_size, num_heads, query_len, head_dim]
+        key_states: [batch_size, num_kv_heads, key_len, head_dim]
+        value_states: [batch_size, num_kv_heads, key_len, head_dim]
+        scaling: Attention scaling factor
+        causal_mask: Causal attention mask
+        is_causal: Whether to apply causal masking
+    
+    Returns:
+        tuple: (output_tensor, timing_ms) or ("OOM", 0) if out of memory
+    """
+    _, _, query_len, _ = query_states.shape
+    _, _, key_len, _ = key_states.shape
+    if query_len > 32768 and key_len > 32768:
+        return "OOM", 0
+
+    query_states = query_states.contiguous()
+    key_states = key_states.contiguous()
+    value_states = value_states.contiguous()
+
+    try:
+        # Create gradient for output
+        batch_size, num_heads, query_len, head_dim = query_states.shape
+        dout = torch.randn(
+            batch_size, query_len, num_heads, head_dim,
+            device=query_states.device, dtype=query_states.dtype
+        )
+        
+        # Forward pass - SDPA expects q, k, v in [batch, num_heads, seq_len, head_dim] format
+        attn_outputs = F.scaled_dot_product_attention(
+            query_states,                    # [batch, num_heads, query_len, head_dim]
+            key_states,                      # [batch, num_kv_heads, key_len, head_dim]
+            value_states,                    # [batch, num_kv_heads, key_len, head_dim]
+            attn_mask=causal_mask,
+            scale=scaling,
+            # is_causal=is_causal if query_len == key_len else False,
+            enable_gqa=True
+        )
+        # Transpose to match expected output format
+        attn_outputs = attn_outputs.transpose(1, 2).contiguous()  # [batch, query_len, num_heads, head_dim]
+        
+        torch.cuda.synchronize()
+        start_time = time.time()
+
+        # Backward pass
+        attn_outputs.backward(dout)
+        
+        torch.cuda.synchronize()
+        end_time = time.time()
+        
+        return attn_outputs, (end_time - start_time) * 1000  # Convert to milliseconds
+        
+    except torch.cuda.OutOfMemoryError:
+        return "OOM", 0
+
+
+def dynamic_mask_attention_backward_cuda(
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    value_states: torch.Tensor,
+    dt_proj: torch.Tensor,
+    A: torch.Tensor,
+    scaling: float,
+    causal_mask: torch.Tensor,
+    keep_window_size=2048,
+    is_causal=True,
+):
+    """
+    CUDA implementation of dynamic mask attention backward pass.
+    
+    Args:
+        query_states: [batch_size, num_heads, query_len, head_dim]
+        key_states: [batch_size, num_kv_heads, key_len, head_dim]
+        value_states: [batch_size, num_kv_heads, key_len, head_dim]
+        dt_proj: [num_kv_heads, num_kv_heads * head_dim]
+        A: [num_kv_heads]
+        scaling: Attention scaling factor
+        causal_mask: Causal attention mask
+        keep_window_size: Number of tokens to keep in attention window
+        is_causal: Whether to apply causal masking
+    
+    Returns:
+        tuple: (output_tensor, timing_ms) or ("OOM", 0) or ("Not Available", 0)
+    """
+    if flash_dmattn_func is None:
+        return "Not Available", 0
+
+    # Calculate zoh_states
+    zoh_states = calculate_zoh_states(value_states, dt_proj, A)
+
+    # Use prepare_dynamic_mask to get the processed attention mask  
+    attn_bias, attn_mask = prepare_dynamic_mask(
+        query_states,
+        zoh_states,
+        keep_window_size,
+        causal_mask if is_causal else None
+    )  # [batch_size, num_kv_heads, query_len, key_len]
+    
+    # Ensure correct data types and memory layout for CUDA function
+    # CUDA function expects: q, k, v in [batch, seqlen, num_heads, head_dim] format
+    query_states = query_states.transpose(1, 2)     # [batch, query_len, num_heads, head_dim]
+    key_states = key_states.transpose(1, 2)         # [batch, key_len, num_kv_heads, head_dim]
+    value_states = value_states.transpose(1, 2)     # [batch, key_len, num_kv_heads, head_dim]
+
+    try:
+        # Create gradient for output
+        batch_size, query_len, num_heads, head_dim = query_states.shape
+        dout = torch.randn(
+            batch_size, query_len, num_heads, head_dim,
+            device=query_states.device, dtype=query_states.dtype
+        )
+        
+        # Call the flash_dmattn_func interface
+        attn_outputs = flash_dmattn_func(
+            query=query_states,                                         # q: [batch, query_len, num_heads, head_dim]
+            key=key_states,                                             # k: [batch, key_len, num_kv_heads, head_dim]
+            value=value_states,                                         # v: [batch, key_len, num_kv_heads, head_dim]
+            attn_mask=attn_mask,                                        # mask: [batch, num_kv_heads, query_len, key_len]
+            attn_bias=attn_bias,                                        # bias: [batch, num_kv_heads, query_len, key_len]
+            is_causal=is_causal,                                        # causal masking
+            scale=scaling,                                              # scaling factor
+            softcap=0.0,
+            deterministic=False,
+            return_attn_probs=False
+        )
+
+        torch.cuda.synchronize()
+        start_time = time.time()
+        
+        # Backward pass
+        attn_outputs.backward(dout)
+        
+        torch.cuda.synchronize()
+        end_time = time.time()
+        
+        return attn_outputs, (end_time - start_time) * 1000  # Convert to milliseconds
+        
+    except torch.cuda.OutOfMemoryError:
+        return "OOM", 0
+
+
+def dynamic_mask_attention_backward_triton(
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    value_states: torch.Tensor,
+    dt_proj: torch.Tensor,
+    A: torch.Tensor,
+    scaling: float,
+    causal_mask: torch.Tensor,
+    keep_window_size=2048,
+    is_causal=True,
+):
+    """
+    Triton implementation of dynamic mask attention backward pass.
+    
+    Args:
+        query_states: [batch_size, num_heads, query_len, head_dim]
+        key_states: [batch_size, num_kv_heads, key_len, head_dim]
+        value_states: [batch_size, num_kv_heads, key_len, head_dim]
+        dt_proj: [num_kv_heads, num_kv_heads * head_dim]
+        A: [num_kv_heads]
+        scaling: Attention scaling factor
+        causal_mask: Causal attention mask
+        keep_window_size: Number of tokens to keep in attention window
+        is_causal: Whether to apply causal masking
+    
+    Returns:
+        tuple: (output_tensor, timing_ms) or ("OOM", 0) or ("Not Available", 0)
+    """
+    if triton_dmattn_func is None:
+        return "Not Available", 0
+    
+    _, num_heads, _, _ = query_states.shape
+    _, num_kv_heads, _, _ = key_states.shape
+    num_queries_per_kv = num_heads // num_kv_heads
+
+    try:
+        # Calculate zoh_states
+        zoh_states = calculate_zoh_states(value_states, dt_proj, A)
+
+        # Use prepare_dynamic_mask to get the processed attention mask  
+        attn_bias, attn_mask = prepare_dynamic_mask(
+            query_states,
+            zoh_states,
+            keep_window_size,
+            causal_mask if is_causal else None
+        )  # [batch_size, num_kv_heads, query_len, key_len]
+        
+        # Repeat KV for multi-head attention (GQA support)
+        key_states = repeat_kv(key_states, num_queries_per_kv)
+        value_states = repeat_kv(value_states, num_queries_per_kv)
+        attn_mask = repeat_kv(attn_mask, num_queries_per_kv)
+        attn_bias = repeat_kv(attn_bias, num_queries_per_kv)
+        
+        # Triton function expects: q, k, v in [batch, seqlen, num_heads, head_dim] format
+        query_states = query_states.transpose(1, 2).contiguous()        # [batch, query_len, num_heads, head_dim]  
+        key_states = key_states.transpose(1, 2).contiguous()            # [batch, key_len, num_heads, head_dim]  
+        value_states = value_states.transpose(1, 2).contiguous()        # [batch, key_len, num_heads, head_dim]  
+        attn_mask = attn_mask.contiguous()                              # [batch, num_heads, seqlen_q, seqlen_k]
+        attn_bias = attn_bias.contiguous()                              # [batch, num_heads, seqlen_q, seqlen_k]
+
+        # Create gradient for output
+        batch_size, query_len, num_heads, head_dim = query_states.shape
+        dout = torch.randn(
+            batch_size, query_len, num_heads, head_dim,
+            device=query_states.device, dtype=query_states.dtype
+        )
+        
+        # Call the Triton implementation
+        attn_outputs = triton_dmattn_func(
+            query=query_states,                                         # q: [batch, seqlen_q, num_heads, head_dim]
+            key=key_states,                                             # k: [batch, seqlen_k, num_heads, head_dim]
+            value=value_states,                                         # v: [batch, seqlen_k, num_heads, head_dim]
+            attn_mask=attn_mask,                                        # mask: [batch, num_heads, seqlen_q, seqlen_k]
+            attn_bias=attn_bias,                                        # bias: [batch, num_heads, seqlen_q, seqlen_k]
+            is_causal=is_causal,                                        # causal masking
+            scale=scaling                                               # scaling factor
+        )
+
+        torch.cuda.synchronize()
+        start_time = time.time()
+
+        # Backward pass
+        attn_outputs.backward(dout)
+        
+        torch.cuda.synchronize()
+        end_time = time.time()
+        
+        return attn_outputs, (end_time - start_time) * 1000  # Convert to milliseconds
+        
+    except torch.cuda.OutOfMemoryError:
+        return "OOM", 0
+
+
+def dynamic_mask_attention_backward_flex(
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    value_states: torch.Tensor,
+    dt_proj: torch.Tensor,
+    A: torch.Tensor,
+    scaling: float,
+    causal_mask: torch.Tensor,
+    keep_window_size=2048,
+    is_causal=True,
+):
+    """
+    Flex Attention implementation of dynamic mask attention backward pass.
+    
+    Args:
+        query_states: [batch_size, num_heads, query_len, head_dim]
+        key_states: [batch_size, num_kv_heads, key_len, head_dim]
+        value_states: [batch_size, num_kv_heads, key_len, head_dim]
+        dt_proj: [num_kv_heads, num_kv_heads * head_dim]
+        A: [num_kv_heads]
+        scaling: Attention scaling factor
+        causal_mask: Causal attention mask
+        keep_window_size: Number of tokens to keep in attention window
+        is_causal: Whether to apply causal masking
+    
+    Returns:
+        tuple: (output_tensor, timing_ms) or ("OOM", 0) or ("Not Available", 0)
+    """
+    if flex_dmattn_func is None:
+        return "Not Available", 0
+    
+    _, num_heads, _, _ = query_states.shape
+    _, num_kv_heads, _, _ = key_states.shape
+    num_queries_per_kv = num_heads // num_kv_heads
+
+    try:
+        # Calculate zoh_states
+        zoh_states = calculate_zoh_states(value_states, dt_proj, A)
+
+        # Use prepare_dynamic_mask to get the processed attention mask  
+        attn_bias, attn_mask = prepare_dynamic_mask(
+            query_states,
+            zoh_states,
+            keep_window_size,
+            causal_mask if is_causal else None
+        )  # [batch_size, num_kv_heads, query_len, key_len]
+        
+        # Repeat KV for multi-head attention (GQA support)
+        key_states = repeat_kv(key_states, num_queries_per_kv)
+        value_states = repeat_kv(value_states, num_queries_per_kv)
+        attn_mask = repeat_kv(attn_mask, num_queries_per_kv)
+        attn_bias = repeat_kv(attn_bias, num_queries_per_kv)
+        
+        # Flex attention expects: q, k, v in [batch, num_heads, seqlen, head_dim] format
+        # But attention_mask and attention_bias in [batch, num_heads, query_len, key_len] format
+
+        # Create gradient for output
+        batch_size, query_len, head_dim = query_states.shape[0], query_states.shape[2], query_states.shape[3]
+        dout = torch.randn(
+            batch_size, query_len, num_heads, head_dim,
+            device=query_states.device, dtype=query_states.dtype
+        )
+        
+        # Call the Flex Attention implementation
+        attn_outputs = flex_dmattn_func(
+            query_states.transpose(1, 2),               # q: [batch, query_len, num_heads, head_dim]
+            key_states.transpose(1, 2),                 # k: [batch, key_len, num_heads, head_dim]
+            value_states.transpose(1, 2),               # v: [batch, key_len, num_heads, head_dim]
+            attn_mask=attn_mask,                        # attn_mask: [batch, num_heads, query_len, key_len]
+            attn_bias=attn_bias,                        # attn_bias: [batch, num_heads, query_len, key_len]
+            is_causal=is_causal,                        # is_causal: whether to apply causal masking
+            scale=scaling                               # scaling factor
+        )
+
+        torch.cuda.synchronize()
+        start_time = time.time()
+
+        # Backward pass
+        attn_outputs.backward(dout)
+        
+        torch.cuda.synchronize()
+        end_time = time.time()
+        
+        return attn_outputs, (end_time - start_time) * 1000  # Convert to milliseconds
+        
+    except torch.cuda.OutOfMemoryError:
+        return "OOM", 0
+
+
+def measure_memory_usage():
+    """
+    Measure current GPU memory usage.
+    
+    Returns:
+        tuple: (allocated_mb, reserved_mb)
+    """
+    if torch.cuda.is_available():
+        allocated = torch.cuda.memory_allocated() / 1024 / 1024  # MB
+        reserved = torch.cuda.memory_reserved() / 1024 / 1024    # MB
+        return allocated, reserved
+    return 0, 0
+
+
+def benchmark_backward_attention_performance(config, test_type='all', num_runs=5, warmup_runs=2):
+    """
+    Benchmark backward attention performance for a given configuration.
+    
+    Args:
+        config: Tuple of (batch_size, num_heads, num_kv_heads, query_len, key_len, head_dim, keep_window_size, is_causal)
+        test_type: Type of test to run ('all', 'sdpa', 'cuda', 'triton', 'flex', etc.)
+        num_runs: Number of benchmark runs
+        warmup_runs: Number of warmup runs
+    
+    Returns:
+        dict: Performance metrics
+    """
+    batch_size, num_heads, num_kv_heads, query_len, key_len, head_dim, keep_window_size, is_causal = config
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    
+    # Create random input data (requires_grad=True for backward pass)
+    query_states = torch.randn(
+        batch_size, num_heads, query_len, head_dim, 
+        device=device, dtype=torch.bfloat16, requires_grad=True
+    )
+    key_states = torch.randn(
+        batch_size, num_kv_heads, key_len, head_dim, 
+        device=device, dtype=torch.bfloat16, requires_grad=True
+    )
+    value_states = torch.randn(
+        batch_size, num_kv_heads, key_len, head_dim, 
+        device=device, dtype=torch.bfloat16, requires_grad=True
+    )
+    dt_proj = torch.randn(
+        num_kv_heads, num_kv_heads * head_dim, 
+        device=device, dtype=torch.bfloat16, requires_grad=True
+    )
+    A = torch.randn(num_kv_heads, device=device, dtype=torch.bfloat16, requires_grad=True)
+    
+    # Create custom causal mask with cache position
+    cache_position = torch.arange(key_len - query_len, key_len, device=device)
+    min_type = torch.finfo(value_states.dtype).min
+    causal_mask = torch.full(
+        (query_len, key_len), fill_value=min_type, 
+        device=device, dtype=value_states.dtype
+    )
+    causal_mask = torch.triu(causal_mask, diagonal=1)
+    causal_mask *= torch.arange(key_len, device=device) > cache_position.reshape(-1, 1)
+    causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)
+    
+    # Set scaling factor from config
+    scaling = head_dim ** -0.5
+    
+    results = {
+        'config': config,
+        'sdpa_backward_times': [],
+        'cuda_backward_times': [],
+        'triton_backward_times': [],
+        'flex_backward_times': [],
+        'sdpa_backward_memory': 0,
+        'cuda_backward_memory': 0,
+        'triton_backward_memory': 0,
+        'flex_backward_memory': 0,
+        'sdpa_backward_status': 'success',
+        'cuda_backward_status': 'success',
+        'triton_backward_status': 'success',
+        'flex_backward_status': 'success'
+    }
+    
+    # Determine which implementations to run
+    run_sdpa = test_type in ['all', 'sdpa', 'sdpa-vs-cuda', 'sdpa-vs-triton', 'sdpa-vs-flex']
+    run_cuda = test_type in ['all', 'cuda', 'sdpa-vs-cuda']
+    run_triton = test_type in ['all', 'triton', 'sdpa-vs-triton']
+    run_flex = test_type in ['all', 'flex', 'sdpa-vs-flex']
+    
+    # Benchmark SDPA Backward
+    if run_sdpa:
+        gc.collect()
+        torch.cuda.empty_cache()
+        
+        # Warmup runs
+        for _ in range(warmup_runs):
+            # Clone inputs for each run
+            q_clone = query_states.clone().detach().requires_grad_(True)
+            k_clone = key_states.clone().detach().requires_grad_(True)
+            v_clone = value_states.clone().detach().requires_grad_(True)
+            
+            result = scaled_dot_product_attention_backward(
+                q_clone, k_clone, v_clone, scaling, causal_mask, is_causal
+            )
+            if result[0] == "OOM":
+                results['sdpa_backward_status'] = 'OOM'
+                break
+            torch.cuda.synchronize()
+        
+        if results['sdpa_backward_status'] == 'success':
+            # Measure memory before benchmark
+            mem_before = measure_memory_usage()
+            
+            # Actual benchmark runs
+            for _ in range(num_runs):
+                # Clone inputs for each run
+                q_clone = query_states.clone().detach().requires_grad_(True)
+                k_clone = key_states.clone().detach().requires_grad_(True)
+                v_clone = value_states.clone().detach().requires_grad_(True)
+                
+                result = scaled_dot_product_attention_backward(
+                    q_clone, k_clone, v_clone, scaling, causal_mask, is_causal
+                )
+                
+                if result[0] == "OOM":
+                    results['sdpa_backward_status'] = 'OOM'
+                    break
+                
+                # Use the timing from the function instead of measuring here
+                results['sdpa_backward_times'].append(result[1])  # ms
+            
+            # Measure memory after
+            mem_after = measure_memory_usage()
+            results['sdpa_backward_memory'] = mem_after[0] - mem_before[0]
+    else:
+        results['sdpa_backward_status'] = 'N/A'
+    
+    # Benchmark Dynamic Mask Attention CUDA Backward
+    if run_cuda:
+        gc.collect()
+        torch.cuda.empty_cache()
+        
+        # Warmup runs
+        for _ in range(warmup_runs):
+            # Clone inputs for each run
+            q_clone = query_states.clone().detach().requires_grad_(True)
+            k_clone = key_states.clone().detach().requires_grad_(True)
+            v_clone = value_states.clone().detach().requires_grad_(True)
+            dt_clone = dt_proj.clone().detach().requires_grad_(True)
+            a_clone = A.clone().detach().requires_grad_(True)
+            
+            result = dynamic_mask_attention_backward_cuda(
+                q_clone, k_clone, v_clone, dt_clone, a_clone,
+                scaling, causal_mask, keep_window_size, is_causal
+            )
+            if result[0] in ["OOM", "Not Available"]:
+                results['cuda_backward_status'] = result[0]
+                break
+            torch.cuda.synchronize()
+        
+        if results['cuda_backward_status'] == 'success':
+            # Measure memory before benchmark
+            mem_before = measure_memory_usage()
+            
+            # Actual benchmark runs
+            for _ in range(num_runs):
+                # Clone inputs for each run
+                q_clone = query_states.clone().detach().requires_grad_(True)
+                k_clone = key_states.clone().detach().requires_grad_(True)
+                v_clone = value_states.clone().detach().requires_grad_(True)
+                dt_clone = dt_proj.clone().detach().requires_grad_(True)
+                a_clone = A.clone().detach().requires_grad_(True)
+                
+                result = dynamic_mask_attention_backward_cuda(
+                    q_clone, k_clone, v_clone, dt_clone, a_clone,
+                    scaling, causal_mask, keep_window_size, is_causal
+                )
+                
+                if result[0] in ["OOM", "Not Available"]:
+                    results['cuda_backward_status'] = result[0]
+                    break
+                
+                # Use the timing from the function instead of measuring here
+                results['cuda_backward_times'].append(result[1])  # ms
+            
+            # Measure memory after
+            mem_after = measure_memory_usage()
+            results['cuda_backward_memory'] = mem_after[0] - mem_before[0]
+    else:
+        results['cuda_backward_status'] = 'N/A'
+    
+    # Benchmark Dynamic Mask Attention Triton Backward
+    if run_triton:
+        gc.collect()
+        torch.cuda.empty_cache()
+        
+        # Warmup runs
+        for _ in range(warmup_runs):
+            # Clone inputs for each run
+            q_clone = query_states.clone().detach().requires_grad_(True)
+            k_clone = key_states.clone().detach().requires_grad_(True)
+            v_clone = value_states.clone().detach().requires_grad_(True)
+            dt_clone = dt_proj.clone().detach().requires_grad_(True)
+            a_clone = A.clone().detach().requires_grad_(True)
+            
+            result = dynamic_mask_attention_backward_triton(
+                q_clone, k_clone, v_clone, dt_clone, a_clone,
+                scaling, causal_mask, keep_window_size, is_causal
+            )
+            if result[0] in ["OOM", "Not Available"]:
+                results['triton_backward_status'] = result[0]
+                break
+            torch.cuda.synchronize()
+        
+        if results['triton_backward_status'] == 'success':
+            # Measure memory before benchmark
+            mem_before = measure_memory_usage()
+            
+            # Actual benchmark runs
+            for _ in range(num_runs):
+                # Clone inputs for each run
+                q_clone = query_states.clone().detach().requires_grad_(True)
+                k_clone = key_states.clone().detach().requires_grad_(True)
+                v_clone = value_states.clone().detach().requires_grad_(True)
+                dt_clone = dt_proj.clone().detach().requires_grad_(True)
+                a_clone = A.clone().detach().requires_grad_(True)
+                
+                result = dynamic_mask_attention_backward_triton(
+                    q_clone, k_clone, v_clone, dt_clone, a_clone,
+                    scaling, causal_mask, keep_window_size, is_causal
+                )
+                
+                if result[0] in ["OOM", "Not Available"]:
+                    results['triton_backward_status'] = result[0]
+                    break
+                
+                # Use the timing from the function instead of measuring here
+                results['triton_backward_times'].append(result[1])  # ms
+            
+            # Measure memory after
+            mem_after = measure_memory_usage()
+            results['triton_backward_memory'] = mem_after[0] - mem_before[0]
+    else:
+        results['triton_backward_status'] = 'N/A'
+    
+    # Benchmark Dynamic Mask Attention Flex Backward
+    if run_flex:
+        gc.collect()
+        torch.cuda.empty_cache()
+        
+        # Warmup runs
+        for _ in range(warmup_runs):
+            # Clone inputs for each run
+            q_clone = query_states.clone().detach().requires_grad_(True)
+            k_clone = key_states.clone().detach().requires_grad_(True)
+            v_clone = value_states.clone().detach().requires_grad_(True)
+            dt_clone = dt_proj.clone().detach().requires_grad_(True)
+            a_clone = A.clone().detach().requires_grad_(True)
+            
+            result = dynamic_mask_attention_backward_flex(
+                q_clone, k_clone, v_clone, dt_clone, a_clone,
+                scaling, causal_mask, keep_window_size, is_causal
+            )
+            if result[0] in ["OOM", "Not Available"]:
+                results['flex_backward_status'] = result[0]
+                break
+            torch.cuda.synchronize()
+        
+        if results['flex_backward_status'] == 'success':
+            # Measure memory before benchmark
+            mem_before = measure_memory_usage()
+            
+            # Actual benchmark runs
+            for _ in range(num_runs):
+                # Clone inputs for each run
+                q_clone = query_states.clone().detach().requires_grad_(True)
+                k_clone = key_states.clone().detach().requires_grad_(True)
+                v_clone = value_states.clone().detach().requires_grad_(True)
+                dt_clone = dt_proj.clone().detach().requires_grad_(True)
+                a_clone = A.clone().detach().requires_grad_(True)
+                
+                result = dynamic_mask_attention_backward_flex(
+                    q_clone, k_clone, v_clone, dt_clone, a_clone,
+                    scaling, causal_mask, keep_window_size, is_causal
+                )
+                
+                if result[0] in ["OOM", "Not Available"]:
+                    results['flex_backward_status'] = result[0]
+                    break
+                
+                # Use the timing from the function instead of measuring here
+                results['flex_backward_times'].append(result[1])  # ms
+            
+            # Measure memory after
+            mem_after = measure_memory_usage()
+            results['flex_backward_memory'] = mem_after[0] - mem_before[0]
+    else:
+        results['flex_backward_status'] = 'N/A'
+    
+    return results
+
+
+def run_backward_performance_benchmark(test_type='all', num_runs=3, warmup_runs=2):
+    """Run comprehensive backward pass performance benchmark across different configurations."""
+    print("\n" + "🏆" + "=" * 76 + "🏆")
+    
+    # Update title based on test type
+    if test_type == 'all':
+        title = "🔥 Backward Pass Performance Benchmark: All Implementations 🔥"
+    elif test_type == 'sdpa-vs-cuda':
+        title = "🚀 Backward Pass Performance: SDPA vs CUDA 🚀"
+    elif test_type == 'sdpa-vs-triton':
+        title = "🌟 Backward Pass Performance: SDPA vs Triton 🌟"
+    elif test_type == 'sdpa-vs-flex':
+        title = "✨ Backward Pass Performance: SDPA vs Flex ✨"
+    elif test_type == 'sdpa':
+        title = "📊 Backward Pass Performance: SDPA Only 📊"
+    elif test_type == 'cuda':
+        title = "🚀 Backward Pass Performance: CUDA Only 🚀"
+    elif test_type == 'triton':
+        title = "🌟 Backward Pass Performance: Triton Only 🌟"
+    elif test_type == 'flex':
+        title = "✨ Backward Pass Performance: Flex Only ✨"
+    else:
+        title = "🔥 Backward Pass Performance Benchmark 🔥"
+    
+    print(title)
+    print("🏆" + "=" * 76 + "🏆")
+    
+    # Test configurations: (batch_size, num_heads, num_kv_heads, query_len, key_len, head_dim, keep_window_size, is_causal)
+    configs = [
+        # Vary sequence length
+        (1, 2, 1, 256, 256, 64, 1024, True),
+        (1, 2, 1, 512, 512, 64, 1024, True),
+        (1, 2, 1, 1024, 1024, 64, 1024, True),
+        (1, 2, 1, 2048, 2048, 64, 1024, True),
+        (1, 2, 1, 4096, 4096, 64, 4096, True),
+        (1, 2, 1, 8192, 8192, 64, 1024, True),
+        (1, 2, 1, 16384, 16384, 64, 1024, True),
+        
+        # Vary batch size
+        (1, 2, 1, 4096, 4096, 64, 1024, True),
+        (2, 2, 1, 4096, 4096, 64, 1024, True),
+        (4, 2, 1, 4096, 4096, 64, 1024, True),
+        (8, 2, 1, 4096, 4096, 64, 1024, True),
+        
+        # Vary head count
+        (1, 1, 1, 4096, 4096, 64, 1024, True),
+        (1, 2, 1, 4096, 4096, 64, 1024, True),
+        (1, 4, 1, 4096, 4096, 64, 1024, True),
+        (1, 8, 2, 4096, 4096, 64, 1024, True),
+        
+        # Vary head dimension
+        (1, 2, 1, 16384, 16384, 32, 1024, True),
+        (1, 2, 1, 16384, 16384, 64, 1024, True),
+        (1, 2, 1, 16384, 16384, 96, 1024, True),
+        (1, 2, 1, 16384, 16384, 128, 1024, True),
+
+        # Vary keep_window_size
+        (1, 2, 1, 16384, 16384, 64, 32, True),
+        (1, 2, 1, 16384, 16384, 64, 64, True),
+        (1, 2, 1, 16384, 16384, 64, 128, True),
+        (1, 2, 1, 16384, 16384, 64, 256, True),
+        (1, 2, 1, 16384, 16384, 64, 512, True),
+        (1, 2, 1, 16384, 16384, 64, 1024, True),
+        (1, 2, 1, 16384, 16384, 64, 2048, True),
+        (1, 2, 1, 16384, 16384, 64, 4096, True),
+        (1, 2, 1, 16384, 16384, 64, 8192, True),
+        (1, 2, 1, 16384, 16384, 64, 16384, True),
+    ]
+    
+    print(f"\n📊 Backward Pass Benchmark Results (averaged over {num_runs} runs):")
+    print(f"🔧 {'Configuration':<60} ⚡ {'SDPA-BWD':<12} 🚀 {'CUDA-BWD':<12} 🌟 {'Triton-BWD':<12} ✨ {'Flex-BWD':<15} 📈 {'Speedup':<15}")
+    print("🔄" + "-" * 160 + "🔄")
+    
+    all_results = []
+    
+    for config in configs:
+        try:
+            results = benchmark_backward_attention_performance(config, test_type, num_runs, warmup_runs)
+            all_results.append(results)
+            
+            # Format configuration string
+            batch_size, num_heads, num_kv_heads, query_len, key_len, head_dim, keep_window_size, is_causal = config
+            config_str = f"B{batch_size}H{num_heads}K{num_kv_heads}Q{query_len}K{key_len}D{head_dim}W{keep_window_size}{'C' if is_causal else 'N'}"
+            
+            # Calculate averages and format results
+            sdpa_avg = f"{sum(results['sdpa_backward_times'])/len(results['sdpa_backward_times']):.2f}ms" if results['sdpa_backward_times'] else results['sdpa_backward_status']
+            cuda_avg = f"{sum(results['cuda_backward_times'])/len(results['cuda_backward_times']):.2f}ms" if results['cuda_backward_times'] else results['cuda_backward_status']
+            triton_avg = f"{sum(results['triton_backward_times'])/len(results['triton_backward_times']):.2f}ms" if results['triton_backward_times'] else results['triton_backward_status']
+            flex_avg = f"{sum(results['flex_backward_times'])/len(results['flex_backward_times']):.2f}ms" if results['flex_backward_times'] else results['flex_backward_status']
+            
+            # Calculate speedup (SDPA vs others)
+            speedup_info = []
+            if results['sdpa_backward_times'] and results['cuda_backward_times']:
+                sdpa_time = sum(results['sdpa_backward_times'])/len(results['sdpa_backward_times'])
+                cuda_time = sum(results['cuda_backward_times'])/len(results['cuda_backward_times'])
+                speedup_info.append(f"CUDA: {sdpa_time/cuda_time:.1f}x")
+            
+            if results['sdpa_backward_times'] and results['triton_backward_times']:
+                sdpa_time = sum(results['sdpa_backward_times'])/len(results['sdpa_backward_times'])
+                triton_time = sum(results['triton_backward_times'])/len(results['triton_backward_times'])
+                speedup_info.append(f"Tri: {sdpa_time/triton_time:.1f}x")
+                
+            if results['sdpa_backward_times'] and results['flex_backward_times']:
+                sdpa_time = sum(results['sdpa_backward_times'])/len(results['sdpa_backward_times'])
+                flex_time = sum(results['flex_backward_times'])/len(results['flex_backward_times'])
+                speedup_info.append(f"Flex: {sdpa_time/flex_time:.1f}x")
+            
+            speedup_str = ", ".join(speedup_info) if speedup_info else "N/A"
+            
+            print(f"📊 {config_str:<60} ⚡ {sdpa_avg:<12} 🚀 {cuda_avg:<12} 🌟 {triton_avg:<12} ✨ {flex_avg:<15} 📈 {speedup_str:<15}")
+            
+        except Exception as e:
+            print(f"❌ Error in config {config}: {e}")
+            continue
+    
+    print("🔄" + "-" * 160 + "🔄")
+    
+    # Summary statistics
+    implementation_speedups = {
+        'cuda': [],
+        'triton': [],
+        'flex': []
+    }
+    
+    for results in all_results:
+        if results['sdpa_backward_times'] and results['cuda_backward_times']:
+            sdpa_time = sum(results['sdpa_backward_times'])/len(results['sdpa_backward_times'])
+            cuda_time = sum(results['cuda_backward_times'])/len(results['cuda_backward_times'])
+            implementation_speedups['cuda'].append(sdpa_time/cuda_time)
+            
+        if results['sdpa_backward_times'] and results['triton_backward_times']:
+            sdpa_time = sum(results['sdpa_backward_times'])/len(results['sdpa_backward_times'])
+            triton_time = sum(results['triton_backward_times'])/len(results['triton_backward_times'])
+            implementation_speedups['triton'].append(sdpa_time/triton_time)
+            
+        if results['sdpa_backward_times'] and results['flex_backward_times']:
+            sdpa_time = sum(results['sdpa_backward_times'])/len(results['sdpa_backward_times'])
+            flex_time = sum(results['flex_backward_times'])/len(results['flex_backward_times'])
+            implementation_speedups['flex'].append(sdpa_time/flex_time)
+    
+    print(f"\n🏆 Backward Pass Summary:")
+    
+    # Display statistics for each implementation
+    for impl_key, speedups in implementation_speedups.items():
+        if speedups:
+            impl_name = impl_key.upper()
+            avg_speedup = sum(speedups) / len(speedups)
+            max_speedup = max(speedups)
+            min_speedup = min(speedups)
+            print(f"  🚀 {impl_name:7} speedup: avg={avg_speedup:.2f}x, max={max_speedup:.2f}x, min={min_speedup:.2f}x ({len(speedups)} configs)")
+        else:
+            print(f"  ❌ {impl_key.upper():7} : No valid measurements")
+
+
+def main():
+    """
+    Run backward pass performance benchmarks for Dynamic Mask Attention.
+    
+    This script measures and compares backward pass performance including:
+    - Gradient computation latency measurements across different configurations
+    - Memory usage analysis during backward pass
+    - Throughput comparisons for gradient computation
+    - Scalability analysis for large sequences
+    """
+    
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(
+        description='Backward pass performance benchmark for Dynamic Mask Attention'
+    )
+    parser.add_argument('--seed', type=int, default=42, help='Random seed')
+    parser.add_argument('--runs', type=int, default=3, help='Number of benchmark runs')
+    parser.add_argument('--warmup', type=int, default=2, help='Number of warmup runs')
+    parser.add_argument('--test-type', type=str, default='all', 
+                        choices=['all', 'sdpa', 'cuda', 'triton', 'flex', 'sdpa-vs-cuda', 'sdpa-vs-triton', 'sdpa-vs-flex'],
+                        help='Type of benchmark to run (default: all)')
+    
+    args = parser.parse_args()
+    
+    # Set random seed
+    torch.manual_seed(args.seed)
+    
+    # Print test environment information
+    print(f"🐍 PyTorch version: {torch.__version__}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device_icon = "🔥" if device.type == "cuda" else "💻"
+    print(f"{device_icon} Device: {device}")
+    
+    if torch.cuda.is_available():
+        print(f"🎮 CUDA device: {torch.cuda.get_device_name()}")
+        print(f"💾 CUDA memory: {torch.cuda.get_device_properties(0).total_memory / 1024**3:.1f} GB")
+    
+    print(f"🎲 Random seed: {args.seed}")
+    print(f"📊 Test type: {args.test_type}")
+    print(f"🔄 Runs: {args.runs}, Warmup: {args.warmup}")
+    
+    # Run backward pass performance benchmark
+    run_backward_performance_benchmark(args.test_type, args.runs, args.warmup)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/forward_performance.py
+++ b/benchmarks/forward_performance.py
@@ -269,7 +269,7 @@ def dynamic_mask_attention_cuda(
             is_causal=is_causal,
             scale=scaling,
             softcap=0.0,
-            deterministic=True,
+            deterministic=False,
             return_attn_probs=return_softmax
         )
         

--- a/csrc/src/flash_bwd_kernel.h
+++ b/csrc/src/flash_bwd_kernel.h
@@ -623,9 +623,9 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
         //     cute::copy(smem_tiled_copy_KV, tSsK(_, _, k), tSrK_copy_view(_, _, k));
         // }
         // if (cute::thread0()) { print(tSrK); }
-        FLASH_NAMESPACE::sparse_gemm(
+        FLASH_NAMESPACE::gemm(
             acc_s,
-            tSrQ, tSrK, tSsQ, tSsK, tSrMask,
+            tSrQ, tSrK, tSsQ, tSsK,
             tiled_mma_sdp,
             smem_tiled_copy_QdO, smem_tiled_copy_KV,
             smem_thr_copy_QdO, smem_thr_copy_KV
@@ -699,9 +699,9 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
 
         // if (cute::thread0()) { print(dP_sum); }
 
-        FLASH_NAMESPACE::sparse_gemm</*A_in_regs=*/false, /*B_in_regs=*/Kernel_traits::Is_V_in_regs>(
+        FLASH_NAMESPACE::gemm</*A_in_regs=*/false, /*B_in_regs=*/Kernel_traits::Is_V_in_regs>(
             acc_dp,
-            tdPrdO, tdPrV, tdPsdO, tdPsV, tSrMask,
+            tdPrdO, tdPrV, tdPsdO, tdPsV,
             tiled_mma_sdp,
             smem_tiled_copy_QdO, smem_tiled_copy_KV,
             smem_thr_copy_QdO, smem_thr_copy_KV
@@ -774,9 +774,9 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
         // FLASH_NAMESPACE::gemm_rs(acc_dv, tdVrPt, tdVrdO, tdVsdOt, tiled_mma_dkv, smem_thr_copy_QdOt);
         // Tensor tdKrdSt = make_tensor(tdSrdS.data(), tdVrPt.layout());
         // FLASH_NAMESPACE::gemm_rs(acc_dk, tdKrdSt, tdKrQt, tdKsQt, tiled_mma_dkv, smem_thr_copy_QdOt);
-        FLASH_NAMESPACE::sparse_gemm(
+        FLASH_NAMESPACE::gemm(
             acc_dv,
-            tdVrPt, tdVrdO, tdVsPt, tdVsdOt, tSrMask,
+            tdVrPt, tdVrdO, tdVsPt, tdVsdOt,
             tiled_mma_dkv,
             smem_tiled_copy_PdSt, smem_tiled_copy_QdOt,
             smem_thr_copy_PdSt, smem_thr_copy_QdOt
@@ -811,9 +811,9 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
             }
         }
 
-        FLASH_NAMESPACE::sparse_gemm(
+        FLASH_NAMESPACE::gemm(
             acc_dq,
-            tdQrdS, tdQrKt, tdQsdS, tdQsKt, tSrMask,
+            tdQrdS, tdQrKt, tdQsdS, tdQsKt,
             tiled_mma_dq,
             smem_tiled_copy_dS, smem_tiled_copy_Kt,
             smem_thr_copy_dS, smem_thr_copy_Kt
@@ -866,9 +866,9 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
             cute::copy(smem_tiled_copy_dQ, taccdQrdQ, taccdQsdQ);
         }
 
-        FLASH_NAMESPACE::sparse_gemm(
+        FLASH_NAMESPACE::gemm(
             acc_dk,
-            tdKrdSt, tdKrQt, tdKsdSt, tdKsQt, tSrMask,
+            tdKrdSt, tdKrQt, tdKsdSt, tdKsQt,
             tiled_mma_dkv,
             smem_tiled_copy_PdSt, smem_tiled_copy_QdOt,
             smem_thr_copy_PdSt, smem_thr_copy_QdOt

--- a/csrc/src/flash_bwd_kernel.h
+++ b/csrc/src/flash_bwd_kernel.h
@@ -763,8 +763,6 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
         Tensor tdSrdS = FLASH_NAMESPACE::convert_type<Element>(dS_reshaped);
         Tensor tdSadS = smem_thr_copy_PdS.retile_S(tdSrdS);     // ((Atom, AtomNum), MMA_M, MMA_N)
         cute::copy(smem_tiled_copy_PdS, tdSadS, tdSsdS);
-        Tensor tdBiasadS = smem_thr_copy_PdS.retile_S(tdSrdS);  // ((Atom, AtomNum), MMA_N, MMA_N)
-        cute::copy(smem_tiled_copy_PdS, tdBiasadS, tSsBias);
         __syncthreads();
         // Write dS to dBias
         FLASH_NAMESPACE::copy_MN<Is_even_MN, /*Clear_OOB_MN=*/false>(

--- a/csrc/src/flash_bwd_kernel.h
+++ b/csrc/src/flash_bwd_kernel.h
@@ -822,10 +822,10 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
 
         if (m_block > m_block_min) {
             gLSE.data() = gLSE.data() + (-int(kBlockM));
-            tMaskgMask.data() = tMaskgMask.data() + (-int(kBlockM * params.mask_row_stride));
-            tBiasgBias.data() = tBiasgBias.data() + (-int(kBlockM * params.bias_row_stride));
             #pragma unroll
             for (int mi = 0; mi < size(lse); ++mi) { lse(mi) = gLSE(get<0>(taccScS_row(mi))); }
+            tMaskgMask.data() = tMaskgMask.data() + (-int(kBlockM * params.mask_row_stride));
+            tBiasgBias.data() = tBiasgBias.data() + (-int(kBlockM * params.bias_row_stride));
             gdPsum.data() = gdPsum.data() + (-int(kBlockM));
             // Advance gMask, gBias
             FLASH_NAMESPACE::copy_MN<Is_even_MN, /*Clear_OOB_MN=*/true>(

--- a/csrc/src/flash_bwd_kernel.h
+++ b/csrc/src/flash_bwd_kernel.h
@@ -823,8 +823,8 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
                 tMaskcMask,
                 binfo.actual_seqlen_q - (m_block - 1) * kBlockM, binfo.actual_seqlen_k - n_block * kBlockN
             );
-                FLASH_NAMESPACE::cp_async_fence();
-            }
+            FLASH_NAMESPACE::cp_async_fence();
+        }
 
         FLASH_NAMESPACE::gemm(
             acc_dq,

--- a/csrc/src/flash_bwd_launch_template.h
+++ b/csrc/src/flash_bwd_launch_template.h
@@ -137,12 +137,12 @@ void run_mha_bwd_hdim32(Flash_bwd_params &params, cudaStream_t stream) {
     if (status_ != cudaSuccess) {
       C10_CUDA_CHECK(status_);
     }
-    if (max_smem_per_block >= 136 * 1024) {             // H100 and A100
-        // 136KB
+    if (max_smem_per_block >= 104 * 1024) {             // H100 and A100
+        // 104KB
         run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 128, 128, 8, 4, 4, 4, false, false, T>, Is_causal>(params, stream);
     } else {                                            // sm86 and sm89
-        // 76KB
-        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 128, 8, 4, 4, 4, false, false, T>, Is_causal>(params, stream);
+        // 96KB
+        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 128, 128, 8, 4, 4, 4, true, false, T>, Is_causal>(params, stream);
     }
 }
 
@@ -160,17 +160,14 @@ void run_mha_bwd_hdim64(Flash_bwd_params &params, cudaStream_t stream) {
     // printf("max_smem_per_block = %d\n", max_smem_per_block);
     // Changing AtomLayoutMdQ from 2 to 4 takes the same time
     // This is slightly faster. We want to split M more so we need fewer registers to store LSE.
-    if (max_smem_per_block >= 176 * 1024) {             // H100
-        // 176KB
+    if (max_smem_per_block >= 144 * 1024) {             // H100 and A100
+        // 144KB
         run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 128, 128, 8, 4, 4, 4, false, false, T>, Is_causal>(params, stream);
         // This has a lot of register spilling
-        // run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 128, 8, 4, 4, 4, true, false, T>>(params, stream);
-    } else if (max_smem_per_block >= 160 * 1024) {      // A100
-        // 160KB
-        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 128, 128, 8, 4, 4, 4, true, false, T>, Is_causal>(params, stream);
+        // run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 128, 128, 8, 4, 4, 4, true, false, T>>(params, stream);
     } else {                                            // sm86 and sm89
         // 88KB
-        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 128, 8, 2, 4, 4, true, false, T>, Is_causal>(params, stream);
+        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 128, 8, 2, 4, 4, false, false, T>, Is_causal>(params, stream);
     }
     // M=128, N=64 is quite slow, I think because we need to read/write dQaccum twice as many times
 }
@@ -187,12 +184,12 @@ void run_mha_bwd_hdim96(Flash_bwd_params &params, cudaStream_t stream) {
       C10_CUDA_CHECK(status_);
     }
     // printf("max_smem_per_block = %d\n", max_smem_per_block);
-    if (max_smem_per_block >= 132 * 1024) {             // H100 and A100
-        // 132KB
+    if (max_smem_per_block >= 116 * 1024) {             // H100 and A100
+        // 116KB
         run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 128, 8, 2, 4, 4, false, false, T>, Is_causal>(params, stream);
     } else {                                            // sm86 and sm89
-        // 88KB
-        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 64, 8, 2, 4, 4, false, false, T>, Is_causal>(params, stream);
+        // 92KB
+        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 128, 8, 2, 4, 4, true, false, T>, Is_causal>(params, stream);
     }
 }
 
@@ -214,12 +211,12 @@ void run_mha_bwd_hdim128(Flash_bwd_params &params, cudaStream_t stream) {
     // run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 64, 8, 2, 2, 2, false, false, T>>(params, stream);
     if (max_smem_per_block >= 224 * 1024) {             // H100
         // 224KB
-        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 128, 128, 8, 2, 4, 2, true, false, T>, Is_causal>(params, stream);
+        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 128, 128, 8, 2, 4, 2, false, false, T>, Is_causal>(params, stream);
     } else if (max_smem_per_block >= 144 * 1024) {      // A100
         // 144KB
-        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 128, 8, 2, 4, 2, true, false, T>, Is_causal>(params, stream);
+        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 128, 8, 2, 4, 2, false, false, T>, Is_causal>(params, stream);
     } else {                                            // sm86 and sm89
-        // 96KB
+        // 88KB
         run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 64, 8, 4, 2, 2, true, false, T>, Is_causal>(params, stream);
     }
 }
@@ -235,14 +232,14 @@ void run_mha_bwd_hdim192(Flash_bwd_params &params, cudaStream_t stream) {
     if (status_ != cudaSuccess) {
       C10_CUDA_CHECK(status_);
     }
-    if (max_smem_per_block >= 224 * 1024) {             // H100
-        // 224KB
+    if (max_smem_per_block >= 208 * 1024) {             // H100
+        // 208KB
         run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 128, 8, 4, 2, 2, false, false, T>, Is_causal>(params, stream);
-    } else if (max_smem_per_block >= 136 * 1024) {      // A100
-        // 136KB
-        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 64, 8, 4, 2, 2, true, false, T>, Is_causal>(params, stream);
+    } else if (max_smem_per_block >= 152 * 1024) {      // A100
+        // 152KB
+        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 64, 8, 4, 2, 2, false, false, T>, Is_causal>(params, stream);
     } else {                                            // sm86 and sm89
-        // 92KB
+        // 84KB
         run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 32, 64, 8, 4, 2, 2, true, false, T>, Is_causal>(params, stream);
     }
 }
@@ -258,15 +255,15 @@ void run_mha_bwd_hdim256(Flash_bwd_params &params, cudaStream_t stream) {
     if (status_ != cudaSuccess) {
       C10_CUDA_CHECK(status_);
     }
-    if (max_smem_per_block >= 208 * 1024) {             // H100
-        // 208KB
+    if (max_smem_per_block >= 200 * 1024) {             // H100
+        // 200KB
         run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 64, 8, 4, 2, 2, false, false, T>, Is_causal>(params, stream);
-    } else if (max_smem_per_block >= 144 * 1024) {      // A100
-        // 144KB
+    } else if (max_smem_per_block >= 136 * 1024) {      // A100
+        // 136KB
         run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 64, 8, 4, 2, 2, true, true, T>, Is_causal>(params, stream);
     } else {                                            // sm86 and sm89
-        // 84KB
-        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 32, 32, 8, 4, 1, 2, true, false, T>, Is_causal>(params, stream);
+        // 98KB
+        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 32, 32, 8, 4, 1, 2, false, false, T>, Is_causal>(params, stream);
     }
 }
 

--- a/csrc/src/flash_bwd_launch_template.h
+++ b/csrc/src/flash_bwd_launch_template.h
@@ -142,7 +142,8 @@ void run_mha_bwd_hdim32(Flash_bwd_params &params, cudaStream_t stream) {
         run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 128, 128, 8, 4, 4, 4, false, false, T>, Is_causal>(params, stream);
     } else {                                            // sm86 and sm89
         // 96KB
-        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 128, 128, 8, 4, 4, 4, true, false, T>, Is_causal>(params, stream);
+        // We need to adjust no_double_buffer to save some smem, because is_v_in_regs=true will still allocate smem that may overflow
+        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 128, 128, 8, 4, 4, 4, false, true, T>, Is_causal>(params, stream);
     }
 }
 
@@ -188,8 +189,8 @@ void run_mha_bwd_hdim96(Flash_bwd_params &params, cudaStream_t stream) {
         // 116KB
         run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 128, 8, 2, 4, 4, false, false, T>, Is_causal>(params, stream);
     } else {                                            // sm86 and sm89
-        // 92KB
-        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 128, 8, 2, 4, 4, true, false, T>, Is_causal>(params, stream);
+        // 80KB
+        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 64, 8, 2, 4, 4, false, false, T>, Is_causal>(params, stream);
     }
 }
 
@@ -217,7 +218,7 @@ void run_mha_bwd_hdim128(Flash_bwd_params &params, cudaStream_t stream) {
         run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 128, 8, 2, 4, 2, false, false, T>, Is_causal>(params, stream);
     } else {                                            // sm86 and sm89
         // 88KB
-        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 64, 8, 4, 2, 2, true, false, T>, Is_causal>(params, stream);
+        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 64, 8, 4, 2, 2, false, true, T>, Is_causal>(params, stream);
     }
 }
 
@@ -239,8 +240,8 @@ void run_mha_bwd_hdim192(Flash_bwd_params &params, cudaStream_t stream) {
         // 152KB
         run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 64, 8, 4, 2, 2, false, false, T>, Is_causal>(params, stream);
     } else {                                            // sm86 and sm89
-        // 84KB
-        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 32, 64, 8, 4, 2, 2, true, false, T>, Is_causal>(params, stream);
+        // 88KB
+        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 32, 64, 8, 4, 2, 2, false, true, T>, Is_causal>(params, stream);
     }
 }
 
@@ -258,12 +259,12 @@ void run_mha_bwd_hdim256(Flash_bwd_params &params, cudaStream_t stream) {
     if (max_smem_per_block >= 200 * 1024) {             // H100
         // 200KB
         run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 64, 8, 4, 2, 2, false, false, T>, Is_causal>(params, stream);
-    } else if (max_smem_per_block >= 136 * 1024) {      // A100
-        // 136KB
-        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 64, 64, 8, 4, 2, 2, true, true, T>, Is_causal>(params, stream);
+    } else if (max_smem_per_block >= 132 * 1024) {      // A100
+        // 132KB
+        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 32, 64, 8, 4, 2, 2, false, false, T>, Is_causal>(params, stream);
     } else {                                            // sm86 and sm89
-        // 98KB
-        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 32, 32, 8, 4, 1, 2, false, false, T>, Is_causal>(params, stream);
+        // 82KB
+        run_flash_bwd<Flash_bwd_kernel_traits<Headdim, 32, 32, 8, 4, 1, 2, true, false, T>, Is_causal>(params, stream);
     }
 }
 

--- a/csrc/src/flash_fwd_kernel.h
+++ b/csrc/src/flash_fwd_kernel.h
@@ -395,6 +395,7 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
     constexpr int n_masking_steps = (!Is_causal)
         ? 1
         : ((Is_even_MN && Is_causal) ? cute::ceil_div(kBlockM, kBlockN) : cute::ceil_div(kBlockM, kBlockN) + 1);
+    bool first_processed_block = true;
     #pragma unroll
     for (int masking_step = 0; masking_step < n_masking_steps; ++masking_step, --n_block) {
         Tensor acc_s = partition_fragment_C(tiled_mma, Shape<Int<kBlockM>, Int<kBlockN>>{});  // (MMA=4, MMA_M, MMA_N)
@@ -402,13 +403,62 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
         FLASH_NAMESPACE::cp_async_wait<0>();
         __syncthreads();
 
-        // Copy Mask and Bias from smem to registers
+        // Copy mask from smem to registers and do OR-reduce to see if any active threads
         Tensor tSrMask = make_tensor<Element>(shape(acc_s));
-        Tensor tSrBias = make_tensor<Element>(shape(acc_s));
         Tensor tSrMask_copy_view = smem_thr_copy_Mask.retile_D(tSrMask);
-        cute::copy(smem_tiled_copy_Mask, tSsMask, tSrMask_copy_view);
-        Tensor tSrBias_copy_view = smem_thr_copy_Bias.retile_D(tSrBias);
-        cute::copy(smem_tiled_copy_Bias, tSsBias, tSrBias_copy_view);
+        Tensor tSsMask_copy_view = smem_thr_copy_Mask.retile_S(tSsMask);
+        bool any_active_local = false;
+        #pragma unroll
+        for (int i = 0; i < size(tSrMask_copy_view); ++i) {
+            Element m = tSsMask_copy_view(i);
+            any_active_local |= (m != Element(0));
+            tSrMask_copy_view(i) = m;
+        }
+        bool any_active = __syncthreads_or(any_active_local);
+
+        // Early skip for fully masked blocks
+        if (!any_active) {      // Skip loading V and all computation
+
+            // Still need to load the next K/Mask/Bias if there are more blocks
+            if (n_block > n_block_min) {
+                FLASH_NAMESPACE::copy</*Is_even_MN=*/true, Is_even_K>(
+                    gmem_tiled_copy_QKV,
+                    tKgK(_, _, _, n_block - 1), tKsK,
+                    tKVcKV, tKVpKV
+                );
+                FLASH_NAMESPACE::copy_MN</*Is_even_MN=*/true>(
+                    gmem_tiled_copy_MaskBias,
+                    tMaskgMask(_, _, _, n_block - 1), tMasksMask, 
+                    tMaskcMask,
+                    binfo.actual_seqlen_q - m_block * kBlockM, binfo.actual_seqlen_k - (n_block - 1) * kBlockN
+                );
+                FLASH_NAMESPACE::copy_MN</*Is_even_MN=*/true>(
+                    gmem_tiled_copy_MaskBias,
+                    tBiasgBias(_, _, _, n_block - 1), tBiassBias,
+                    tBiascBias,
+                    binfo.actual_seqlen_q - m_block * kBlockM, binfo.actual_seqlen_k - (n_block - 1) * kBlockN
+                );
+                // This cp_async_fence needs to be in the if block, otherwise the synchronization
+                // isn't right and we get race conditions.
+                cute::cp_async_fence();
+            }
+
+            if constexpr (Return_softmax){
+                // Even if the block is fully masked, we still need to write something to gS
+                // Convert acc_s from fp32 to fp16/bf16
+                Tensor rP = FLASH_NAMESPACE::convert_type<Element>(acc_s);
+                cute::copy(rP, tSgS);
+                tSgS.data() = tSgS.data() + (-kBlockN);
+            }
+
+            // This check is at the end of the loop since we always have at least 1 iteration
+            if (n_masking_steps > 1 && n_block <= n_block_min) {
+                --n_block;
+                break;
+            }
+
+            continue;
+        }
 
         // Advance gV
         if (masking_step > 0) {
@@ -428,10 +478,9 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
         }
         cute::cp_async_fence();
 
-        // Use sparse general matrix multiplication
-        FLASH_NAMESPACE::sparse_gemm</*A_in_regs=*/Kernel_traits::Is_Q_in_regs>(
+        FLASH_NAMESPACE::gemm</*A_in_regs=*/Kernel_traits::Is_Q_in_regs>(
             acc_s,
-            tSrQ, tSrK, tSsQ, tSsK, tSrMask,        // Active key mask for sparse K matrix multiplication
+            tSrQ, tSrK, tSsQ, tSsK,
             tiled_mma,
             smem_tiled_copy_Q, smem_tiled_copy_K,
             smem_thr_copy_Q, smem_thr_copy_K
@@ -440,6 +489,11 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
         if constexpr (Is_softcap){
             FLASH_NAMESPACE::apply_softcap(acc_s, params.softcap);
         }
+
+        // Copy bias from smem to registers
+        Tensor tSrBias = make_tensor<Element>(shape(acc_s));
+        Tensor tSrBias_copy_view = smem_thr_copy_Bias.retile_D(tSrBias);
+        cute::copy(smem_tiled_copy_Bias, tSsBias, tSrBias_copy_view);
 
         // Scale attention scores and apply mask/bias
         mask.template apply_mask<Is_causal, Is_even_MN>(
@@ -473,9 +527,10 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
         }
 
         // TODO: when we have key_padding_mask we'll need to Check_inf
-        masking_step == 0
+        first_processed_block == true
             ? softmax.template softmax</*Is_first=*/true,  /*Check_inf=*/true>(acc_s, acc_o)
             : softmax.template softmax</*Is_first=*/false, /*Check_inf=*/true>(acc_s, acc_o);
+        first_processed_block = false;
         // masking_step == 0
         //     ? softmax.template softmax_rescale_o</*Is_first=*/true,  /*Check_inf=*/true>(acc_s, acc_o, params.scale_softmax_log2)
         //     : softmax.template softmax_rescale_o</*Is_first=*/false, /*Check_inf=*/true>(acc_s, acc_o, params.scale_softmax_log2);
@@ -491,10 +546,9 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
         // if using m16n8k16 or (4, MMA_M, MMA_N) if using m16n8k8.
         Tensor tOrP = make_tensor(rP.data(), FLASH_NAMESPACE::convert_layout_acc_Aregs<typename Kernel_traits::TiledMma>(rP.layout()));
         // if (cute::thread0()) { print(tOrP); }
-        // Use sparse general matrix multiplication with register accumulation for V as well
-        FLASH_NAMESPACE::sparse_gemm_rs(
+        FLASH_NAMESPACE::gemm_rs(
             acc_o,
-            tOrP, tOrVt, tOsVt, tSrMask,    // Apply the same mask for sparse V matrix multiplication
+            tOrP, tOrVt, tOsVt,
             tiled_mma,
             smem_tiled_copy_V, smem_thr_copy_V
         );
@@ -514,13 +568,54 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
         FLASH_NAMESPACE::cp_async_wait<0>();
         __syncthreads();
 
-        // Copy Mask and Bias from smem to registers
+        // Copy mask from smem to registers and do OR-reduce to see if any active threads
         Tensor tSrMask = make_tensor<Element>(shape(acc_s));
-        Tensor tSrBias = make_tensor<Element>(shape(acc_s));
         Tensor tSrMask_copy_view = smem_thr_copy_Mask.retile_D(tSrMask);
-        cute::copy(smem_tiled_copy_Mask, tSsMask, tSrMask_copy_view);
-        Tensor tSrBias_copy_view = smem_thr_copy_Bias.retile_D(tSrBias);
-        cute::copy(smem_tiled_copy_Bias, tSsBias, tSrBias_copy_view);
+        Tensor tSsMask_copy_view = smem_thr_copy_Mask.retile_S(tSsMask);
+        bool any_active_local = false;
+        #pragma unroll
+        for (int i = 0; i < size(tSrMask_copy_view); ++i) {
+            Element m = tSsMask_copy_view(i);
+            any_active_local |= (m != Element(0));
+            tSrMask_copy_view(i) = m;
+        }
+        bool any_active = __syncthreads_or(any_active_local);
+
+        // Early skip for fully masked blocks
+        if (!any_active) {      // Skip loading V and all computation
+
+            // Still need to load the next K/Mask/Bias if there are more blocks
+            if (n_block > n_block_min) {
+                FLASH_NAMESPACE::copy</*Is_even_MN=*/true, Is_even_K>(
+                    gmem_tiled_copy_QKV,
+                    tKgK(_, _, _, n_block - 1), tKsK,
+                    tKVcKV, tKVpKV
+                );
+                FLASH_NAMESPACE::copy_MN</*Is_even_MN=*/true>(
+                    gmem_tiled_copy_MaskBias,
+                    tMaskgMask(_, _, _, n_block - 1), tMasksMask, 
+                    tMaskcMask,
+                    binfo.actual_seqlen_q - m_block * kBlockM, binfo.actual_seqlen_k - (n_block - 1) * kBlockN
+                );
+                FLASH_NAMESPACE::copy_MN</*Is_even_MN=*/true>(
+                    gmem_tiled_copy_MaskBias,
+                    tBiasgBias(_, _, _, n_block - 1), tBiassBias,
+                    tBiascBias,
+                    binfo.actual_seqlen_q - m_block * kBlockM, binfo.actual_seqlen_k - (n_block - 1) * kBlockN
+                );
+                cute::cp_async_fence();
+            }
+
+            if constexpr (Return_softmax){
+                // Even if the block is fully masked, we still need to write something to gS
+                // Convert acc_s from fp32 to fp16/bf16
+                Tensor rP = FLASH_NAMESPACE::convert_type<Element>(acc_s);
+                cute::copy(rP, tSgS);
+                tSgS.data() = tSgS.data() + (-kBlockN);
+            }
+
+            continue;
+        }
 
         FLASH_NAMESPACE::copy</*Is_even_MN=*/true, Is_even_K>(
             gmem_tiled_copy_QKV,
@@ -529,10 +624,9 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
         );
         cute::cp_async_fence();
 
-        // Use sparse general matrix multiplication
-        FLASH_NAMESPACE::sparse_gemm</*A_in_regs=*/Kernel_traits::Is_Q_in_regs>(
+        FLASH_NAMESPACE::gemm</*A_in_regs=*/Kernel_traits::Is_Q_in_regs>(
             acc_s,
-            tSrQ, tSrK, tSsQ, tSsK, tSrMask,        // Active key mask for sparse K matrix multiplication
+            tSrQ, tSrK, tSsQ, tSsK,
             tiled_mma,
             smem_tiled_copy_Q, smem_tiled_copy_K,
             smem_thr_copy_Q, smem_thr_copy_K
@@ -540,6 +634,11 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
         if constexpr (Is_softcap){
             FLASH_NAMESPACE::apply_softcap(acc_s, params.softcap);
         }
+
+        // Copy bias from smem to registers
+        Tensor tSrBias = make_tensor<Element>(shape(acc_s));
+        Tensor tSrBias_copy_view = smem_thr_copy_Bias.retile_D(tSrBias);
+        cute::copy(smem_tiled_copy_Bias, tSsBias, tSrBias_copy_view);
 
         // Scale attention scores and apply dynamic mask
         mask.template apply_mask</*Causal_mask=*/false>(
@@ -572,7 +671,10 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
             cute::cp_async_fence();
         }
 
-        softmax.template softmax</*Is_first=*/false, /*Check_inf=*/true>(acc_s, acc_o);
+        first_processed_block == true
+            ? softmax.template softmax</*Is_first=*/true,  /*Check_inf=*/true>(acc_s, acc_o)
+            : softmax.template softmax</*Is_first=*/false, /*Check_inf=*/true>(acc_s, acc_o);
+        first_processed_block = false;
         // softmax.template softmax_rescale_o</*Is_first=*/false, /*Check_inf=*/true>(acc_s, acc_o, params.scale_softmax_log2);
 
         // Convert acc_s from fp32 to fp16/bf16
@@ -586,10 +688,9 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
         // if using m16n8k16 or (4, MMA_M, MMA_N) if using m16n8k8.
         Tensor tOrP = make_tensor(rP.data(), FLASH_NAMESPACE::convert_layout_acc_Aregs<typename Kernel_traits::TiledMma>(rP.layout()));
 
-        // Use sparse general matrix multiplication with register accumulation for V as well
-        FLASH_NAMESPACE::sparse_gemm_rs(
+        FLASH_NAMESPACE::gemm_rs(
             acc_o,
-            tOrP, tOrVt, tOsVt, tSrMask,    // Apply the same mask for sparse V matrix multiplication
+            tOrP, tOrVt, tOsVt,
             tiled_mma,
             smem_tiled_copy_V, smem_thr_copy_V
         );

--- a/csrc/src/flash_fwd_kernel.h
+++ b/csrc/src/flash_fwd_kernel.h
@@ -1057,7 +1057,7 @@ inline __device__ void compute_attn_1rowblock_splitkv(const Params &params, cons
                 const int block_table_idx_cur = n_block * kBlockN / params.page_block_size;
                 const int block_table_offset_cur = n_block * kBlockN - block_table_idx_cur * params.page_block_size;
                 const int block_table_idx_next = (n_block - 1) * kBlockN / params.page_block_size;
-                const int block_table_offset_next =(n_block - 1) * kBlockN - block_table_idx_next * params.page_block_size;
+                const int block_table_offset_next = (n_block - 1) * kBlockN - block_table_idx_next * params.page_block_size;
                 tKgK.data() = tKgK.data() + (block_table[block_table_idx_next] - block_table[block_table_idx_cur]) * params.k_batch_stride + (block_table_offset_next - block_table_offset_cur) * params.k_row_stride;
                 tMaskgMask.data() = tMaskgMask.data() + (block_table[block_table_idx_next] - block_table[block_table_idx_cur]) * params.mask_batch_stride + (block_table_offset_next - block_table_offset_cur);
                 tBiasgBias.data() = tBiasgBias.data() + (block_table[block_table_idx_next] - block_table[block_table_idx_cur]) * params.bias_batch_stride + (block_table_offset_next - block_table_offset_cur);
@@ -1166,7 +1166,7 @@ inline __device__ void compute_attn_1rowblock_splitkv(const Params &params, cons
         FLASH_NAMESPACE::cp_async_wait<0>();
         __syncthreads();
         if (n_block > n_block_min) {
-            // Advance gK
+            // Advance gK, gMask, gBias
             if (block_table == nullptr) {
                 tKgK.data() = tKgK.data() + (-int(kBlockN * params.k_row_stride));
                 tMaskgMask.data() = tMaskgMask.data() + (-int(kBlockN));

--- a/csrc/src/flash_fwd_kernel.h
+++ b/csrc/src/flash_fwd_kernel.h
@@ -1067,8 +1067,6 @@ inline __device__ void compute_attn_1rowblock_splitkv(const Params &params, cons
                 tKgK, tKsK,
                 tKVcKV, tKVpKV
             );
-            // This cp_async_fence needs to be in the if block, otherwise the synchronization
-            // isn't right and we get race conditions.
             FLASH_NAMESPACE::copy_MN</*Is_even_MN=*/true>(
                 gmem_tiled_copy_MaskBias,
                 tMaskgMask, tMasksMask, 
@@ -1081,6 +1079,8 @@ inline __device__ void compute_attn_1rowblock_splitkv(const Params &params, cons
                 tBiascBias,
                 binfo.actual_seqlen_q - m_block * kBlockM, binfo.actual_seqlen_k - (n_block - 1) * kBlockN
             );
+            // This cp_async_fence needs to be in the if block, otherwise the synchronization
+            // isn't right and we get race conditions.
             cute::cp_async_fence();
         }
 

--- a/csrc/src/flash_fwd_kernel.h
+++ b/csrc/src/flash_fwd_kernel.h
@@ -509,8 +509,6 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
                 tKgK(_, _, _, n_block - 1), tKsK,
                 tKVcKV, tKVpKV
             );
-            // This cp_async_fence needs to be in the if block, otherwise the synchronization
-            // isn't right and we get race conditions.
             FLASH_NAMESPACE::copy_MN</*Is_even_MN=*/true>(
                 gmem_tiled_copy_MaskBias,
                 tMaskgMask(_, _, _, n_block - 1), tMasksMask, 
@@ -523,6 +521,8 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
                 tBiascBias,
                 binfo.actual_seqlen_q - m_block * kBlockM, binfo.actual_seqlen_k - (n_block - 1) * kBlockN
             );
+            // This cp_async_fence needs to be in the if block, otherwise the synchronization
+            // isn't right and we get race conditions.
             cute::cp_async_fence();
         }
 

--- a/csrc/src/flash_fwd_launch_template.h
+++ b/csrc/src/flash_fwd_launch_template.h
@@ -155,7 +155,7 @@ void run_flash_splitkv_fwd(Flash_fwd_params &params, cudaStream_t stream) {
 template<typename T, int Headdim, bool Is_causal>
 void run_mha_fwd_splitkv_dispatch(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int kBlockM = 64;  // Fixed for all head dimensions
-    constexpr static int kBlockN = Headdim <= 32 ? 128 : (Headdim <= 64 ? 64 : (Headdim < 128 ? 64 : 32));
+    constexpr static int kBlockN = Headdim <= 64 ? 64 : (Headdim < 128 ? 64 : 32);
     run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN, 4, false, false, T>, Is_causal>(params, stream);
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,89 @@
+[build-system]
+requires = [
+  "setuptools>=64",
+  "wheel",
+  "packaging",
+  "psutil",
+  "ninja"
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "flash-dmattn"
+dynamic = ["version"]
+description = "Flash Dynamic Mask Attention: Fast and Memory-Efficient Trainable Dynamic Mask Sparse Attention"
+readme = "README.md"
+license = { file = "LICENSE" }
+authors = [
+  { name = "Jingze Shi", email = "losercheems@gmail.com" },
+  { name = "Yifan Wu", email = "ywu012@connect.hkust-gz.edu.cn" },
+  { name = "Bingheng Wu", email = "wubingheng52136@gmail.com" },
+  { name = "Yiran Peng", email = "amagipeng@gmail.com" },
+  { name = "Liangdong Wang", email = "wangliangdong@baai.ac.cn" },
+  { name = "Guang Li", email = "liuguang@baai.ac.cn" },
+  { name = "Yuyu Luo", email = "yuyuluo@hkust-gz.edu.cn" }
+]
+maintainers = [
+  { name = "Jingze Shi", email = "losercheems@gmail.com" }
+]
+requires-python = ">=3.9"
+dependencies = [
+  "torch",
+  "einops"
+]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: BSD License",
+  "Operating System :: Unix"
+]
+
+[project.urls]
+Homepage = "https://github.com/SmallDoge/flash-dmattn"
+Source = "https://github.com/SmallDoge/flash-dmattn"
+Issues = "https://github.com/SmallDoge/flash-dmattn/issues"
+
+[project.optional-dependencies]
+triton = [
+  "triton>=2.0.0"
+]
+flex = [
+  "transformers>=4.38.0"
+]
+all = [
+  "triton>=2.0.0",
+  "transformers>=4.38.0"
+]
+test = [
+  "pytest>=6.0",
+  "pytest-benchmark",
+  "numpy"
+]
+dev = [
+  "triton>=2.0.0",
+  "transformers>=4.38.0",
+  "pytest>=6.0",
+  "pytest-benchmark",
+  "numpy"
+]
+
+[tool.setuptools.dynamic]
+version = { attr = "flash_dmattn.__version__" }
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["flash_dmattn*"]
+exclude = [
+  "build",
+  "csrc",
+  "include",
+  "tests",
+  "dist",
+  "docs",
+  "benchmarks",
+  "flash_dmattn.egg-info"
+]
+
+[tool.setuptools.package-data]
+flash_dmattn = ["*.py"]
+
+[tool.setuptools]


### PR DESCRIPTION

## Description
Implement block-sparse skipping for fully inactive (all-masked) query–key tiles in the backward kernel of Flash-DMAttn.  
When an entire $(\text{BlockM} \times \text{BlockN})$ mask tile is zero, all mathematical contributions from that tile are provably zero. We detect this early, avoid issuing 5 GEMMs (and associated softmax + reduction work), and safely advance pointers while preserving numerical equivalence. This closes issue #88.

## Type of Change
- [x] Performance optimization  
- [x] CUDA kernel improvement  
- [x] Code refactoring  
- [ ] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

## Related Issues
- Fixes #88

## Changes Made

### High-Level
Added coarse block-level sparsity in the backward kernel (`compute_dq_dk_dv_1colblock`) by introducing an early “inactive tile” branch that:
1. Loads the mask tile.
2. Computes a warp/block-wide OR $any\_active$.
3. If fully inactive, skips 5 GEMMs:
   - Recompute $QK^\top$
   - $dO \cdot V^\top$ partial
   - $P^\top \cdot dO \to dV$
   - $dP \cdot K \to dQ$
   - $dP^\top \cdot Q \to dK$
4. Advances iteration state (pointers, phase toggles) identically to dense path.
5. Preserves alias & accumulator lifetimes with added synchronization.

### Why It Is Correct to Skip the 5 GEMMs

Let the current query block index set be $I$ and key/value block index set be $J$.  
Mask tile condition (fully inactive):

$$
M_{ij} = 0,\quad \forall i \in I,\; j \in J
$$

Forward logits for unmasked positions:

$$
S_{ij} = \frac{(QK^\top)_{ij}}{\sqrt{d}} + B_{ij} + \text{mask\_term}_{ij}
$$

Masked entries use:

$$
\text{mask\_term}_{ij} = -\infty \;\Rightarrow\; P_{ij} = \mathrm{softmax}_j(S_{ij}) = 0
$$

Backward contributions (standard masked softmax attention algebra):

1. Probability:

$$
P_{ij} = 0 \Rightarrow \text{tile probabilities are identically zero.}
$$

2. Gradient wrt $V$ (local tile part):

$$
\Delta dV_j = \sum_{i \in I} P_{ij} \, dO_i = 0
$$

3. Define the usual row correction:

$$
T_i = \sum_{k} P_{ik} \,(dO_i \cdot V_k)
$$

4. (One common formulation) Softmax differential:

$$
dP_{ij} = P_{ij}\left((dO_i \cdot V_j) - T_i\right) \;\Rightarrow\; P_{ij}=0 \;\Rightarrow\; dP_{ij}=0
$$

5. Gradients:

$$
dQ_i = \sum_{j} dP_{ij} K_j \quad \Rightarrow \quad 0
$$

$$
dK_j = \sum_{i} dP_{ij} Q_i \quad \Rightarrow \quad 0
$$

$$
\Delta dV_j = \sum_{i} P_{ij} dO_i \quad \Rightarrow \quad 0
$$

Therefore the five GEMMs:

$$
QK^\top,\quad dO V^\top,\quad P^\top dO,\quad dP K,\quad dP^\top Q
$$

produce zero contributions for this tile and can be skipped.

### Algebraic Summary of Skipped Operations
- SdP GEMM ($QK^\top$) unnecessary: $P_{ij}$ already forced to $0$ by mask.
- $dO V^\top$ tile slice later multiplied by $P_{ij}$ (zero).
- $P^\top dO \to dV$: term is $\sum_i P_{ij} dO_i = 0$.
- $dP K \to dQ$: term is $\sum_j dP_{ij} K_j = 0$.
- $dP^\top Q \to dK$: term is $\sum_i dP_{ij} Q_i = 0$.

### Implementation Details
- Load mask early, compute $any\_active = \bigvee_{i,j} (M_{ij} \neq 0)$.
- If inactive, branch:
  - Optionally zero (or leave unused) shared-memory regions for $P/dS$ aliases to prevent stale reuse.
  - Skip softmax recompute and all 5 GEMMs.
  - Maintain identical pointer / phase / double-buffer advancement.
  - Ensure last-iteration store semantics for $dQ$ remain correct (explicit zero if needed).
- Added post-$dK$ `__syncthreads()` before bias ↔ $dS$ reuse to avoid overwrite hazards causing NaNs.
- Shared memory aliasing:
  - $s\text{Mask} \leftrightarrow sP$ reuse (safe).
  - $s\text{Bias} \leftrightarrow sdS$ reuse (safe with barrier).
  - Avoid deeper alias with $sdQ$ to reduce race risk.

### Code Changes
- `flash_bwd_kernel.h`: early skip branch, synchronization barrier, clarified alias comments.
- (If modified) `kernel_traits.h`: ensured transposed layout symbols available.
- Optional instrumentation hooks (can be compiled out) for counting skipped tiles.
- Benchmark / equivalence scripts exercised new path.

### Correctness & Determinism
- Gradient equivalence holds across varied sequence lengths & sparsity patterns.
- Deterministic accumulation path unaffected: skipping removes operations; does not reorder reductions.
- Accumulators either uninitialized-and-unused (skip path) or explicitly zeroed before store.

### Performance Rationale
Let:

$$
p = \text{active tile fraction}, \qquad \varepsilon = \text{relative overhead of skip check per inactive tile}
$$
Dense time:
$$
T_{\text{dense}}
$$
New time:
$$
T_{\text{new}} \approx p\, T_{\text{dense}} + (1-p)\,\varepsilon\, T_{\text{dense}}
$$
Speedup:
$$
\text{Speedup} = \frac{T_{\text{dense}}}{T_{\text{new}}} \approx \frac{1}{p + (1-p)\varepsilon}
$$

For low $p$, large speedup; for $p \to 1$, overhead $(1-p)\varepsilon$ is negligible because $\varepsilon \ll 1$ (a mask load + reduction + branch).

### Safety Invariants
- No alias region overwritten before final consumer completes.
- Phase / pointer increments identical in both branches (prevents drift).
- Double-buffer toggles synchronized.
- Softmax row statistics unaffected (inactive tile contributes zeros).
- Final gradient stores never read uninitialized fragments.

### Future Work
- Adaptive threshold: bypass sparse path if $p > 0.85$.
- Sub-tile (fragment-level) sparsity.
- Export skip counters for runtime tuning.
- Double-buffer bias/$dS$ to further hide latency.
- Support compressed mask encodings (bitmap / RLE).

## Documentation
- [ ] Add “Adaptive Sparse Backward” subsection to integration.md.
- [ ] Note performance model & equations in api_reference.md.

## Testing
- Gradient equivalence scripts (e.g. backward_equivalence.py) pass within FP tolerance.
- Verified absence of NaNs / Infs after barrier insertion.
- Tested multiple sizes: 64, 128, 256, 1024+ and varied sparsity.

### Test Configuration (example)
- OS: Ubuntu 22.04 / (also validated on Windows dev env)
- Python: 3.12
- PyTorch: 2.x
- CUDA: 12.1
- GPU: A100 / RTX 4090

## Performance Impact
(Representative qualitative observations; numeric table to follow.)
- ~$30\%$ active density: noticeable backward latency reduction (major GEMMs skipped).
- $>90\%$ density: overhead < a few percent; will shrink further with adaptive threshold.
- Smem aliasing improved occupancy in head_dim=128 cases.

## Breaking Changes
None. Public API and numerical results unchanged.

## Checklist
- [x] Style guidelines followed
- [x] Self-review & comments added
- [x] No new warnings
- [x] Existing tests pass
- [x] Gradient equivalence validated
- [ ] Benchmarks table updated (pending final sweep)
- [x] Compiles SM 8.0+
- [x] No memory leaks

### CUDA-specific
- [x] Races eliminated (barrier added)
- [x] Aliasing documented
- [x] Deterministic mode preserved

## Additional Notes
A longer appendix deriving $dP$ and $dS$ variants can be added to docs if reviewers request.

## Suggested Squash Commit Message
Backward kernel: block-sparse early skip (skip 5 GEMMs on fully masked tiles) + safe smem aliasing (mask→P, bias↔dS) + sync fix (Fixes #88)
