### PR TITLE
Update PyTorch version matrix for Python 3.13 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
         # manylinux docker image, but I haven't figured out how to install CUDA on manylinux.
         os: [ubuntu-22.04, ubuntu-22.04-arm]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        torch-version: ["2.4.0", "2.5.1", "2.6.0", "2.7.1", "2.8.0"]
+        torch-version: ["2.5.1", "2.6.0", "2.7.1", "2.8.0"]
         cuda-version: ["12.9.1"]
         # We need separate wheels that either uses C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI) or not.
         # Pytorch wheels currently don't use it, but nvcr images have Pytorch compiled with C++11 ABI.
@@ -60,6 +60,9 @@ jobs:
           # Pytorch < 2.5 does not support Python 3.13
           - torch-version: "2.4.0"
             python-version: "3.13"
+          - torch-version: "2.5.1"
+            python-version: "3.13"
+            os: ubuntu-22.04-arm
     uses: ./.github/workflows/_build.yml
     with:
       runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Remove support for PyTorch 2.4.0 and add support for PyTorch 2.5.1 on Python 3.13 in the version matrix.