### PR TITLE
Remove CUDA architecture '120' for compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
         # Without this we get import error (undefined symbol: _ZN3c105ErrorC2ENS_14SourceLocationESs)
         # when building without C++11 ABI and using it on nvcr images.
         cxx11_abi: ["FALSE", "TRUE"]
-        arch: ["80", "90", "100", "120"]
+        arch: ["80", "90", "100"]
         include:
             - torch-version: "2.9.0.dev20250904"
               cuda-version: "13.0"

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ SKIP_CUDA_BUILD = should_skip_cuda_build()
 
 @functools.lru_cache(maxsize=None)
 def cuda_archs():
-    return os.getenv("FLASH_DMATTN_CUDA_ARCHS", "80;90;100;120").split(";")
+    return os.getenv("FLASH_DMATTN_CUDA_ARCHS", "80;90;100").split(";")
 
 
 def detect_preferred_sm_arch() -> Optional[str]:


### PR DESCRIPTION
Eliminate CUDA architecture '120' from the build configuration to enhance compatibility. Adjustments made to the environment variable for CUDA architectures accordingly.