### PR TITLE
Enable head dimension 128 test cases for backward and forward equivalence

### DIFF
--- a/benchmarks/backward_equivalence.py
+++ b/benchmarks/backward_equivalence.py
@@ -598,23 +598,22 @@ def test_cuda_backward_equivalence(accuracy_threshold=0.95):
         (1, 2, 1, 4096, 4096, 96, True),
         (1, 2, 1, 4096, 4096, 96, False),
 
-        # Not support head_dim => 128 in sm89 yet
-        # Because fwd uses splitkv branch, this branch does not support head_dim>=128 for now
         # Head dim 128
-        # (1, 2, 1, 128, 128, 128, True),
-        # (1, 2, 1, 128, 128, 128, True),
-        # (1, 2, 1, 256, 256, 128, True),
-        # (1, 2, 1, 256, 256, 128, False),
-        # (1, 2, 1, 512, 512, 128, True),
-        # (1, 2, 1, 512, 512, 128, False),
-        # (1, 2, 1, 1024, 1024, 128, True),
-        # (1, 2, 1, 1024, 1024, 128, False),
-        # (1, 2, 1, 2048, 2048, 128, True),
-        # (1, 2, 1, 2048, 2048, 128, False),
-        # (1, 2, 1, 4096, 4096, 128, True),
-        # (1, 2, 1, 4096, 4096, 128, False),
+        (1, 2, 1, 128, 128, 128, True),
+        (1, 2, 1, 128, 128, 128, False),
+        (1, 2, 1, 256, 256, 128, True),
+        (1, 2, 1, 256, 256, 128, False),
+        (1, 2, 1, 512, 512, 128, True),
+        (1, 2, 1, 512, 512, 128, False),
+        (1, 2, 1, 1024, 1024, 128, True),
+        (1, 2, 1, 1024, 1024, 128, False),
+        (1, 2, 1, 2048, 2048, 128, True),
+        (1, 2, 1, 2048, 2048, 128, False),
+        (1, 2, 1, 4096, 4096, 128, True),
+        (1, 2, 1, 4096, 4096, 128, False),
 
         # Head dim 256
+        # Because fwd uses splitkv branch, this branch does not support head_dim=256 for now
         # For head_dim=256, besides the reason of splitkv branch, bwd itself does not support it, not enough shared memory
         # (1, 2, 1, 128, 128, 256, True),
         # (1, 2, 1, 128, 128, 256, False),

--- a/benchmarks/forward_equivalence.py
+++ b/benchmarks/forward_equivalence.py
@@ -561,22 +561,22 @@ def test_cuda_forward_equivalence(accuracy_threshold=0.95):
         (1, 2, 1, 4096, 4096, 96, True),
         (1, 2, 1, 4096, 4096, 96, False),
 
-        # Not support head_dim >= 128 in sm89 yet
-        # Because fwd uses splitkv branch by default, and shared memory is not enough for sm89
         # Head dim 128
-        # (1, 2, 1, 128, 128, 128, True),
-        # (1, 2, 1, 128, 128, 128, False),
-        # (1, 2, 1, 256, 256, 128, True),
-        # (1, 2, 1, 256, 256, 128, False),
-        # (1, 2, 1, 512, 512, 128, True),
-        # (1, 2, 1, 512, 512, 128, False),
-        # (1, 2, 1, 1024, 1024, 128, True),
-        # (1, 2, 1, 1024, 1024, 128, False),
-        # (1, 2, 1, 2048, 2048, 128, True),
-        # (1, 2, 1, 2048, 2048, 128, False),
-        # (1, 2, 1, 4096, 4096, 128, True),
-        # (1, 2, 1, 4096, 4096, 128, False),
+        (1, 2, 1, 128, 128, 128, True),
+        (1, 2, 1, 128, 128, 128, False),
+        (1, 2, 1, 256, 256, 128, True),
+        (1, 2, 1, 256, 256, 128, False),
+        (1, 2, 1, 512, 512, 128, True),
+        (1, 2, 1, 512, 512, 128, False),
+        (1, 2, 1, 1024, 1024, 128, True),
+        (1, 2, 1, 1024, 1024, 128, False),
+        (1, 2, 1, 2048, 2048, 128, True),
+        (1, 2, 1, 2048, 2048, 128, False),
+        (1, 2, 1, 4096, 4096, 128, True),
+        (1, 2, 1, 4096, 4096, 128, False),
 
+        # Not support head_dim = 256 in sm89 yet
+        # Because fwd uses splitkv branch by default, and shared memory is not enough for sm89
         # Head dim 256
         # (1, 2, 1, 128, 128, 256, True),
         # (1, 2, 1, 128, 128, 256, False),


### PR DESCRIPTION
Uncomment test cases for head dimension 128 in both backward and forward equivalence tests, allowing for comprehensive validation across various sequence lengths. Adjust comments regarding shared memory limitations to reflect the current applicability for head dimension 256.