### PR TITLE
[BUG FIX] Prevent mask/bias materialization; avoid OOB for irregular seqlen

### DIFF
--- a/csrc/flash_dmattn/src/kernel_traits.h
+++ b/csrc/flash_dmattn/src/kernel_traits.h
@@ -183,7 +183,14 @@ struct Flash_fwd_kernel_traits : public Base {
             Layout<Shape<_1, _8>>{}
         )
     );      // Val layout, 8 vals per read
-    using GmemTiledCopyMaskBias = decltype(
+    using GmemTiledCopyMask = decltype(
+        make_tiled_copy(
+            Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, Element>{},
+            GmemLayoutAtom{},
+            Layout<Shape<_1, _8>>{}
+        )
+    );      // Val layout, 8 vals per read
+    using GmemTiledCopyBias = decltype(
         make_tiled_copy(
             Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, Element>{},
             GmemLayoutAtom{},
@@ -442,7 +449,14 @@ struct Flash_bwd_kernel_traits : public Base {
             Layout<Shape < _1, _8>>{}
         )
     );      // Val layout, 8 vals per store
-    using GmemTiledCopyMaskBias = decltype(
+    using GmemTiledCopyMask = decltype(
+        make_tiled_copy(
+            Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, elem_type>{},
+            GmemLayoutAtom{},
+            Layout<Shape<_1, _8>>{}
+        )
+    );      // Val layout, 8 vals per read
+    using GmemTiledCopyBias = decltype(
         make_tiled_copy(
             Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, elem_type>{},
             GmemLayoutAtom{},

--- a/csrc/flash_dmattn/src/utils.h
+++ b/csrc/flash_dmattn/src/utils.h
@@ -521,15 +521,16 @@ __forceinline__ __device__ void copy(
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <
-    bool Is_even_MN=true, bool Clear_OOB_MN=true, bool Bool_to_Element=false, typename To_type=void,
-    typename TiledCopy, typename Engine0, typename Layout0, typename Engine1, typename Layout1,
-    typename Engine2, typename Layout2
+    bool Is_even_MN=true, bool Clear_OOB_MN=false, bool Bool_to_Element=false, typename To_type=void,
+    // typename TiledCopy, 
+    typename Engine0, typename Layout0, typename Engine1, typename Layout1,
+    typename Engine2, typename Layout2, typename Engine3, typename Layout3
 >
 __forceinline__ __device__ void copy_MN(
-    TiledCopy tiled_copy,
+    // TiledCopy tiled_copy,
     Tensor<Engine0, Layout0> const &S, Tensor<Engine1, Layout1> &D,
-    Tensor<Engine2, Layout2> const &identity_MN,
-    const int max_M=0, const int max_N=0
+    Tensor<Engine2, Layout2> const &identity_MN,  Tensor<Engine3, Layout3> const &predicate_N,
+    const int max_M=0
 ) {
     CUTE_STATIC_ASSERT_V(rank(S) == Int<3>{});          // (MMA, MMA_M, MMA_N) 
     CUTE_STATIC_ASSERT_V(rank(D) == Int<3>{});          // (MMA, MMA_M, MMA_N)
@@ -542,14 +543,19 @@ __forceinline__ __device__ void copy_MN(
         if (Is_even_MN || get<0>(identity_MN(0, m, 0)) < max_M) {
             #pragma unroll
             for (int n = 0; n < size<2>(S); ++n) {
-                if (Is_even_MN || get<1>(identity_MN(0, m, n)) < max_N) {
+                if (Is_even_MN || predicate_N(n)) {
                     if constexpr (Bool_to_Element) {
                         #pragma unroll
                         for (int i = 0; i < size<0>(S); ++i) {
                             D(i, m, n) = static_cast<bool>(S(i, m, n)) ? To_type(1) : To_type(0);
                         }   
                     } else {
-                        cute::copy(tiled_copy, S(_, m, n), D(_, m, n));
+                        // Using vectorized load will cause out-of-bounds access when !Is_even_MN && !predicate_N(n)
+                        // cute::copy(tiled_copy, S(_, m, n), D(_, m, n));
+                        #pragma unroll
+                        for (int i = 0; i < size<0>(S); ++i) {
+                            D(i, m, n) = S(i, m, n);
+                        }
                     }
                 } else if (Clear_OOB_MN) {
                     cute::clear(D(_, m, n));

--- a/csrc/flash_dmattn/src/utils.h
+++ b/csrc/flash_dmattn/src/utils.h
@@ -335,6 +335,25 @@ __forceinline__ __device__ void sparse_gemm_rs(
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+
+template <typename Tensor, typename ThrCopy>
+__forceinline__ __device__ void mask_or_reduce(
+    Tensor &tSsMask,
+    bool &active,
+    ThrCopy smem_thr_copy_Mask
+) {
+    Tensor tSsMask_copy_view = smem_thr_copy_Mask.retile_D(tSsMask);
+    bool active_local = false;
+    #pragma unroll
+    for (int i = 0; i < size(tSsMask_copy_view); ++i) {
+        active_local |= tSsMask_copy_view(i);
+    }
+    active = __syncthreads_or(active_local);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
 // Convert acc_layout from (MMA=4, MMA_M, MMA_N) to (nrow=(2, MMA_M), ncol=(2, MMA_N))
 template<typename Layout>
 __forceinline__ __device__ auto convert_layout_acc_rowcol(Layout acc_layout) {


### PR DESCRIPTION
## Summary

#161 #169

- Replace vectorized/cp.async loads of mask/bias with scalar (per-element) loads to:
  - Prevent materialization of expanded mask/bias tensors (preserve views, reduce memory).
  - Robustly handle irregular sequence lengths (non-128-aligned K), eliminating OOB and misaligned-address errors.

## Root Cause
- Vectorized/cp.async loads assumed 16B-aligned row strides. With unpadded `seqlen_k = 4095`, bias rows became misaligned (e.g., 8190B stride for fp16), causing CUDA misaligned address errors.
- Padding mask/bias to 128 aligned K avoided the fault but forced materialization, defeating memory savings from `expand` views.

## Changes
- Introduced column predicates (`predicate_N`) and updated copy helper:
  - `utils.h`: `copy_MN` supports per-column predicate and row-limit, with scalar elementwise copy. When `Bool_to_Element=true`, converts bool mask to numeric element.
- Applied predicate-based scalar loads:
  - `flash_fwd_kernel.h`: Use `copy_MN` to load mask/bias with per-N predicates in masking steps; use even fast-path in non-masking loop.
  - `flash_bwd_kernel.h`: Symmetric updates for dS/mask/bias loads and dbias writes with `Clear_OOB_MN=false`.
- Python interface unchanged semantically; mask/bias no longer need K-dimension padding, preserving `expand` views.

## Reproduction
Before fix:
1. Env: PyTorch 2.8.0a0+nv, CUDA, RTX 4090.
2. Run `benchmarks/forward_equivalence.py` with:
   - batch=1, heads=2, kv_heads=1, seqlen_q=4095, seqlen_k=4095, head_dim=128, is_causal=True.
3. Error: `RuntimeError: CUDA error: misaligned address` during forward.

After fix:
- Same config passes; no CUDA errors.
- Accuracy vs Python prototype ≥ threshold (≥95%).

## Tests
- Forward/backward equivalence: standard suites across:
  - irregular K (4095), regular K (4096/4096, 8192/8192), causal/non-causal.
- Performance sanity: minor overhead isolated to tail blocks; end-to-end impact negligible in typical shapes.

## Compatibility
- No API changes.
- Behavior identical for regular shapes.
- Memory usage reduced when using `expand` views for mask/bias (no materialization).

## Checklist
- [x] Linked issue provided (internal)
- [x] Adds or updates tests (equivalence for irregular K; OOB regression)
- [x] Updates docs/changelog as needed
- [x] No correctness regressions
- [x] Perf impact acceptable (tail-only, negligible E2E)