### PR TITLE
Fix attention mask handling for invalid topk values

### DIFF
--- a/examples/modeling/modeling_doge.py
+++ b/examples/modeling/modeling_doge.py
@@ -353,11 +353,12 @@ class DogeAttention(nn.Module):
                 )
             attn_bias = attn_bias.masked_fill(attention_mask[:, :, :, : attn_bias.shape[-1]] != 0, min_dtype)
         if attn_bias.shape[-1] > keep_window_size:
-            topk_indices = torch.topk(
+            topk_values, topk_indices = torch.topk(
                 attn_bias, keep_window_size, dim=-1, largest=True, sorted=False
-            ).indices
+            )
+            valid_topk = topk_values != min_dtype
             attn_mask = torch.zeros_like(attn_bias, dtype=dtype, device=attn_bias.device)
-            attn_mask = attn_mask.scatter(-1, topk_indices, 1.0)
+            attn_mask = attn_mask.scatter(-1, topk_indices, valid_topk.to(dtype))
             attn_bias = attn_bias.masked_fill(attn_mask == 0.0, min_dtype)
         else:
             attn_mask = torch.ones_like(attn_bias, dtype=dtype, device=attn_bias.device)


### PR DESCRIPTION
Ensure the attention mask correctly processes topk values by validating them before applying the mask, preventing incorrect masking of valid attention scores.