### PR TITLE
Simplify backend imports and initialization

### DIFF
--- a/flash_dmattn/__init__.py
+++ b/flash_dmattn/__init__.py
@@ -2,71 +2,32 @@
 
 from typing import Optional
 
-__version__ = "1.0.0"
+__version__ = "1.0.3"
 
+
+# Import CUDA functions when available
 try:
-    from .flash_dmattn_triton import triton_dmattn_func
+    from flash_dmattn.flash_dmattn_interface import flash_dmattn_func
+    CUDA_AVAILABLE = True
+except ImportError:
+    CUDA_AVAILABLE = False
+    flash_dmattn_func = None
+
+# Import Triton functions when available
+try:
+    from flash_dmattn.flash_dmattn_triton import triton_dmattn_func
     TRITON_AVAILABLE = True
 except ImportError:
     TRITON_AVAILABLE = False
     triton_dmattn_func = None
 
+# Import Flex functions when available
 try:
-    from .flash_dmattn_flex import flex_dmattn_func
+    from flash_dmattn.flash_dmattn_flex import flex_dmattn_func
     FLEX_AVAILABLE = True
 except ImportError:
     FLEX_AVAILABLE = False
     flex_dmattn_func = None
-
-# Check if CUDA extension is available
-try:
-    import flash_dmattn_cuda    # type: ignore[import]
-    CUDA_AVAILABLE = True
-except ImportError:
-    CUDA_AVAILABLE = False
-
-# Import CUDA functions when available
-if CUDA_AVAILABLE:
-    try:
-        from .flash_dmattn_interface import (
-            flash_dmattn_func,
-            flash_dmattn_kvpacked_func,
-            flash_dmattn_qkvpacked_func,
-            flash_dmattn_varlen_func,
-            flash_dmattn_varlen_kvpacked_func,
-            flash_dmattn_varlen_qkvpacked_func,
-        )
-    except ImportError:
-        # Fallback if interface module is not available
-        flash_dmattn_func = None
-        flash_dmattn_kvpacked_func = None
-        flash_dmattn_qkvpacked_func = None
-        flash_dmattn_varlen_func = None
-        flash_dmattn_varlen_kvpacked_func = None
-        flash_dmattn_varlen_qkvpacked_func = None
-else:
-    flash_dmattn_func = None
-    flash_dmattn_kvpacked_func = None
-    flash_dmattn_qkvpacked_func = None
-    flash_dmattn_varlen_func = None
-    flash_dmattn_varlen_kvpacked_func = None
-    flash_dmattn_varlen_qkvpacked_func = None
-
-__all__ = [
-    "triton_dmattn_func",
-    "flex_dmattn_func", 
-    "flash_dmattn_func",
-    "flash_dmattn_kvpacked_func",
-    "flash_dmattn_qkvpacked_func",
-    "flash_dmattn_varlen_func",
-    "flash_dmattn_varlen_kvpacked_func",
-    "flash_dmattn_varlen_qkvpacked_func",
-    "flash_dmattn_func_auto",
-    "get_available_backends",
-    "TRITON_AVAILABLE",
-    "FLEX_AVAILABLE",
-    "CUDA_AVAILABLE",
-]
 
 
 def get_available_backends():
@@ -87,7 +48,7 @@ def flash_dmattn_func_auto(backend: Optional[str] = None, **kwargs):
     
     Args:
         backend (str, optional): Backend to use ('cuda', 'triton', 'flex'). 
-                                If None, will use the first available backend in order: cuda, triton, flex.
+            If None, will use the first available backend in order: cuda, triton, flex.
         **kwargs: Arguments to pass to the attention function.
     
     Returns:
@@ -107,8 +68,6 @@ def flash_dmattn_func_auto(backend: Optional[str] = None, **kwargs):
     if backend == "cuda":
         if not CUDA_AVAILABLE:
             raise RuntimeError("CUDA backend is not available. Please build the CUDA extension.")
-        if flash_dmattn_func is None:
-            raise RuntimeError("CUDA flash_dmattn_func is not available. Please check the installation.")
         return flash_dmattn_func
     
     elif backend == "triton":
@@ -123,3 +82,15 @@ def flash_dmattn_func_auto(backend: Optional[str] = None, **kwargs):
     
     else:
         raise ValueError(f"Unknown backend: {backend}. Available backends: {get_available_backends()}")
+
+
+__all__ = [
+    "CUDA_AVAILABLE",
+    "TRITON_AVAILABLE",
+    "FLEX_AVAILABLE",
+    "flash_dmattn_func",
+    "triton_dmattn_func",
+    "flex_dmattn_func",
+    "get_available_backends",
+    "flash_dmattn_func_auto",
+]


### PR DESCRIPTION
## Description
Streamlines package initialization by consolidating backend imports into consistent try/except blocks and removing redundant CUDA extension checks and nested import logic. Focuses the public API on the core CUDA interface while keeping Triton and Flex backends accessible. Updates version to 1.0.3.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring

## Related Issues
- Fixes #150  

## Changes Made

### Code Changes
- [x] Modified Python API
- [ ] Updated CUDA kernels
- [ ] Changed build system
- [ ] Updated dependencies

Details:
- Switched to absolute imports and simplified error handling in `flash_dmattn/__init__.py`.
- Unified backend availability flags: `CUDA_AVAILABLE`, `TRITON_AVAILABLE`, `FLEX_AVAILABLE`.
- Exposed a clean API surface via `__all__`:
  - `flash_dmattn_func` (from `flash_dmattn/flash_dmattn_interface.py`)
  - `triton_dmattn_func` (from `flash_dmattn/flash_dmattn_triton.py`)
  - `flex_dmattn_func` (from `flash_dmattn/flash_dmattn_flex.py`)
  - `get_available_backends`, `flash_dmattn_func_auto`
- Removed redundant/legacy CUDA function variants from exports.
- Bumped `__version__` to `1.0.3`.

### Documentation
- [ ] Updated README
- [ ] Updated API documentation
- [ ] Added examples
- [ ] Updated benchmarks

## Testing

- [x] Existing imports work without side effects:
  - `from flash_dmattn import flash_dmattn_func_auto, get_available_backends`
- [x] Backend detection reflects installed backends and returns correct callables for `"cuda" | "triton" | "flex"`.
- [x] Smoke tests on small tensors (forward path) for available backends.
- [ ] Backward pass smoke tests (if gradients are enabled).

### Test Configuration
- OS: Windows 11 / Ubuntu 22.04
- Python: 3.10.x
- PyTorch: 2.4.x
- CUDA: 12.1
- GPU: NVIDIA RTX 4090

## Performance Impact
- No runtime performance impact. Changes only affect import-time initialization logic.

## Breaking Changes
- Removed legacy/duplicated CUDA function exports from the package root.

Migration:
- Import core functions from `flash_dmattn` directly:
  - `from flash_dmattn import flash_dmattn_func, flash_dmattn_func_auto`
  - For specific backends: `triton_dmattn_func`, `flex_dmattn_func`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

### CUDA-specific (if applicable)
- [ ] CUDA kernels compile without warnings
- [ ] Tested on SM 8.0+ architectures
- [ ] Memory usage has been profiled
- [ ] No memory leaks detected

## Additional Notes
- The simplified init path reduces import-time failures and clarifies error messages when optional backends are unavailable.