### PR TITLE
Enhance decoding functions with FP8 and quantization support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Flash-Sparse-Attention is a high-performance trainable sparse attention library built on Triton (and optionally CUTLASS/CUTE). It provides dense, sparse (softmax-thresholded), and gated attention kernels with forward, backward, and decode (KV-cache) paths. Requires NVIDIA GPU with compute capability >= 8.0.
+
+## Commands
+
+### Install
+```bash
+pip install -e ".[dev]"          # editable install with test deps
+pip install -e ".[dev,cute]"     # also install CUTE/CUTLASS deps
+```
+
+### Tests
+Tests require CUDA. Run from the repo root:
+```bash
+python -m pytest tests                              # all tests
+python -m pytest tests/test_dense_base_forward.py    # single file
+python -m pytest tests/test_dense_base_forward.py -s -q  # with stdout, quiet
+python -m pytest tests/test_dense_base_forward.py::test_dense_base_forward_correctness  # single test
+```
+Tests import `test_utils` from the `tests/` directory (not a package — pytest adds it to sys.path). No conftest.py exists.
+
+### Lint & Format
+```bash
+make style                # ruff check --fix + ruff format (whole codebase)
+make fixup                # same but only on files changed vs main
+make quality              # lint + format check + tests (CI gate)
+```
+
+### Benchmarks
+```bash
+python tests/benchmark_forward.py
+python tests/benchmark_backward.py
+python tests/benchmark_decode.py
+```
+
+## Architecture
+
+### Kernel Organization (`flash_sparse_attn/ops/triton/`)
+
+Three kernel families, each with three operation files:
+- `flash_dense_{fwd,bwd,dec}.py` — standard dense attention
+- `flash_sparse_{fwd,bwd,dec}.py` — sparse attention (softmax threshold)
+- `flash_gated_{fwd,bwd,dec}.py` — gated attention (alpha/delta gate inputs)
+
+Each `_dec.py` file contains multiple kernel variants:
+- SM80 kernel (Ampere+, standard path)
+- SM90 kernel (Hopper, FP8 support via `torch.float8_e5m2`)
+- Split-KV kernels for long-sequence decode
+- Both base (padded batch) and varlen (variable-length via `cu_seqlens`) dispatch functions
+
+Shared utilities: `block_info.py`, `cache_utils.py`, `assert_inputs.py`, `activations.py`, `flash_fwd_combine.py`, `flash_dec_combine.py`, `utils.py`.
+
+### Interface Layer (`flash_sparse_attn/ops/triton/interface.py`)
+
+Single file exposing 12 public functions (the full public API):
+- `flash_{dense,sparse,gated}_attn_func` — training forward+backward (autograd Functions)
+- `flash_{dense,sparse,gated}_attn_with_kvcache_func` — decode with KV cache
+- `flash_{dense,sparse,gated}_attn_varlen_func` — varlen training
+- `flash_{dense,sparse,gated}_attn_varlen_with_kvcache_func` — varlen decode
+
+All 12 are re-exported from `flash_sparse_attn/__init__.py`.
+
+### Tensor Layouts
+
+- Training kernels: `(batch, seqlen, num_heads, head_dim)` — "bshd"
+- Decode kernels: query is `(batch, num_heads, head_dim)` (seqlen_q=1 squeezed), KV is `(batch, seqlen_k, num_kv_heads, head_dim)`
+- SDPA-style benchmarks use `(batch, num_heads, seqlen, head_dim)` — "bhsd"
+
+### CUTE Backend (`flash_sparse_attn/ops/cute/`)
+
+Alternative CUTLASS-based implementation (requires `[cute]` extras). Separate interface at `ops/cute/interface.py`. Not part of the main Triton kernel path.
+
+### Test Structure (`tests/`)
+
+Test files follow the pattern `test_{dense,sparse,gated}_{base,varlen}_{forward,backward,decode}.py`. All heavy lifting is in `tests/test_utils.py` which provides:
+- `run_forward_base_case`, `run_backward_base_case`, `run_decode_case` (and varlen variants)
+- Reference implementations using PyTorch SDPA
+- `BenchmarkConfig` / `BenchmarkResult` dataclasses
+- FP8 quantization helper `_quantize_per_tensor_fp8`
+
+### FP8 Support
+
+FP8 decode is available on SM90+ (Hopper). Detection: `torch.float8_e5m2` dtype triggers SM90 kernel dispatch. Scales (`query_scale`, `key_scale`, `value_scale`) are passed through the interface functions. Output is always `bfloat16` when input is FP8.

--- a/flash_sparse_attn/ops/triton/assert_inputs.py
+++ b/flash_sparse_attn/ops/triton/assert_inputs.py
@@ -186,6 +186,9 @@ def assert_dec_inputs(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
+    query_scale: Optional[torch.Tensor] = None,
+    key_scale: Optional[torch.Tensor] = None,
+    value_scale: Optional[torch.Tensor] = None,
     alpha: Optional[torch.Tensor] = None,
     delta: Optional[torch.Tensor] = None,
     cu_seqlens_k: Optional[torch.Tensor] = None,
@@ -202,6 +205,9 @@ def assert_dec_inputs(
     :param query: Query tensor
     :param key: Key tensor
     :param value: Value tensor
+    :param query_scale: Optional query scale tensor for quantized inputs
+    :param key_scale: Optional key scale tensor for quantized inputs
+    :param value_scale: Optional value scale tensor for quantized inputs
     :param alpha: Alpha tensor for gated attention
     :param delta: Delta tensor for gated attention
     :param cu_seqlens_k: Cumulative sequence lengths for keys
@@ -221,6 +227,24 @@ def assert_dec_inputs(
         assert query.dtype in [torch.float16, torch.bfloat16, torch.float8_e5m2], (
             "Input dtype must be float16, bfloat16, or float8_e5m2"
         )
+        if query.dtype == torch.float8_e5m2:
+            assert (
+                query_scale is not None
+                and key_scale is not None
+                and value_scale is not None
+            ), "Scale tensors must be provided for float8 inputs"
+            assert query_scale.dtype in [
+                torch.float32,
+                torch.float16,
+                torch.bfloat16,
+                torch.float8_e8m0fnu,
+            ], "Scale tensors must be float32, float16, bfloat16, or float8_e8m0fnu"
+            assert query_scale.dtype == key_scale.dtype == value_scale.dtype, (
+                "All scale tensors must have the same dtype"
+            )
+            assert (
+                query_scale.device == key_scale.device == value_scale.device == device
+            ), "All scale tensors must be on the same device as query/key/value"
     else:
         assert query.dtype in [torch.float16, torch.bfloat16], (
             "Input dtype must be float16 or bfloat16"
@@ -250,28 +274,3 @@ def assert_dec_inputs(
     if seqused_k is not None:
         assert device == seqused_k.device, "All inputs must be on the same device"
         assert seqused_k.dtype == torch.int32, "seqused_k must be int32"
-
-
-def assert_dec_outputs(
-    out: Optional[torch.Tensor],
-    lse: Optional[torch.Tensor],
-    dtype: torch.dtype,
-    device: torch.device,
-):
-    """
-    Assert the validity of optional output tensors for the decode kernel.
-
-    :param out: Optional output tensor
-    :param lse: Optional logsumexp tensor
-    :param dtype: Expected output tensor dtype
-    :param device: Expected output tensor device
-
-    :raises AssertionError: If any of the assertions fail
-    """
-    if out is not None:
-        assert out.dtype == dtype, "out must have the same dtype as query"
-        assert out.device == device, "out must be on the same device as query"
-
-    if lse is not None:
-        assert lse.dtype == torch.float32, "lse must have dtype torch.float32"
-        assert lse.device == device, "lse must be on the same device as query"

--- a/flash_sparse_attn/ops/triton/assert_inputs.py
+++ b/flash_sparse_attn/ops/triton/assert_inputs.py
@@ -265,9 +265,17 @@ def assert_dec_inputs(
         assert device == alpha.device == delta.device, (
             "All inputs must be on the same device"
         )
-        assert alpha.dtype == delta.dtype == query.dtype, (
-            "Alpha and Delta tensors must have the same dtype as query/key/value"
-        )
+        if query.dtype != torch.float8_e5m2:
+            assert alpha.dtype == delta.dtype == query.dtype, (
+                "Alpha and Delta tensors must have the same dtype as query/key/value"
+            )
+        else:
+            assert alpha.dtype in [torch.float16, torch.bfloat16], (
+                "Alpha tensor must be float16 or bfloat16 for FP8 inputs"
+            )
+            assert alpha.dtype == delta.dtype, (
+                "Alpha and Delta tensors must have the same dtype"
+            )
     if cu_seqlens_k is not None:
         assert device == cu_seqlens_k.device, "All inputs must be on the same device"
         assert cu_seqlens_k.dtype == torch.int32, "cu_seqlens_k must be int32"

--- a/flash_sparse_attn/ops/triton/flash_dense_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_dec.py
@@ -467,11 +467,404 @@ def _dec_dense_base_kernel(
 _dec_dense_base_kernel = cache_utils.wrap_kernel(_dec_dense_base_kernel)
 
 
+# TODO: TMA, WGMMA, Pipelines, Async
+@triton.jit
+def _dec_dense_sm90_kernel(
+    Q,
+    K,
+    V,
+    Out,
+    Lse,
+    query_scale,
+    key_scale,
+    value_scale,
+    softmax_scale_log2,
+    stride_qb,
+    stride_qh,
+    stride_qm,
+    stride_kb,
+    stride_kh,
+    stride_kn,
+    stride_vb,
+    stride_vh,
+    stride_vn,
+    stride_ob,
+    stride_oh,
+    stride_om,
+    stride_os,
+    stride_lb,
+    stride_lh,
+    stride_lm,
+    stride_ls,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    seqused_q,
+    seqused_k,
+    num_splits,
+    seqlen_q,
+    seqlen_k,
+    head_dim,
+    QHEADS_PER_KVHEAD_PACKGQA: tl.constexpr,
+    TILE_M: tl.constexpr,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+    IS_LOCAL: tl.constexpr,
+    WINDOW_SIZE_LEFT: tl.constexpr,
+    WINDOW_SIZE_RIGHT: tl.constexpr,
+    HAS_CU_SEQLENS_Q: tl.constexpr,
+    HAS_CU_SEQLENS_K: tl.constexpr,
+    HAS_SEQUSED_Q: tl.constexpr,
+    HAS_SEQUSED_K: tl.constexpr,
+):
+    head_idx = tl.program_id(0)
+    batch_split_idx = tl.program_id(1)
+    batch_idx = batch_split_idx // num_splits
+    split_idx = batch_split_idx - batch_idx * num_splits
+    head_kv_idx = head_idx
+
+    # Get seqlen info for this batch
+    (
+        offset_q,
+        offset_k,
+        padded_offset_q,
+        padded_offset_k,
+        actual_seqlen_q,
+        actual_seqlen_k,
+    ) = seqlen_info.get_seqlen_info_qk(
+        batch_idx=batch_idx,
+        seqlen_q_static=seqlen_q,
+        seqlen_k_static=seqlen_k,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        seqused_q=seqused_q,
+        seqused_k=seqused_k,
+        TILE_M=TILE_M,
+        TILE_N=TILE_N,
+        HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
+        HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
+        HAS_SEQUSED_Q=HAS_SEQUSED_Q,
+        HAS_SEQUSED_K=HAS_SEQUSED_K,
+    )
+
+    # Initialize base pointers
+    q_base = seqlen_info.offset_batch_Q(
+        Q + head_idx * QHEADS_PER_KVHEAD_PACKGQA * stride_qh,
+        batch_idx,
+        offset_q,
+        padded_offset_q,
+        stride_qb,
+        stride_qm,
+        HAS_CU_SEQLENS_Q,
+        USE_PADDED=False,
+    )
+    k_base = seqlen_info.offset_batch_K(
+        K + head_kv_idx * stride_kh,
+        batch_idx,
+        offset_k,
+        padded_offset_k,
+        stride_kb,
+        stride_kn,
+        HAS_CU_SEQLENS_K,
+        USE_PADDED=False,
+    )
+    v_base = seqlen_info.offset_batch_K(
+        V + head_kv_idx * stride_vh,
+        batch_idx,
+        offset_k,
+        padded_offset_k,
+        stride_vb,
+        stride_vn,
+        HAS_CU_SEQLENS_K,
+        USE_PADDED=False,
+    )
+    out_base = seqlen_info.offset_batch_Q(
+        Out + head_idx * QHEADS_PER_KVHEAD_PACKGQA * stride_oh,
+        batch_idx,
+        offset_q,
+        padded_offset_q,
+        stride_ob,
+        stride_om,
+        HAS_CU_SEQLENS_Q,
+        USE_PADDED=False,
+    )
+    lse_base = seqlen_info.offset_batch_Q(
+        Lse + head_idx * QHEADS_PER_KVHEAD_PACKGQA * stride_lh,
+        batch_idx,
+        offset_q,
+        padded_offset_q,
+        stride_lb,
+        stride_lm,
+        HAS_CU_SEQLENS_Q,
+        USE_PADDED=False,
+    )
+
+    # For split KV, offset output and LSE base pointers by split_idx
+    out_base += split_idx * stride_os
+    lse_base += split_idx * stride_ls
+
+    # Compute n_block range for this m_block
+    n_block_min, n_block_max = block_info.get_n_block_min_max(
+        seqlen_q=actual_seqlen_q,
+        seqlen_k=actual_seqlen_k,
+        m_block=0,
+        split_idx=split_idx,
+        num_splits=num_splits,
+        TILE_N=TILE_N,
+        TILE_M=TILE_M,
+        IS_CAUSAL=False,
+        IS_LOCAL=IS_LOCAL,
+        IS_SPLIT_KV=True,
+        WINDOW_SIZE_LEFT=WINDOW_SIZE_LEFT,
+        WINDOW_SIZE_RIGHT=WINDOW_SIZE_RIGHT,
+        QHEAD_PER_KVHEAD_PACKGQA=QHEADS_PER_KVHEAD_PACKGQA,
+    )
+    n_block_min_no_mask = block_info.get_n_block_min_before_local_mask(
+        seqlen_q=actual_seqlen_q,
+        seqlen_k=actual_seqlen_k,
+        m_block=0,
+        n_block_min=n_block_min,
+        TILE_N=TILE_N,
+        TILE_M=TILE_M,
+        IS_LOCAL=IS_LOCAL,
+        WINDOW_SIZE_LEFT=WINDOW_SIZE_LEFT,
+        QHEAD_PER_KVHEAD_PACKGQA=QHEADS_PER_KVHEAD_PACKGQA,
+    )
+
+    # Clamp to split's range so the no-mask loop stays within bounds
+    n_block_min_no_mask = tl.maximum(n_block_min_no_mask, n_block_min)
+
+    # Create pointers
+    lse_ptrs = tl.make_block_ptr(
+        base=lse_base,
+        shape=(actual_seqlen_q,),
+        strides=(stride_lh,),
+        offsets=(0,),
+        block_shape=(TILE_M,),
+        order=(0,),
+    )
+    out_ptrs = tl.make_block_ptr(
+        base=out_base,
+        shape=(actual_seqlen_q, head_dim),
+        strides=(stride_oh, 1),
+        offsets=(0, 0),
+        block_shape=(TILE_M, TILE_K),
+        order=(1, 0),
+    )
+
+    # Early exit if no n_blocks to process
+    if n_block_min >= n_block_max:
+        # Write LSE as -inf for proper handling
+        lse_tile = tl.full((TILE_M,), float("-inf"), dtype=tl.float32)
+        tl.store(lse_ptrs, lse_tile, boundary_check=(0,), cache_modifier=".wb")
+
+        # Write output as zero for proper handling
+        o_tile = tl.zeros((TILE_M, TILE_K), dtype=Out.dtype.element_ty)
+        tl.store(out_ptrs, o_tile, boundary_check=(0, 1), cache_modifier=".wb")
+        return
+
+    q_ptrs = tl.make_block_ptr(
+        base=q_base,
+        shape=(actual_seqlen_q, head_dim),
+        strides=(stride_qh, 1),
+        offsets=(0, 0),
+        block_shape=(TILE_M, TILE_K),
+        order=(1, 0),
+    )
+    k_ptrs = tl.make_block_ptr(
+        base=k_base,
+        shape=(head_dim, actual_seqlen_k),
+        strides=(1, stride_kn),
+        offsets=(0, (n_block_max - 1) * TILE_N),
+        block_shape=(TILE_K, TILE_N),
+        order=(0, 1),
+    )
+    v_ptrs = tl.make_block_ptr(
+        base=v_base,
+        shape=(actual_seqlen_k, head_dim),
+        strides=(stride_vn, 1),
+        offsets=((n_block_max - 1) * TILE_N, 0),
+        block_shape=(TILE_N, TILE_K),
+        order=(1, 0),
+    )
+
+    # Load query scale
+    q_scale = tl.load(query_scale)
+
+    # Load key scale
+    k_scale = tl.load(key_scale)
+
+    # Update softmax scale
+    softmax_scale_log2 = softmax_scale_log2 * q_scale * k_scale
+
+    # Load value scale
+    v_scale = tl.load(value_scale)
+
+    # Update final scale
+    final_scale = v_scale
+
+    # Load query tile
+    q_tile = tl.load(q_ptrs, boundary_check=(0, 1), cache_modifier=".ca")
+
+    # Initialize accumulators
+    row_max = tl.full((TILE_M,), float("-inf"), dtype=tl.float32)
+    row_sum = tl.zeros((TILE_M,), dtype=tl.float32)
+    acc_o = tl.zeros((TILE_M, TILE_K), dtype=tl.float32)
+
+    # Load key tile
+    k_tile = tl.load(k_ptrs, boundary_check=(0, 1), cache_modifier=".cg")
+
+    # Process n_blocks with masking
+    # First iteration with seqlen masking
+    n_block = n_block_max - 1
+    k_tile, k_ptrs, v_ptrs, acc_o, row_max, row_sum = _dec_inner_dense_base_kernel(
+        q_tile=q_tile,
+        k_tile=k_tile,
+        k_ptrs=k_ptrs,
+        v_ptrs=v_ptrs,
+        acc_o=acc_o,
+        row_max=row_max,
+        row_sum=row_sum,
+        softmax_scale_log2=softmax_scale_log2,
+        m_block=0,
+        n_block=n_block,
+        n_block_min=n_block_min,
+        actual_seqlen_q=actual_seqlen_q,
+        actual_seqlen_k=actual_seqlen_k,
+        TILE_M=TILE_M,
+        TILE_N=TILE_N,
+        WINDOW_SIZE_LEFT=WINDOW_SIZE_LEFT,
+        WINDOW_SIZE_RIGHT=WINDOW_SIZE_RIGHT,
+        QHEADS_PER_KVHEAD_PACKGQA=QHEADS_PER_KVHEAD_PACKGQA,
+        IS_MASK=True,
+        MASK_LOCAL=False,
+        CHECK_INF=True,
+    )
+
+    n_block_max_no_mask = n_block_max - 1
+    n_block_min_no_mask = tl.minimum(n_block_min_no_mask, n_block_max_no_mask)
+
+    # Process n_blocks without masking
+    if n_block_max_no_mask > n_block_min_no_mask:
+        k_ptrs = tl.make_block_ptr(
+            base=k_base,
+            shape=(head_dim, actual_seqlen_k),
+            strides=(1, stride_kn),
+            offsets=(0, (n_block_max_no_mask - 1) * TILE_N),
+            block_shape=(TILE_K, TILE_N),
+            order=(0, 1),
+        )
+        v_ptrs = tl.make_block_ptr(
+            base=v_base,
+            shape=(actual_seqlen_k, head_dim),
+            strides=(stride_vn, 1),
+            offsets=((n_block_max_no_mask - 1) * TILE_N, 0),
+            block_shape=(TILE_N, TILE_K),
+            order=(1, 0),
+        )
+        k_tile = tl.load(k_ptrs, boundary_check=(0, 1), cache_modifier=".cg")
+        for n_block in tl.range(n_block_max_no_mask - 1, n_block_min_no_mask - 1, -1):
+            k_tile, k_ptrs, v_ptrs, acc_o, row_max, row_sum = (
+                _dec_inner_dense_base_kernel(
+                    q_tile=q_tile,
+                    k_tile=k_tile,
+                    k_ptrs=k_ptrs,
+                    v_ptrs=v_ptrs,
+                    acc_o=acc_o,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    softmax_scale_log2=softmax_scale_log2,
+                    m_block=0,
+                    n_block=n_block,
+                    n_block_min=n_block_min_no_mask,
+                    actual_seqlen_q=actual_seqlen_q,
+                    actual_seqlen_k=actual_seqlen_k,
+                    TILE_M=TILE_M,
+                    TILE_N=TILE_N,
+                    WINDOW_SIZE_LEFT=WINDOW_SIZE_LEFT,
+                    WINDOW_SIZE_RIGHT=WINDOW_SIZE_RIGHT,
+                    QHEADS_PER_KVHEAD_PACKGQA=QHEADS_PER_KVHEAD_PACKGQA,
+                    IS_MASK=False,
+                    MASK_LOCAL=False,
+                    CHECK_INF=False,
+                )
+            )
+
+    # Process n_blocks with masking
+    if IS_LOCAL and n_block_min_no_mask > n_block_min:
+        k_ptrs = tl.make_block_ptr(
+            base=k_base,
+            shape=(head_dim, actual_seqlen_k),
+            strides=(1, stride_kn),
+            offsets=(0, (n_block_min_no_mask - 1) * TILE_N),
+            block_shape=(TILE_K, TILE_N),
+            order=(0, 1),
+        )
+        v_ptrs = tl.make_block_ptr(
+            base=v_base,
+            shape=(actual_seqlen_k, head_dim),
+            strides=(stride_vn, 1),
+            offsets=((n_block_min_no_mask - 1) * TILE_N, 0),
+            block_shape=(TILE_N, TILE_K),
+            order=(1, 0),
+        )
+        k_tile = tl.load(k_ptrs, boundary_check=(0, 1), cache_modifier=".cg")
+        for n_block in tl.range(n_block_min_no_mask - 1, n_block_min - 1, -1):
+            k_tile, k_ptrs, v_ptrs, acc_o, row_max, row_sum = (
+                _dec_inner_dense_base_kernel(
+                    q_tile=q_tile,
+                    k_tile=k_tile,
+                    k_ptrs=k_ptrs,
+                    v_ptrs=v_ptrs,
+                    acc_o=acc_o,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    softmax_scale_log2=softmax_scale_log2,
+                    m_block=0,
+                    n_block=n_block,
+                    n_block_min=n_block_min,
+                    actual_seqlen_q=actual_seqlen_q,
+                    actual_seqlen_k=actual_seqlen_k,
+                    TILE_M=TILE_M,
+                    TILE_N=TILE_N,
+                    WINDOW_SIZE_LEFT=WINDOW_SIZE_LEFT,
+                    WINDOW_SIZE_RIGHT=WINDOW_SIZE_RIGHT,
+                    QHEADS_PER_KVHEAD_PACKGQA=QHEADS_PER_KVHEAD_PACKGQA,
+                    IS_MASK=True,
+                    MASK_LOCAL=True,
+                    CHECK_INF=True,
+                )
+            )
+
+    # Finalize softmax
+    row_scale, lse_tile = activations.finalize(
+        row_max=row_max,
+        row_sum=row_sum,
+        scale_log2=softmax_scale_log2,
+        final_scale=final_scale,
+        IS_LOG2=True,
+    )
+
+    # Store LSE
+    tl.store(lse_ptrs, lse_tile, boundary_check=(0,), cache_modifier=".wb")
+
+    # Final rescale
+    acc_o = activations.rescale_o(acc_o, row_scale, LAZY_RESCALE=False)
+
+    # Store output
+    tl.store(out_ptrs, acc_o, boundary_check=(0, 1), cache_modifier=".wb")
+
+
+_dec_dense_sm90_kernel = cache_utils.wrap_kernel(_dec_dense_sm90_kernel)
+
+
 def _flash_dense_attn_base_decode(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
     softmax_scale: float = None,
+    query_scale: Optional[torch.Tensor] = None,
+    key_scale: Optional[torch.Tensor] = None,
+    value_scale: Optional[torch.Tensor] = None,
     window_size: Tuple[int, int] = (None, None),
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
@@ -483,6 +876,7 @@ def _flash_dense_attn_base_decode(
     _, seqlen_k, num_heads_kv, _ = key.shape
     window_size_left, window_size_right = window_size
     is_local = window_size_left is not None or window_size_right is not None
+    is_quantized = query.dtype == torch.float8_e5m2
     softmax_scale = softmax_scale or 1.0 / (head_dim**0.5)
     softmax_scale_log2 = softmax_scale * math.log2(math.e)
     qheads_per_kvhead = num_heads_q // num_heads_kv
@@ -491,6 +885,9 @@ def _flash_dense_attn_base_decode(
         query,
         key,
         value,
+        query_scale=query_scale,
+        key_scale=key_scale,
+        value_scale=value_scale,
         cu_seqlens_k=None,
         seqused_k=None,
         num_heads_q=num_heads_q,
@@ -498,12 +895,6 @@ def _flash_dense_attn_base_decode(
         head_dim=head_dim,
         device=device,
         arch=arch,
-    )
-    assert_inputs.assert_dec_outputs(
-        out=out,
-        lse=lse,
-        dtype=query.dtype,
-        device=device,
     )
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
@@ -525,7 +916,12 @@ def _flash_dense_attn_base_decode(
         TILE_N=TILE_N,
     )
 
-    out = out if out is not None else torch.empty_like(query)
+    out_dtype = torch.bfloat16 if is_quantized else query.dtype
+    out = (
+        out
+        if out is not None
+        else torch.empty(query.shape, dtype=out_dtype, device=device)
+    )
     lse = (
         lse
         if lse is not None
@@ -549,53 +945,105 @@ def _flash_dense_attn_base_decode(
         num_splits=num_splits,
     )
 
-    _dec_dense_base_kernel[grid](
-        query,
-        key,
-        value,
-        out_partial,
-        lse_partial,
-        softmax_scale_log2,
-        query.stride(0),
-        query.stride(-2),
-        1,
-        key.stride(0),
-        key.stride(-2),
-        key.stride(-3),
-        value.stride(0),
-        value.stride(-2),
-        value.stride(-3),
-        out_partial.stride(1),
-        out_partial.stride(-2),
-        1,
-        out_partial.stride(0),
-        lse_partial.stride(1),
-        lse_partial.stride(-1),
-        1,
-        lse_partial.stride(0),
-        None,
-        None,
-        None,
-        None,
-        num_splits,
-        seqlen_q=qheads_per_kvhead,
-        seqlen_k=seqlen_k,
-        head_dim=head_dim,
-        QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
-        TILE_M=TILE_M,
-        TILE_N=TILE_N,
-        TILE_K=TILE_K,
-        IS_LOCAL=is_local,
-        WINDOW_SIZE_LEFT=window_size_left,
-        WINDOW_SIZE_RIGHT=window_size_right,
-        HAS_CU_SEQLENS_Q=False,
-        HAS_CU_SEQLENS_K=False,
-        HAS_SEQUSED_Q=False,
-        HAS_SEQUSED_K=False,
-        num_warps=num_warps,
-        num_stages=num_stages,
-        num_ctas=num_ctas,
-    )
+    if not is_quantized:
+        _dec_dense_base_kernel[grid](
+            query,
+            key,
+            value,
+            out_partial,
+            lse_partial,
+            softmax_scale_log2,
+            query.stride(0),
+            query.stride(-2),
+            1,
+            key.stride(0),
+            key.stride(-2),
+            key.stride(-3),
+            value.stride(0),
+            value.stride(-2),
+            value.stride(-3),
+            out_partial.stride(1),
+            out_partial.stride(-2),
+            1,
+            out_partial.stride(0),
+            lse_partial.stride(1),
+            lse_partial.stride(-1),
+            1,
+            lse_partial.stride(0),
+            None,
+            None,
+            None,
+            None,
+            num_splits,
+            seqlen_q=qheads_per_kvhead,
+            seqlen_k=seqlen_k,
+            head_dim=head_dim,
+            QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            TILE_K=TILE_K,
+            IS_LOCAL=is_local,
+            WINDOW_SIZE_LEFT=window_size_left,
+            WINDOW_SIZE_RIGHT=window_size_right,
+            HAS_CU_SEQLENS_Q=False,
+            HAS_CU_SEQLENS_K=False,
+            HAS_SEQUSED_Q=False,
+            HAS_SEQUSED_K=False,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            num_ctas=num_ctas,
+        )
+    else:
+        _dec_dense_sm90_kernel[grid](
+            query,
+            key,
+            value,
+            out_partial,
+            lse_partial,
+            query_scale,
+            key_scale,
+            value_scale,
+            softmax_scale_log2,
+            query.stride(0),
+            query.stride(-2),
+            1,
+            key.stride(0),
+            key.stride(-2),
+            key.stride(-3),
+            value.stride(0),
+            value.stride(-2),
+            value.stride(-3),
+            out_partial.stride(1),
+            out_partial.stride(-2),
+            1,
+            out_partial.stride(0),
+            lse_partial.stride(1),
+            lse_partial.stride(-1),
+            1,
+            lse_partial.stride(0),
+            None,
+            None,
+            None,
+            None,
+            num_splits,
+            seqlen_q=qheads_per_kvhead,
+            seqlen_k=seqlen_k,
+            head_dim=head_dim,
+            QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            TILE_K=TILE_K,
+            IS_LOCAL=is_local,
+            WINDOW_SIZE_LEFT=window_size_left,
+            WINDOW_SIZE_RIGHT=window_size_right,
+            HAS_CU_SEQLENS_Q=False,
+            HAS_CU_SEQLENS_K=False,
+            HAS_SEQUSED_Q=False,
+            HAS_SEQUSED_K=False,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            num_ctas=num_ctas,
+        )
 
     flash_dec_combine._flash_attn_dec_combine(
         out_partial,
@@ -614,6 +1062,9 @@ def _flash_dense_attn_varlen_base_decode(
     cu_seqlens_k: torch.Tensor,
     max_seqlen_k: int,
     softmax_scale: float = None,
+    query_scale: Optional[torch.Tensor] = None,
+    key_scale: Optional[torch.Tensor] = None,
+    value_scale: Optional[torch.Tensor] = None,
     window_size: Tuple[int, int] = (None, None),
     seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
@@ -627,6 +1078,7 @@ def _flash_dense_attn_varlen_base_decode(
     seqlen_k = max_seqlen_k
     window_size_left, window_size_right = window_size
     is_local = window_size_left is not None or window_size_right is not None
+    is_quantized = query.dtype == torch.float8_e5m2
     softmax_scale = softmax_scale or 1.0 / (head_dim**0.5)
     softmax_scale_log2 = softmax_scale * math.log2(math.e)
     qheads_per_kvhead = num_heads_q // num_heads_kv
@@ -635,6 +1087,9 @@ def _flash_dense_attn_varlen_base_decode(
         query,
         key,
         value,
+        query_scale=query_scale,
+        key_scale=key_scale,
+        value_scale=value_scale,
         cu_seqlens_k=cu_seqlens_k,
         seqused_k=seqused_k,
         num_heads_q=num_heads_q,
@@ -642,12 +1097,6 @@ def _flash_dense_attn_varlen_base_decode(
         head_dim=head_dim,
         device=device,
         arch=arch,
-    )
-    assert_inputs.assert_dec_outputs(
-        out=out,
-        lse=lse,
-        dtype=query.dtype,
-        device=device,
     )
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
@@ -669,7 +1118,12 @@ def _flash_dense_attn_varlen_base_decode(
         TILE_N=TILE_N,
     )
 
-    out = out if out is not None else torch.empty_like(query)
+    out_dtype = torch.bfloat16 if is_quantized else query.dtype
+    out = (
+        out
+        if out is not None
+        else torch.empty(query.shape, dtype=out_dtype, device=device)
+    )
     lse = (
         lse
         if lse is not None
@@ -697,53 +1151,105 @@ def _flash_dense_attn_varlen_base_decode(
         num_splits=num_splits,
     )
 
-    _dec_dense_base_kernel[grid](
-        query,
-        key,
-        value,
-        out_partial,
-        lse_partial,
-        softmax_scale_log2,
-        query.stride(0),
-        query.stride(-2),
-        1,
-        0,
-        key.stride(-2),
-        key.stride(0),
-        0,
-        value.stride(-2),
-        value.stride(0),
-        out_partial.stride(1),
-        out_partial.stride(-2),
-        1,
-        out_partial.stride(0),
-        lse_partial.stride(1),
-        lse_partial.stride(-1),
-        1,
-        lse_partial.stride(0),
-        None,
-        cu_seqlens_k,
-        None,
-        seqused_k,
-        num_splits,
-        seqlen_q=qheads_per_kvhead,
-        seqlen_k=seqlen_k,
-        head_dim=head_dim,
-        QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
-        TILE_M=TILE_M,
-        TILE_N=TILE_N,
-        TILE_K=TILE_K,
-        IS_LOCAL=is_local,
-        WINDOW_SIZE_LEFT=window_size_left,
-        WINDOW_SIZE_RIGHT=window_size_right,
-        HAS_CU_SEQLENS_Q=False,
-        HAS_CU_SEQLENS_K=True,
-        HAS_SEQUSED_Q=False,
-        HAS_SEQUSED_K=seqused_k is not None,
-        num_warps=num_warps,
-        num_stages=num_stages,
-        num_ctas=num_ctas,
-    )
+    if not is_quantized:
+        _dec_dense_base_kernel[grid](
+            query,
+            key,
+            value,
+            out_partial,
+            lse_partial,
+            softmax_scale_log2,
+            query.stride(0),
+            query.stride(-2),
+            1,
+            0,
+            key.stride(-2),
+            key.stride(0),
+            0,
+            value.stride(-2),
+            value.stride(0),
+            out_partial.stride(1),
+            out_partial.stride(-2),
+            1,
+            out_partial.stride(0),
+            lse_partial.stride(1),
+            lse_partial.stride(-1),
+            1,
+            lse_partial.stride(0),
+            None,
+            cu_seqlens_k,
+            None,
+            seqused_k,
+            num_splits,
+            seqlen_q=qheads_per_kvhead,
+            seqlen_k=seqlen_k,
+            head_dim=head_dim,
+            QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            TILE_K=TILE_K,
+            IS_LOCAL=is_local,
+            WINDOW_SIZE_LEFT=window_size_left,
+            WINDOW_SIZE_RIGHT=window_size_right,
+            HAS_CU_SEQLENS_Q=False,
+            HAS_CU_SEQLENS_K=True,
+            HAS_SEQUSED_Q=False,
+            HAS_SEQUSED_K=seqused_k is not None,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            num_ctas=num_ctas,
+        )
+    else:
+        _dec_dense_sm90_kernel[grid](
+            query,
+            key,
+            value,
+            out_partial,
+            lse_partial,
+            query_scale,
+            key_scale,
+            value_scale,
+            softmax_scale_log2,
+            query.stride(0),
+            query.stride(-2),
+            1,
+            0,
+            key.stride(-2),
+            key.stride(0),
+            0,
+            value.stride(-2),
+            value.stride(0),
+            out_partial.stride(1),
+            out_partial.stride(-2),
+            1,
+            out_partial.stride(0),
+            lse_partial.stride(1),
+            lse_partial.stride(-1),
+            1,
+            lse_partial.stride(0),
+            None,
+            cu_seqlens_k,
+            None,
+            seqused_k,
+            num_splits,
+            seqlen_q=qheads_per_kvhead,
+            seqlen_k=seqlen_k,
+            head_dim=head_dim,
+            QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            TILE_K=TILE_K,
+            IS_LOCAL=is_local,
+            WINDOW_SIZE_LEFT=window_size_left,
+            WINDOW_SIZE_RIGHT=window_size_right,
+            HAS_CU_SEQLENS_Q=False,
+            HAS_CU_SEQLENS_K=True,
+            HAS_SEQUSED_Q=False,
+            HAS_SEQUSED_K=seqused_k is not None,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            num_ctas=num_ctas,
+        )
 
     flash_dec_combine._flash_attn_dec_combine(
         out_partial,

--- a/flash_sparse_attn/ops/triton/flash_gated_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_dec.py
@@ -221,7 +221,6 @@ def _dec_gated_base_kernel(
     HAS_SEQUSED_Q: tl.constexpr,
     HAS_SEQUSED_K: tl.constexpr,
     IS_LOGSIGMOID_GATE: tl.constexpr,
-    IS_ADAPT_GATE: tl.constexpr,
 ):
     head_idx = tl.program_id(0)
     batch_split_idx = tl.program_id(1)
@@ -755,6 +754,602 @@ def _dec_gated_base_kernel(
 _dec_gated_base_kernel = cache_utils.wrap_kernel(_dec_gated_base_kernel)
 
 
+# TODO: TMA, WGMMA, Pipelines, Async
+@triton.jit
+def _dec_gated_sm90_kernel(
+    Q,
+    K,
+    V,
+    A,
+    D,
+    Out,
+    Lse,
+    query_scale,
+    key_scale,
+    value_scale,
+    softmax_scale_log2,
+    softmax_threshold_log2,
+    gate_threshold_log2,
+    stride_qb,
+    stride_qh,
+    stride_qm,
+    stride_kb,
+    stride_kh,
+    stride_kn,
+    stride_vb,
+    stride_vh,
+    stride_vn,
+    stride_ab,
+    stride_ah,
+    stride_am,
+    stride_db,
+    stride_dh,
+    stride_dn,
+    stride_ob,
+    stride_oh,
+    stride_om,
+    stride_os,
+    stride_lb,
+    stride_lh,
+    stride_lm,
+    stride_ls,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    seqused_q,
+    seqused_k,
+    num_splits,
+    seqlen_q,
+    seqlen_k,
+    head_dim,
+    QHEADS_PER_KVHEAD_PACKGQA: tl.constexpr,
+    TILE_M: tl.constexpr,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+    IS_LOCAL: tl.constexpr,
+    WINDOW_SIZE_LEFT: tl.constexpr,
+    WINDOW_SIZE_RIGHT: tl.constexpr,
+    HAS_CU_SEQLENS_Q: tl.constexpr,
+    HAS_CU_SEQLENS_K: tl.constexpr,
+    HAS_SEQUSED_Q: tl.constexpr,
+    HAS_SEQUSED_K: tl.constexpr,
+    IS_LOGSIGMOID_GATE: tl.constexpr,
+):
+    head_idx = tl.program_id(0)
+    batch_split_idx = tl.program_id(1)
+    batch_idx = batch_split_idx // num_splits
+    split_idx = batch_split_idx - batch_idx * num_splits
+    head_kv_idx = head_idx
+
+    # Get seqlen info for this batch
+    (
+        offset_q,
+        offset_k,
+        padded_offset_q,
+        padded_offset_k,
+        actual_seqlen_q,
+        actual_seqlen_k,
+    ) = seqlen_info.get_seqlen_info_qk(
+        batch_idx=batch_idx,
+        seqlen_q_static=seqlen_q,
+        seqlen_k_static=seqlen_k,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        seqused_q=seqused_q,
+        seqused_k=seqused_k,
+        TILE_M=TILE_M,
+        TILE_N=TILE_N,
+        HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
+        HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
+        HAS_SEQUSED_Q=HAS_SEQUSED_Q,
+        HAS_SEQUSED_K=HAS_SEQUSED_K,
+    )
+
+    # Initialize base pointers
+    q_base = seqlen_info.offset_batch_Q(
+        Q + head_idx * QHEADS_PER_KVHEAD_PACKGQA * stride_qh,
+        batch_idx,
+        offset_q,
+        padded_offset_q,
+        stride_qb,
+        stride_qm,
+        HAS_CU_SEQLENS_Q,
+        USE_PADDED=False,
+    )
+    k_base = seqlen_info.offset_batch_K(
+        K + head_kv_idx * stride_kh,
+        batch_idx,
+        offset_k,
+        padded_offset_k,
+        stride_kb,
+        stride_kn,
+        HAS_CU_SEQLENS_K,
+        USE_PADDED=False,
+    )
+    v_base = seqlen_info.offset_batch_K(
+        V + head_kv_idx * stride_vh,
+        batch_idx,
+        offset_k,
+        padded_offset_k,
+        stride_vb,
+        stride_vn,
+        HAS_CU_SEQLENS_K,
+        USE_PADDED=False,
+    )
+    a_base = seqlen_info.offset_batch_Q(
+        A + head_idx * QHEADS_PER_KVHEAD_PACKGQA * stride_ah,
+        batch_idx,
+        offset_q,
+        padded_offset_q,
+        stride_ab,
+        stride_am,
+        HAS_CU_SEQLENS_Q,
+        USE_PADDED=False,
+    )
+    d_base = seqlen_info.offset_batch_K(
+        D + head_kv_idx * stride_dh,
+        batch_idx,
+        offset_k,
+        padded_offset_k,
+        stride_db,
+        stride_dn,
+        HAS_CU_SEQLENS_K,
+        USE_PADDED=False,
+    )
+    out_base = seqlen_info.offset_batch_Q(
+        Out + head_idx * QHEADS_PER_KVHEAD_PACKGQA * stride_oh,
+        batch_idx,
+        offset_q,
+        padded_offset_q,
+        stride_ob,
+        stride_om,
+        HAS_CU_SEQLENS_Q,
+        USE_PADDED=False,
+    )
+    lse_base = seqlen_info.offset_batch_Q(
+        Lse + head_idx * QHEADS_PER_KVHEAD_PACKGQA * stride_lh,
+        batch_idx,
+        offset_q,
+        padded_offset_q,
+        stride_lb,
+        stride_lm,
+        HAS_CU_SEQLENS_Q,
+        USE_PADDED=False,
+    )
+
+    # For split KV, offset output and LSE base pointers by split_idx
+    out_base += split_idx * stride_os
+    lse_base += split_idx * stride_ls
+    # Compute n_block range for this m_block
+    n_block_min, n_block_max = block_info.get_n_block_min_max(
+        seqlen_q=actual_seqlen_q,
+        seqlen_k=actual_seqlen_k,
+        m_block=0,
+        split_idx=split_idx,
+        num_splits=num_splits,
+        TILE_N=TILE_N,
+        TILE_M=TILE_M,
+        IS_CAUSAL=False,
+        IS_LOCAL=IS_LOCAL,
+        IS_SPLIT_KV=True,
+        WINDOW_SIZE_LEFT=WINDOW_SIZE_LEFT,
+        WINDOW_SIZE_RIGHT=WINDOW_SIZE_RIGHT,
+        QHEAD_PER_KVHEAD_PACKGQA=QHEADS_PER_KVHEAD_PACKGQA,
+    )
+    n_block_min_no_mask = block_info.get_n_block_min_before_local_mask(
+        seqlen_q=actual_seqlen_q,
+        seqlen_k=actual_seqlen_k,
+        m_block=0,
+        n_block_min=n_block_min,
+        TILE_N=TILE_N,
+        TILE_M=TILE_M,
+        IS_LOCAL=IS_LOCAL,
+        WINDOW_SIZE_LEFT=WINDOW_SIZE_LEFT,
+        QHEAD_PER_KVHEAD_PACKGQA=QHEADS_PER_KVHEAD_PACKGQA,
+    )
+
+    # Clamp to split's range so the no-mask loop stays within bounds
+    n_block_min_no_mask = tl.maximum(n_block_min_no_mask, n_block_min)
+
+    # Create pointers
+    lse_ptrs = tl.make_block_ptr(
+        base=lse_base,
+        shape=(actual_seqlen_q,),
+        strides=(stride_lh,),
+        offsets=(0,),
+        block_shape=(TILE_M,),
+        order=(0,),
+    )
+    out_ptrs = tl.make_block_ptr(
+        base=out_base,
+        shape=(actual_seqlen_q, head_dim),
+        strides=(stride_oh, 1),
+        offsets=(0, 0),
+        block_shape=(TILE_M, TILE_K),
+        order=(1, 0),
+    )
+    # Early exit if no n_blocks to process
+    if n_block_min >= n_block_max:
+        # Write LSE as -inf for proper handling
+        lse_tile = tl.full((TILE_M,), float("-inf"), dtype=tl.float32)
+        tl.store(lse_ptrs, lse_tile, boundary_check=(0,), cache_modifier=".wb")
+
+        # Write output as zero for proper handling
+        o_tile = tl.zeros((TILE_M, TILE_K), dtype=Out.dtype.element_ty)
+        tl.store(out_ptrs, o_tile, boundary_check=(0, 1), cache_modifier=".wb")
+        return
+
+    q_ptrs = tl.make_block_ptr(
+        base=q_base,
+        shape=(actual_seqlen_q, head_dim),
+        strides=(stride_qh, 1),
+        offsets=(0, 0),
+        block_shape=(TILE_M, TILE_K),
+        order=(1, 0),
+    )
+    a_ptrs = tl.make_block_ptr(
+        base=a_base,
+        shape=(actual_seqlen_q,),
+        strides=(stride_ah,),
+        offsets=(0,),
+        block_shape=(TILE_M,),
+        order=(0,),
+    )
+    k_ptrs = tl.make_block_ptr(
+        base=k_base,
+        shape=(head_dim, actual_seqlen_k),
+        strides=(1, stride_kn),
+        offsets=(0, (n_block_max - 1) * TILE_N),
+        block_shape=(TILE_K, TILE_N),
+        order=(0, 1),
+    )
+    v_ptrs = tl.make_block_ptr(
+        base=v_base,
+        shape=(actual_seqlen_k, head_dim),
+        strides=(stride_vn, 1),
+        offsets=((n_block_max - 1) * TILE_N, 0),
+        block_shape=(TILE_N, TILE_K),
+        order=(1, 0),
+    )
+    d_ptrs = tl.make_block_ptr(
+        base=d_base,
+        shape=(actual_seqlen_k,),
+        strides=(stride_dn,),
+        offsets=((n_block_max - 1) * TILE_N,),
+        block_shape=(TILE_N,),
+        order=(0,),
+    )
+    # Load query scale
+    q_scale = tl.load(query_scale)
+
+    # Load key scale
+    k_scale = tl.load(key_scale)
+
+    # Update softmax scale
+    softmax_scale_log2 = softmax_scale_log2 * q_scale * k_scale
+
+    # Load value scale
+    v_scale = tl.load(value_scale)
+
+    # Update final scale
+    final_scale = v_scale
+
+    # Load query tile
+    q_tile = tl.load(q_ptrs, boundary_check=(0, 1), cache_modifier=".ca")
+
+    # Load key tile
+    k_tile = tl.load(k_ptrs, boundary_check=(0, 1), cache_modifier=".cg")
+
+    # Initialize accumulators
+    gate_max = tl.full((), float("-inf"), dtype=tl.float32)
+    block_max = tl.full((), float("-inf"), dtype=tl.float32)
+    row_max = tl.full((TILE_M,), float("-inf"), dtype=tl.float32)
+    row_sum = tl.zeros((TILE_M,), dtype=tl.float32)
+    acc_o = tl.zeros((TILE_M, TILE_K), dtype=tl.float32)
+
+    # Load alpha tile
+    a_tile = tl.load(a_ptrs, boundary_check=(0,), cache_modifier=".ca").to(tl.float32)
+    a_max = tl.max(a_tile)
+    a_min = tl.min(a_tile)
+
+    # Load delta tile
+    d_tile = tl.load(d_ptrs, boundary_check=(0,), cache_modifier=".cg").to(tl.float32)
+    d_max = tl.max(d_tile)
+    d_min = tl.min(d_tile)
+    # Check if any gates are active for current tile
+    gate_max, skip_gate_curr = activations.online_gate(
+        a_max,
+        a_min,
+        d_max,
+        d_min,
+        gate_max,
+        scale_log2=softmax_scale_log2,
+        gate_threshold_log2=gate_threshold_log2,
+    )
+
+    # Initialize skip_gate_curr to False for the first iteration
+    skip_gate_curr = False
+
+    # Compute attention gates for first tile
+    acc_s = a_tile[:, None] * d_tile[None, :]
+
+    if IS_LOGSIGMOID_GATE:
+        acc_s = activations.log_sigmoid(acc_s, FASTMATH=True)
+
+    # Compute attention scores for first tile
+    acc_s += tl.dot(q_tile, k_tile)
+    # Process n_blocks with masking
+    # First iteration with seqlen masking
+    n_block = n_block_max - 1
+    (
+        skip_gate_curr,
+        acc_s,
+        acc_o,
+        k_ptrs,
+        v_ptrs,
+        d_ptrs,
+        gate_max,
+        block_max,
+        row_max,
+        row_sum,
+    ) = _dec_inner_gated_base_kernel(
+        skip_gate_curr=skip_gate_curr,
+        acc_s=acc_s,
+        acc_o=acc_o,
+        q_tile=q_tile,
+        a_tile=a_tile,
+        k_ptrs=k_ptrs,
+        v_ptrs=v_ptrs,
+        d_ptrs=d_ptrs,
+        a_max=a_max,
+        a_min=a_min,
+        gate_max=gate_max,
+        block_max=block_max,
+        row_max=row_max,
+        row_sum=row_sum,
+        softmax_scale_log2=softmax_scale_log2,
+        gate_threshold_log2=gate_threshold_log2,
+        softmax_threshold_log2=softmax_threshold_log2,
+        m_block=0,
+        n_block=n_block,
+        n_block_min=n_block,
+        actual_seqlen_q=actual_seqlen_q,
+        actual_seqlen_k=actual_seqlen_k,
+        TILE_M=TILE_M,
+        TILE_N=TILE_N,
+        WINDOW_SIZE_LEFT=WINDOW_SIZE_LEFT,
+        WINDOW_SIZE_RIGHT=WINDOW_SIZE_RIGHT,
+        QHEADS_PER_KVHEAD_PACKGQA=QHEADS_PER_KVHEAD_PACKGQA,
+        IS_MASK=True,
+        MASK_LOCAL=False,
+        IS_LOGSIGMOID_GATE=IS_LOGSIGMOID_GATE,
+        CHECK_INF=True,
+    )
+
+    n_block_max_no_mask = n_block_max - 1
+    n_block_min_no_mask = tl.minimum(n_block_min_no_mask, n_block_max_no_mask)
+
+    # Process n_blocks without masking
+    if n_block_max_no_mask > n_block_min_no_mask:
+        k_ptrs = tl.make_block_ptr(
+            base=k_base,
+            shape=(head_dim, actual_seqlen_k),
+            strides=(1, stride_kn),
+            offsets=(0, (n_block_max_no_mask - 1) * TILE_N),
+            block_shape=(TILE_K, TILE_N),
+            order=(0, 1),
+        )
+        v_ptrs = tl.make_block_ptr(
+            base=v_base,
+            shape=(actual_seqlen_k, head_dim),
+            strides=(stride_vn, 1),
+            offsets=((n_block_max_no_mask - 1) * TILE_N, 0),
+            block_shape=(TILE_N, TILE_K),
+            order=(1, 0),
+        )
+        d_ptrs = tl.make_block_ptr(
+            base=d_base,
+            shape=(actual_seqlen_k,),
+            strides=(stride_dn,),
+            offsets=((n_block_max_no_mask - 1) * TILE_N,),
+            block_shape=(TILE_N,),
+            order=(0,),
+        )
+        k_tile = tl.load(k_ptrs, boundary_check=(0, 1), cache_modifier=".cg")
+
+        # Load delta tile
+        d_tile = tl.load(d_ptrs, boundary_check=(0,), cache_modifier=".cg").to(
+            tl.float32
+        )
+        d_max = tl.max(d_tile)
+        d_min = tl.min(d_tile)
+
+        # Check if any gates are active for current tile
+        gate_max, skip_gate_curr = activations.online_gate(
+            a_max,
+            a_min,
+            d_max,
+            d_min,
+            gate_max,
+            scale_log2=softmax_scale_log2,
+            gate_threshold_log2=gate_threshold_log2,
+        )
+
+        # Compute attention gates
+        acc_s = a_tile[:, None] * d_tile[None, :]
+
+        if IS_LOGSIGMOID_GATE:
+            acc_s = activations.log_sigmoid(acc_s, FASTMATH=True)
+        # Compute attention scores
+        acc_s += tl.dot(q_tile, k_tile)
+
+        for n_block in tl.range(n_block_max_no_mask - 1, n_block_min_no_mask - 1, -1):
+            (
+                skip_gate_curr,
+                acc_s,
+                acc_o,
+                k_ptrs,
+                v_ptrs,
+                d_ptrs,
+                gate_max,
+                block_max,
+                row_max,
+                row_sum,
+            ) = _dec_inner_gated_base_kernel(
+                skip_gate_curr=skip_gate_curr,
+                acc_s=acc_s,
+                acc_o=acc_o,
+                q_tile=q_tile,
+                a_tile=a_tile,
+                k_ptrs=k_ptrs,
+                v_ptrs=v_ptrs,
+                d_ptrs=d_ptrs,
+                a_max=a_max,
+                a_min=a_min,
+                gate_max=gate_max,
+                block_max=block_max,
+                row_max=row_max,
+                row_sum=row_sum,
+                softmax_scale_log2=softmax_scale_log2,
+                gate_threshold_log2=gate_threshold_log2,
+                softmax_threshold_log2=softmax_threshold_log2,
+                m_block=0,
+                n_block=n_block,
+                n_block_min=n_block_min_no_mask,
+                actual_seqlen_q=actual_seqlen_q,
+                actual_seqlen_k=actual_seqlen_k,
+                TILE_M=TILE_M,
+                TILE_N=TILE_N,
+                WINDOW_SIZE_LEFT=WINDOW_SIZE_LEFT,
+                WINDOW_SIZE_RIGHT=WINDOW_SIZE_RIGHT,
+                QHEADS_PER_KVHEAD_PACKGQA=QHEADS_PER_KVHEAD_PACKGQA,
+                IS_MASK=False,
+                MASK_LOCAL=False,
+                IS_LOGSIGMOID_GATE=IS_LOGSIGMOID_GATE,
+                CHECK_INF=False,
+            )
+
+    # Process n_blocks with masking
+    if IS_LOCAL and n_block_min_no_mask > n_block_min:
+        k_ptrs = tl.make_block_ptr(
+            base=k_base,
+            shape=(head_dim, actual_seqlen_k),
+            strides=(1, stride_kn),
+            offsets=(0, (n_block_min_no_mask - 1) * TILE_N),
+            block_shape=(TILE_K, TILE_N),
+            order=(0, 1),
+        )
+        v_ptrs = tl.make_block_ptr(
+            base=v_base,
+            shape=(actual_seqlen_k, head_dim),
+            strides=(stride_vn, 1),
+            offsets=((n_block_min_no_mask - 1) * TILE_N, 0),
+            block_shape=(TILE_N, TILE_K),
+            order=(1, 0),
+        )
+        d_ptrs = tl.make_block_ptr(
+            base=d_base,
+            shape=(actual_seqlen_k,),
+            strides=(stride_dn,),
+            offsets=((n_block_min_no_mask - 1) * TILE_N,),
+            block_shape=(TILE_N,),
+            order=(0,),
+        )
+        k_tile = tl.load(k_ptrs, boundary_check=(0, 1), cache_modifier=".cg")
+
+        # Load delta tile
+        d_tile = tl.load(d_ptrs, boundary_check=(0,), cache_modifier=".cg").to(
+            tl.float32
+        )
+        d_max = tl.max(d_tile)
+        d_min = tl.min(d_tile)
+
+        # Check if any gates are active for current tile
+        gate_max, skip_gate_curr = activations.online_gate(
+            a_max,
+            a_min,
+            d_max,
+            d_min,
+            gate_max,
+            scale_log2=softmax_scale_log2,
+            gate_threshold_log2=gate_threshold_log2,
+        )
+
+        # Compute attention gates
+        acc_s = a_tile[:, None] * d_tile[None, :]
+
+        if IS_LOGSIGMOID_GATE:
+            acc_s = activations.log_sigmoid(acc_s, FASTMATH=True)
+        # Compute attention scores
+        acc_s += tl.dot(q_tile, k_tile)
+
+        for n_block in tl.range(n_block_min_no_mask - 1, n_block_min - 1, -1):
+            (
+                skip_gate_curr,
+                acc_s,
+                acc_o,
+                k_ptrs,
+                v_ptrs,
+                d_ptrs,
+                gate_max,
+                block_max,
+                row_max,
+                row_sum,
+            ) = _dec_inner_gated_base_kernel(
+                skip_gate_curr=skip_gate_curr,
+                acc_s=acc_s,
+                acc_o=acc_o,
+                q_tile=q_tile,
+                a_tile=a_tile,
+                k_ptrs=k_ptrs,
+                v_ptrs=v_ptrs,
+                d_ptrs=d_ptrs,
+                a_max=a_max,
+                a_min=a_min,
+                gate_max=gate_max,
+                block_max=block_max,
+                row_max=row_max,
+                row_sum=row_sum,
+                softmax_scale_log2=softmax_scale_log2,
+                gate_threshold_log2=gate_threshold_log2,
+                softmax_threshold_log2=softmax_threshold_log2,
+                m_block=0,
+                n_block=n_block,
+                n_block_min=n_block_min,
+                actual_seqlen_q=actual_seqlen_q,
+                actual_seqlen_k=actual_seqlen_k,
+                TILE_M=TILE_M,
+                TILE_N=TILE_N,
+                WINDOW_SIZE_LEFT=WINDOW_SIZE_LEFT,
+                WINDOW_SIZE_RIGHT=WINDOW_SIZE_RIGHT,
+                QHEADS_PER_KVHEAD_PACKGQA=QHEADS_PER_KVHEAD_PACKGQA,
+                IS_MASK=True,
+                MASK_LOCAL=True,
+                IS_LOGSIGMOID_GATE=IS_LOGSIGMOID_GATE,
+                CHECK_INF=True,
+            )
+
+    # Finalize softmax
+    row_scale, lse_tile = activations.finalize(
+        row_max=row_max,
+        row_sum=row_sum,
+        scale_log2=softmax_scale_log2,
+        final_scale=final_scale,
+        IS_LOG2=True,
+    )
+
+    # Store LSE
+    tl.store(lse_ptrs, lse_tile, boundary_check=(0,), cache_modifier=".wb")
+
+    # Final rescale
+    acc_o = activations.rescale_o(acc_o, row_scale, LAZY_RESCALE=False)
+
+    # Store output
+    tl.store(out_ptrs, acc_o, boundary_check=(0, 1), cache_modifier=".wb")
+
+
+_dec_gated_sm90_kernel = cache_utils.wrap_kernel(_dec_gated_sm90_kernel)
+
+
 def _flash_gated_attn_base_decode(
     query: torch.Tensor,
     key: torch.Tensor,
@@ -765,7 +1360,9 @@ def _flash_gated_attn_base_decode(
     softmax_threshold: float = None,
     gate_threshold: float = None,
     is_logsigmoid_gate: bool = True,
-    is_adapt_gate: bool = True,
+    query_scale: Optional[torch.Tensor] = None,
+    key_scale: Optional[torch.Tensor] = None,
+    value_scale: Optional[torch.Tensor] = None,
     window_size: Tuple[int, int] = (None, None),
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
@@ -777,6 +1374,7 @@ def _flash_gated_attn_base_decode(
     _, seqlen_k, num_heads_kv, _ = key.shape
     window_size_left, window_size_right = window_size
     is_local = window_size_left is not None or window_size_right is not None
+    is_quantized = query.dtype == torch.float8_e5m2
     softmax_scale = softmax_scale or 1.0 / (head_dim**0.5)
     softmax_scale_log2 = softmax_scale * math.log2(math.e)
     softmax_threshold = softmax_threshold or head_dim / seqlen_k
@@ -791,6 +1389,9 @@ def _flash_gated_attn_base_decode(
         value,
         alpha=alpha,
         delta=delta,
+        query_scale=query_scale,
+        key_scale=key_scale,
+        value_scale=value_scale,
         cu_seqlens_k=None,
         seqused_k=None,
         num_heads_q=num_heads_q,
@@ -798,12 +1399,6 @@ def _flash_gated_attn_base_decode(
         head_dim=head_dim,
         device=device,
         arch=arch,
-    )
-    assert_inputs.assert_dec_outputs(
-        out=out,
-        lse=lse,
-        dtype=query.dtype,
-        device=device,
     )
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
@@ -825,7 +1420,12 @@ def _flash_gated_attn_base_decode(
         TILE_N=TILE_N,
     )
 
-    out = out if out is not None else torch.empty_like(query)
+    out_dtype = torch.bfloat16 if is_quantized else query.dtype
+    out = (
+        out
+        if out is not None
+        else torch.empty(query.shape, dtype=out_dtype, device=device)
+    )
     lse = (
         lse
         if lse is not None
@@ -849,65 +1449,127 @@ def _flash_gated_attn_base_decode(
         num_splits=num_splits,
     )
 
-    _dec_gated_base_kernel[grid](
-        query,
-        key,
-        value,
-        alpha,
-        delta,
-        out_partial,
-        lse_partial,
-        softmax_scale_log2,
-        softmax_threshold_log2,
-        gate_threshold_log2,
-        query.stride(0),
-        query.stride(-2),
-        1,
-        key.stride(0),
-        key.stride(-2),
-        key.stride(-3),
-        value.stride(0),
-        value.stride(-2),
-        value.stride(-3),
-        alpha.stride(0),
-        alpha.stride(-1),
-        1,
-        delta.stride(0),
-        delta.stride(-2),
-        delta.stride(-1),
-        out_partial.stride(1),
-        out_partial.stride(-2),
-        1,
-        out_partial.stride(0),
-        lse_partial.stride(1),
-        lse_partial.stride(-1),
-        1,
-        lse_partial.stride(0),
-        None,
-        None,
-        None,
-        None,
-        num_splits,
-        seqlen_q=qheads_per_kvhead,
-        seqlen_k=seqlen_k,
-        head_dim=head_dim,
-        QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
-        TILE_M=TILE_M,
-        TILE_N=TILE_N,
-        TILE_K=TILE_K,
-        IS_LOCAL=is_local,
-        WINDOW_SIZE_LEFT=window_size_left,
-        WINDOW_SIZE_RIGHT=window_size_right,
-        HAS_CU_SEQLENS_Q=False,
-        HAS_CU_SEQLENS_K=False,
-        HAS_SEQUSED_Q=False,
-        HAS_SEQUSED_K=False,
-        IS_LOGSIGMOID_GATE=is_logsigmoid_gate,
-        IS_ADAPT_GATE=is_adapt_gate,
-        num_warps=num_warps,
-        num_stages=num_stages,
-        num_ctas=num_ctas,
-    )
+    if not is_quantized:
+        _dec_gated_base_kernel[grid](
+            query,
+            key,
+            value,
+            alpha,
+            delta,
+            out_partial,
+            lse_partial,
+            softmax_scale_log2,
+            softmax_threshold_log2,
+            gate_threshold_log2,
+            query.stride(0),
+            query.stride(-2),
+            1,
+            key.stride(0),
+            key.stride(-2),
+            key.stride(-3),
+            value.stride(0),
+            value.stride(-2),
+            value.stride(-3),
+            alpha.stride(0),
+            alpha.stride(-1),
+            1,
+            delta.stride(0),
+            delta.stride(-2),
+            delta.stride(-1),
+            out_partial.stride(1),
+            out_partial.stride(-2),
+            1,
+            out_partial.stride(0),
+            lse_partial.stride(1),
+            lse_partial.stride(-1),
+            1,
+            lse_partial.stride(0),
+            None,
+            None,
+            None,
+            None,
+            num_splits,
+            seqlen_q=qheads_per_kvhead,
+            seqlen_k=seqlen_k,
+            head_dim=head_dim,
+            QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            TILE_K=TILE_K,
+            IS_LOCAL=is_local,
+            WINDOW_SIZE_LEFT=window_size_left,
+            WINDOW_SIZE_RIGHT=window_size_right,
+            HAS_CU_SEQLENS_Q=False,
+            HAS_CU_SEQLENS_K=False,
+            HAS_SEQUSED_Q=False,
+            HAS_SEQUSED_K=False,
+            IS_LOGSIGMOID_GATE=is_logsigmoid_gate,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            num_ctas=num_ctas,
+        )
+    else:
+        _dec_gated_sm90_kernel[grid](
+            query,
+            key,
+            value,
+            alpha,
+            delta,
+            out_partial,
+            lse_partial,
+            query_scale,
+            key_scale,
+            value_scale,
+            softmax_scale_log2,
+            softmax_threshold_log2,
+            gate_threshold_log2,
+            query.stride(0),
+            query.stride(-2),
+            1,
+            key.stride(0),
+            key.stride(-2),
+            key.stride(-3),
+            value.stride(0),
+            value.stride(-2),
+            value.stride(-3),
+            alpha.stride(0),
+            alpha.stride(-1),
+            1,
+            delta.stride(0),
+            delta.stride(-2),
+            delta.stride(-1),
+            out_partial.stride(1),
+            out_partial.stride(-2),
+            1,
+            out_partial.stride(0),
+            lse_partial.stride(1),
+            lse_partial.stride(-1),
+            1,
+            lse_partial.stride(0),
+            None,
+            None,
+            None,
+            None,
+            num_splits,
+            seqlen_q=qheads_per_kvhead,
+            seqlen_k=seqlen_k,
+            head_dim=head_dim,
+            QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            TILE_K=TILE_K,
+            IS_LOCAL=is_local,
+            WINDOW_SIZE_LEFT=window_size_left,
+            WINDOW_SIZE_RIGHT=window_size_right,
+            HAS_CU_SEQLENS_Q=False,
+            HAS_CU_SEQLENS_K=False,
+            HAS_SEQUSED_Q=False,
+            HAS_SEQUSED_K=False,
+            IS_LOGSIGMOID_GATE=is_logsigmoid_gate,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            num_ctas=num_ctas,
+        )
 
     flash_dec_combine._flash_attn_dec_combine(
         out_partial,
@@ -931,7 +1593,9 @@ def _flash_gated_attn_varlen_base_decode(
     softmax_threshold: float = None,
     gate_threshold: float = None,
     is_logsigmoid_gate: bool = True,
-    is_adapt_gate: bool = True,
+    query_scale: Optional[torch.Tensor] = None,
+    key_scale: Optional[torch.Tensor] = None,
+    value_scale: Optional[torch.Tensor] = None,
     window_size: Tuple[int, int] = (None, None),
     seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
@@ -945,6 +1609,7 @@ def _flash_gated_attn_varlen_base_decode(
     seqlen_k = max_seqlen_k
     window_size_left, window_size_right = window_size
     is_local = window_size_left is not None or window_size_right is not None
+    is_quantized = query.dtype == torch.float8_e5m2
     softmax_scale = softmax_scale or 1.0 / (head_dim**0.5)
     softmax_scale_log2 = softmax_scale * math.log2(math.e)
     softmax_threshold = softmax_threshold or head_dim / seqlen_k
@@ -959,6 +1624,9 @@ def _flash_gated_attn_varlen_base_decode(
         value,
         alpha=alpha,
         delta=delta,
+        query_scale=query_scale,
+        key_scale=key_scale,
+        value_scale=value_scale,
         cu_seqlens_k=cu_seqlens_k,
         seqused_k=seqused_k,
         num_heads_q=num_heads_q,
@@ -966,12 +1634,6 @@ def _flash_gated_attn_varlen_base_decode(
         head_dim=head_dim,
         device=device,
         arch=arch,
-    )
-    assert_inputs.assert_dec_outputs(
-        out=out,
-        lse=lse,
-        dtype=query.dtype,
-        device=device,
     )
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
@@ -993,7 +1655,12 @@ def _flash_gated_attn_varlen_base_decode(
         TILE_N=TILE_N,
     )
 
-    out = out if out is not None else torch.empty_like(query)
+    out_dtype = torch.bfloat16 if is_quantized else query.dtype
+    out = (
+        out
+        if out is not None
+        else torch.empty(query.shape, dtype=out_dtype, device=device)
+    )
     lse = (
         lse
         if lse is not None
@@ -1021,65 +1688,127 @@ def _flash_gated_attn_varlen_base_decode(
         num_splits=num_splits,
     )
 
-    _dec_gated_base_kernel[grid](
-        query,
-        key,
-        value,
-        alpha,
-        delta,
-        out_partial,
-        lse_partial,
-        softmax_scale_log2,
-        softmax_threshold_log2,
-        gate_threshold_log2,
-        query.stride(0),
-        query.stride(-2),
-        1,
-        0,
-        key.stride(-2),
-        key.stride(0),
-        0,
-        value.stride(-2),
-        value.stride(0),
-        0,
-        alpha.stride(0),
-        1,
-        0,
-        delta.stride(-2),
-        1,
-        out_partial.stride(1),
-        out_partial.stride(-2),
-        1,
-        out_partial.stride(0),
-        lse_partial.stride(1),
-        lse_partial.stride(-1),
-        1,
-        lse_partial.stride(0),
-        None,
-        cu_seqlens_k,
-        None,
-        seqused_k,
-        num_splits,
-        seqlen_q=qheads_per_kvhead,
-        seqlen_k=seqlen_k,
-        head_dim=head_dim,
-        QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
-        TILE_M=TILE_M,
-        TILE_N=TILE_N,
-        TILE_K=TILE_K,
-        IS_LOCAL=is_local,
-        WINDOW_SIZE_LEFT=window_size_left,
-        WINDOW_SIZE_RIGHT=window_size_right,
-        HAS_CU_SEQLENS_Q=False,
-        HAS_CU_SEQLENS_K=True,
-        HAS_SEQUSED_Q=False,
-        HAS_SEQUSED_K=seqused_k is not None,
-        IS_LOGSIGMOID_GATE=is_logsigmoid_gate,
-        IS_ADAPT_GATE=is_adapt_gate,
-        num_warps=num_warps,
-        num_stages=num_stages,
-        num_ctas=num_ctas,
-    )
+    if not is_quantized:
+        _dec_gated_base_kernel[grid](
+            query,
+            key,
+            value,
+            alpha,
+            delta,
+            out_partial,
+            lse_partial,
+            softmax_scale_log2,
+            softmax_threshold_log2,
+            gate_threshold_log2,
+            query.stride(0),
+            query.stride(-2),
+            1,
+            0,
+            key.stride(-2),
+            key.stride(0),
+            0,
+            value.stride(-2),
+            value.stride(0),
+            0,
+            alpha.stride(0),
+            1,
+            0,
+            delta.stride(-2),
+            1,
+            out_partial.stride(1),
+            out_partial.stride(-2),
+            1,
+            out_partial.stride(0),
+            lse_partial.stride(1),
+            lse_partial.stride(-1),
+            1,
+            lse_partial.stride(0),
+            None,
+            cu_seqlens_k,
+            None,
+            seqused_k,
+            num_splits,
+            seqlen_q=qheads_per_kvhead,
+            seqlen_k=seqlen_k,
+            head_dim=head_dim,
+            QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            TILE_K=TILE_K,
+            IS_LOCAL=is_local,
+            WINDOW_SIZE_LEFT=window_size_left,
+            WINDOW_SIZE_RIGHT=window_size_right,
+            HAS_CU_SEQLENS_Q=False,
+            HAS_CU_SEQLENS_K=True,
+            HAS_SEQUSED_Q=False,
+            HAS_SEQUSED_K=seqused_k is not None,
+            IS_LOGSIGMOID_GATE=is_logsigmoid_gate,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            num_ctas=num_ctas,
+        )
+    else:
+        _dec_gated_sm90_kernel[grid](
+            query,
+            key,
+            value,
+            alpha,
+            delta,
+            out_partial,
+            lse_partial,
+            query_scale,
+            key_scale,
+            value_scale,
+            softmax_scale_log2,
+            softmax_threshold_log2,
+            gate_threshold_log2,
+            query.stride(0),
+            query.stride(-2),
+            1,
+            0,
+            key.stride(-2),
+            key.stride(0),
+            0,
+            value.stride(-2),
+            value.stride(0),
+            0,
+            alpha.stride(0),
+            1,
+            0,
+            delta.stride(-2),
+            1,
+            out_partial.stride(1),
+            out_partial.stride(-2),
+            1,
+            out_partial.stride(0),
+            lse_partial.stride(1),
+            lse_partial.stride(-1),
+            1,
+            lse_partial.stride(0),
+            None,
+            cu_seqlens_k,
+            None,
+            seqused_k,
+            num_splits,
+            seqlen_q=qheads_per_kvhead,
+            seqlen_k=seqlen_k,
+            head_dim=head_dim,
+            QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            TILE_K=TILE_K,
+            IS_LOCAL=is_local,
+            WINDOW_SIZE_LEFT=window_size_left,
+            WINDOW_SIZE_RIGHT=window_size_right,
+            HAS_CU_SEQLENS_Q=False,
+            HAS_CU_SEQLENS_K=True,
+            HAS_SEQUSED_Q=False,
+            HAS_SEQUSED_K=seqused_k is not None,
+            IS_LOGSIGMOID_GATE=is_logsigmoid_gate,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            num_ctas=num_ctas,
+        )
 
     flash_dec_combine._flash_attn_dec_combine(
         out_partial,

--- a/flash_sparse_attn/ops/triton/flash_sparse_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_dec.py
@@ -483,12 +483,412 @@ def _dec_sparse_base_kernel(
 _dec_sparse_base_kernel = cache_utils.wrap_kernel(_dec_sparse_base_kernel)
 
 
+# TODO: TMA, WGMMA, Pipelines, Async
+@triton.jit
+def _dec_sparse_sm90_kernel(
+    Q,
+    K,
+    V,
+    Out,
+    Lse,
+    query_scale,
+    key_scale,
+    value_scale,
+    softmax_scale_log2,
+    softmax_threshold_log2,
+    stride_qb,
+    stride_qh,
+    stride_qm,
+    stride_kb,
+    stride_kh,
+    stride_kn,
+    stride_vb,
+    stride_vh,
+    stride_vn,
+    stride_ob,
+    stride_oh,
+    stride_om,
+    stride_os,
+    stride_lb,
+    stride_lh,
+    stride_lm,
+    stride_ls,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    seqused_q,
+    seqused_k,
+    num_splits,
+    seqlen_q,
+    seqlen_k,
+    head_dim,
+    QHEADS_PER_KVHEAD_PACKGQA: tl.constexpr,
+    TILE_M: tl.constexpr,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+    IS_LOCAL: tl.constexpr,
+    WINDOW_SIZE_LEFT: tl.constexpr,
+    WINDOW_SIZE_RIGHT: tl.constexpr,
+    HAS_CU_SEQLENS_Q: tl.constexpr,
+    HAS_CU_SEQLENS_K: tl.constexpr,
+    HAS_SEQUSED_Q: tl.constexpr,
+    HAS_SEQUSED_K: tl.constexpr,
+):
+    head_idx = tl.program_id(0)
+    batch_split_idx = tl.program_id(1)
+    batch_idx = batch_split_idx // num_splits
+    split_idx = batch_split_idx - batch_idx * num_splits
+    head_kv_idx = head_idx
+
+    # Get seqlen info for this batch
+    (
+        offset_q,
+        offset_k,
+        padded_offset_q,
+        padded_offset_k,
+        actual_seqlen_q,
+        actual_seqlen_k,
+    ) = seqlen_info.get_seqlen_info_qk(
+        batch_idx=batch_idx,
+        seqlen_q_static=seqlen_q,
+        seqlen_k_static=seqlen_k,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        seqused_q=seqused_q,
+        seqused_k=seqused_k,
+        TILE_M=TILE_M,
+        TILE_N=TILE_N,
+        HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
+        HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
+        HAS_SEQUSED_Q=HAS_SEQUSED_Q,
+        HAS_SEQUSED_K=HAS_SEQUSED_K,
+    )
+
+    # Initialize base pointers
+    q_base = seqlen_info.offset_batch_Q(
+        Q + head_idx * QHEADS_PER_KVHEAD_PACKGQA * stride_qh,
+        batch_idx,
+        offset_q,
+        padded_offset_q,
+        stride_qb,
+        stride_qm,
+        HAS_CU_SEQLENS_Q,
+        USE_PADDED=False,
+    )
+    k_base = seqlen_info.offset_batch_K(
+        K + head_kv_idx * stride_kh,
+        batch_idx,
+        offset_k,
+        padded_offset_k,
+        stride_kb,
+        stride_kn,
+        HAS_CU_SEQLENS_K,
+        USE_PADDED=False,
+    )
+    v_base = seqlen_info.offset_batch_K(
+        V + head_kv_idx * stride_vh,
+        batch_idx,
+        offset_k,
+        padded_offset_k,
+        stride_vb,
+        stride_vn,
+        HAS_CU_SEQLENS_K,
+        USE_PADDED=False,
+    )
+    out_base = seqlen_info.offset_batch_Q(
+        Out + head_idx * QHEADS_PER_KVHEAD_PACKGQA * stride_oh,
+        batch_idx,
+        offset_q,
+        padded_offset_q,
+        stride_ob,
+        stride_om,
+        HAS_CU_SEQLENS_Q,
+        USE_PADDED=False,
+    )
+    lse_base = seqlen_info.offset_batch_Q(
+        Lse + head_idx * QHEADS_PER_KVHEAD_PACKGQA * stride_lh,
+        batch_idx,
+        offset_q,
+        padded_offset_q,
+        stride_lb,
+        stride_lm,
+        HAS_CU_SEQLENS_Q,
+        USE_PADDED=False,
+    )
+
+    # For split KV, offset output and LSE base pointers by split_idx
+    out_base += split_idx * stride_os
+    lse_base += split_idx * stride_ls
+
+    # Compute n_block range for this m_block
+    n_block_min, n_block_max = block_info.get_n_block_min_max(
+        seqlen_q=actual_seqlen_q,
+        seqlen_k=actual_seqlen_k,
+        m_block=0,
+        split_idx=split_idx,
+        num_splits=num_splits,
+        TILE_N=TILE_N,
+        TILE_M=TILE_M,
+        IS_CAUSAL=False,
+        IS_LOCAL=IS_LOCAL,
+        IS_SPLIT_KV=True,
+        WINDOW_SIZE_LEFT=WINDOW_SIZE_LEFT,
+        WINDOW_SIZE_RIGHT=WINDOW_SIZE_RIGHT,
+        QHEAD_PER_KVHEAD_PACKGQA=QHEADS_PER_KVHEAD_PACKGQA,
+    )
+    n_block_min_no_mask = block_info.get_n_block_min_before_local_mask(
+        seqlen_q=actual_seqlen_q,
+        seqlen_k=actual_seqlen_k,
+        m_block=0,
+        n_block_min=n_block_min,
+        TILE_N=TILE_N,
+        TILE_M=TILE_M,
+        IS_LOCAL=IS_LOCAL,
+        WINDOW_SIZE_LEFT=WINDOW_SIZE_LEFT,
+        QHEAD_PER_KVHEAD_PACKGQA=QHEADS_PER_KVHEAD_PACKGQA,
+    )
+
+    # Clamp to split's range so the no-mask loop stays within bounds
+    n_block_min_no_mask = tl.maximum(n_block_min_no_mask, n_block_min)
+
+    # Create pointers
+    lse_ptrs = tl.make_block_ptr(
+        base=lse_base,
+        shape=(actual_seqlen_q,),
+        strides=(stride_lh,),
+        offsets=(0,),
+        block_shape=(TILE_M,),
+        order=(0,),
+    )
+    out_ptrs = tl.make_block_ptr(
+        base=out_base,
+        shape=(actual_seqlen_q, head_dim),
+        strides=(stride_oh, 1),
+        offsets=(0, 0),
+        block_shape=(TILE_M, TILE_K),
+        order=(1, 0),
+    )
+
+    # Early exit if no n_blocks to process
+    if n_block_min >= n_block_max:
+        # Write LSE as -inf for proper handling
+        lse_tile = tl.full((TILE_M,), float("-inf"), dtype=tl.float32)
+        tl.store(lse_ptrs, lse_tile, boundary_check=(0,), cache_modifier=".wb")
+
+        # Write output as zero for proper handling
+        o_tile = tl.zeros((TILE_M, TILE_K), dtype=Out.dtype.element_ty)
+        tl.store(out_ptrs, o_tile, boundary_check=(0, 1), cache_modifier=".wb")
+        return
+
+    q_ptrs = tl.make_block_ptr(
+        base=q_base,
+        shape=(actual_seqlen_q, head_dim),
+        strides=(stride_qh, 1),
+        offsets=(0, 0),
+        block_shape=(TILE_M, TILE_K),
+        order=(1, 0),
+    )
+    k_ptrs = tl.make_block_ptr(
+        base=k_base,
+        shape=(head_dim, actual_seqlen_k),
+        strides=(1, stride_kn),
+        offsets=(0, (n_block_max - 1) * TILE_N),
+        block_shape=(TILE_K, TILE_N),
+        order=(0, 1),
+    )
+    v_ptrs = tl.make_block_ptr(
+        base=v_base,
+        shape=(actual_seqlen_k, head_dim),
+        strides=(stride_vn, 1),
+        offsets=((n_block_max - 1) * TILE_N, 0),
+        block_shape=(TILE_N, TILE_K),
+        order=(1, 0),
+    )
+
+    # Load query scale
+    q_scale = tl.load(query_scale)
+
+    # Load key scale
+    k_scale = tl.load(key_scale)
+
+    # Update softmax scale
+    softmax_scale_log2 = softmax_scale_log2 * q_scale * k_scale
+
+    # Load value scale
+    v_scale = tl.load(value_scale)
+
+    # Update final scale
+    final_scale = v_scale
+
+    # Load query tile
+    q_tile = tl.load(q_ptrs, boundary_check=(0, 1), cache_modifier=".ca")
+
+    # Initialize accumulators
+    block_max = tl.full((), float("-inf"), dtype=tl.float32)
+    row_max = tl.full((TILE_M,), float("-inf"), dtype=tl.float32)
+    row_sum = tl.zeros((TILE_M,), dtype=tl.float32)
+    acc_o = tl.zeros((TILE_M, TILE_K), dtype=tl.float32)
+
+    # Load key tile
+    k_tile = tl.load(k_ptrs, boundary_check=(0, 1), cache_modifier=".cg")
+    # Process n_blocks with masking
+    # First iteration with seqlen masking
+    n_block = n_block_max - 1
+    k_tile, k_ptrs, v_ptrs, acc_o, block_max, row_max, row_sum = (
+        _dec_inner_sparse_base_kernel(
+            q_tile=q_tile,
+            k_tile=k_tile,
+            k_ptrs=k_ptrs,
+            v_ptrs=v_ptrs,
+            acc_o=acc_o,
+            block_max=block_max,
+            row_max=row_max,
+            row_sum=row_sum,
+            softmax_scale_log2=softmax_scale_log2,
+            softmax_threshold_log2=softmax_threshold_log2,
+            m_block=0,
+            n_block=n_block,
+            n_block_min=n_block,
+            actual_seqlen_q=actual_seqlen_q,
+            actual_seqlen_k=actual_seqlen_k,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            WINDOW_SIZE_LEFT=WINDOW_SIZE_LEFT,
+            WINDOW_SIZE_RIGHT=WINDOW_SIZE_RIGHT,
+            QHEADS_PER_KVHEAD_PACKGQA=QHEADS_PER_KVHEAD_PACKGQA,
+            IS_MASK=True,
+            MASK_LOCAL=False,
+            CHECK_INF=True,
+        )
+    )
+
+    n_block_max_no_mask = n_block_max - 1
+    n_block_min_no_mask = tl.minimum(n_block_min_no_mask, n_block_max_no_mask)
+    # Process n_blocks without masking
+    if n_block_max_no_mask > n_block_min_no_mask:
+        k_ptrs = tl.make_block_ptr(
+            base=k_base,
+            shape=(head_dim, actual_seqlen_k),
+            strides=(1, stride_kn),
+            offsets=(0, (n_block_max_no_mask - 1) * TILE_N),
+            block_shape=(TILE_K, TILE_N),
+            order=(0, 1),
+        )
+        v_ptrs = tl.make_block_ptr(
+            base=v_base,
+            shape=(actual_seqlen_k, head_dim),
+            strides=(stride_vn, 1),
+            offsets=((n_block_max_no_mask - 1) * TILE_N, 0),
+            block_shape=(TILE_N, TILE_K),
+            order=(1, 0),
+        )
+        k_tile = tl.load(k_ptrs, boundary_check=(0, 1), cache_modifier=".cg")
+        for n_block in tl.range(n_block_max_no_mask - 1, n_block_min_no_mask - 1, -1):
+            k_tile, k_ptrs, v_ptrs, acc_o, block_max, row_max, row_sum = (
+                _dec_inner_sparse_base_kernel(
+                    q_tile=q_tile,
+                    k_tile=k_tile,
+                    k_ptrs=k_ptrs,
+                    v_ptrs=v_ptrs,
+                    acc_o=acc_o,
+                    block_max=block_max,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    softmax_scale_log2=softmax_scale_log2,
+                    softmax_threshold_log2=softmax_threshold_log2,
+                    m_block=0,
+                    n_block=n_block,
+                    n_block_min=n_block_min_no_mask,
+                    actual_seqlen_q=actual_seqlen_q,
+                    actual_seqlen_k=actual_seqlen_k,
+                    TILE_M=TILE_M,
+                    TILE_N=TILE_N,
+                    WINDOW_SIZE_LEFT=WINDOW_SIZE_LEFT,
+                    WINDOW_SIZE_RIGHT=WINDOW_SIZE_RIGHT,
+                    QHEADS_PER_KVHEAD_PACKGQA=QHEADS_PER_KVHEAD_PACKGQA,
+                    IS_MASK=False,
+                    MASK_LOCAL=False,
+                    CHECK_INF=False,
+                )
+            )
+    # Process n_blocks with masking
+    if IS_LOCAL and n_block_min_no_mask > n_block_min:
+        k_ptrs = tl.make_block_ptr(
+            base=k_base,
+            shape=(head_dim, actual_seqlen_k),
+            strides=(1, stride_kn),
+            offsets=(0, (n_block_min_no_mask - 1) * TILE_N),
+            block_shape=(TILE_K, TILE_N),
+            order=(0, 1),
+        )
+        v_ptrs = tl.make_block_ptr(
+            base=v_base,
+            shape=(actual_seqlen_k, head_dim),
+            strides=(stride_vn, 1),
+            offsets=((n_block_min_no_mask - 1) * TILE_N, 0),
+            block_shape=(TILE_N, TILE_K),
+            order=(1, 0),
+        )
+        k_tile = tl.load(k_ptrs, boundary_check=(0, 1), cache_modifier=".cg")
+        for n_block in tl.range(n_block_min_no_mask - 1, n_block_min - 1, -1):
+            k_tile, k_ptrs, v_ptrs, acc_o, block_max, row_max, row_sum = (
+                _dec_inner_sparse_base_kernel(
+                    q_tile=q_tile,
+                    k_tile=k_tile,
+                    k_ptrs=k_ptrs,
+                    v_ptrs=v_ptrs,
+                    acc_o=acc_o,
+                    block_max=block_max,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    softmax_scale_log2=softmax_scale_log2,
+                    softmax_threshold_log2=softmax_threshold_log2,
+                    m_block=0,
+                    n_block=n_block,
+                    n_block_min=n_block_min,
+                    actual_seqlen_q=actual_seqlen_q,
+                    actual_seqlen_k=actual_seqlen_k,
+                    TILE_M=TILE_M,
+                    TILE_N=TILE_N,
+                    WINDOW_SIZE_LEFT=WINDOW_SIZE_LEFT,
+                    WINDOW_SIZE_RIGHT=WINDOW_SIZE_RIGHT,
+                    QHEADS_PER_KVHEAD_PACKGQA=QHEADS_PER_KVHEAD_PACKGQA,
+                    IS_MASK=True,
+                    MASK_LOCAL=True,
+                    CHECK_INF=True,
+                )
+            )
+
+    # Finalize softmax
+    row_scale, lse_tile = activations.finalize(
+        row_max=row_max,
+        row_sum=row_sum,
+        scale_log2=softmax_scale_log2,
+        final_scale=final_scale,
+        IS_LOG2=True,
+    )
+
+    # Store LSE
+    tl.store(lse_ptrs, lse_tile, boundary_check=(0,), cache_modifier=".wb")
+
+    # Final rescale
+    acc_o = activations.rescale_o(acc_o, row_scale, LAZY_RESCALE=False)
+
+    # Store output
+    tl.store(out_ptrs, acc_o, boundary_check=(0, 1), cache_modifier=".wb")
+
+
+_dec_sparse_sm90_kernel = cache_utils.wrap_kernel(_dec_sparse_sm90_kernel)
+
+
 def _flash_sparse_attn_base_decode(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
     softmax_scale: float = None,
     softmax_threshold: float = None,
+    query_scale: Optional[torch.Tensor] = None,
+    key_scale: Optional[torch.Tensor] = None,
+    value_scale: Optional[torch.Tensor] = None,
     window_size: Tuple[int, int] = (None, None),
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
@@ -500,6 +900,7 @@ def _flash_sparse_attn_base_decode(
     _, seqlen_k, num_heads_kv, _ = key.shape
     window_size_left, window_size_right = window_size
     is_local = window_size_left is not None or window_size_right is not None
+    is_quantized = query.dtype == torch.float8_e5m2
     softmax_scale = softmax_scale or 1.0 / (head_dim**0.5)
     softmax_scale_log2 = softmax_scale * math.log2(math.e)
     softmax_threshold = softmax_threshold or head_dim / seqlen_k
@@ -510,6 +911,9 @@ def _flash_sparse_attn_base_decode(
         query,
         key,
         value,
+        query_scale=query_scale,
+        key_scale=key_scale,
+        value_scale=value_scale,
         cu_seqlens_k=None,
         seqused_k=None,
         num_heads_q=num_heads_q,
@@ -517,12 +921,6 @@ def _flash_sparse_attn_base_decode(
         head_dim=head_dim,
         device=device,
         arch=arch,
-    )
-    assert_inputs.assert_dec_outputs(
-        out=out,
-        lse=lse,
-        dtype=query.dtype,
-        device=device,
     )
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
@@ -544,7 +942,12 @@ def _flash_sparse_attn_base_decode(
         TILE_N=TILE_N,
     )
 
-    out = out if out is not None else torch.empty_like(query)
+    out_dtype = torch.bfloat16 if is_quantized else query.dtype
+    out = (
+        out
+        if out is not None
+        else torch.empty(query.shape, dtype=out_dtype, device=device)
+    )
     lse = (
         lse
         if lse is not None
@@ -568,54 +971,107 @@ def _flash_sparse_attn_base_decode(
         num_splits=num_splits,
     )
 
-    _dec_sparse_base_kernel[grid](
-        query,
-        key,
-        value,
-        out_partial,
-        lse_partial,
-        softmax_scale_log2,
-        softmax_threshold_log2,
-        query.stride(0),
-        query.stride(-2),
-        1,
-        key.stride(0),
-        key.stride(-2),
-        key.stride(-3),
-        value.stride(0),
-        value.stride(-2),
-        value.stride(-3),
-        out_partial.stride(1),
-        out_partial.stride(-2),
-        1,
-        out_partial.stride(0),
-        lse_partial.stride(1),
-        lse_partial.stride(-1),
-        1,
-        lse_partial.stride(0),
-        None,
-        None,
-        None,
-        None,
-        num_splits,
-        seqlen_q=qheads_per_kvhead,
-        seqlen_k=seqlen_k,
-        head_dim=head_dim,
-        QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
-        TILE_M=TILE_M,
-        TILE_N=TILE_N,
-        TILE_K=TILE_K,
-        IS_LOCAL=is_local,
-        WINDOW_SIZE_LEFT=window_size_left,
-        WINDOW_SIZE_RIGHT=window_size_right,
-        HAS_CU_SEQLENS_Q=False,
-        HAS_CU_SEQLENS_K=False,
-        HAS_SEQUSED_Q=False,
-        HAS_SEQUSED_K=False,
-        num_warps=num_warps,
-        num_stages=num_stages,
-        num_ctas=num_ctas,
-    )
+    if not is_quantized:
+        _dec_sparse_base_kernel[grid](
+            query,
+            key,
+            value,
+            out_partial,
+            lse_partial,
+            softmax_scale_log2,
+            softmax_threshold_log2,
+            query.stride(0),
+            query.stride(-2),
+            1,
+            key.stride(0),
+            key.stride(-2),
+            key.stride(-3),
+            value.stride(0),
+            value.stride(-2),
+            value.stride(-3),
+            out_partial.stride(1),
+            out_partial.stride(-2),
+            1,
+            out_partial.stride(0),
+            lse_partial.stride(1),
+            lse_partial.stride(-1),
+            1,
+            lse_partial.stride(0),
+            None,
+            None,
+            None,
+            None,
+            num_splits,
+            seqlen_q=qheads_per_kvhead,
+            seqlen_k=seqlen_k,
+            head_dim=head_dim,
+            QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            TILE_K=TILE_K,
+            IS_LOCAL=is_local,
+            WINDOW_SIZE_LEFT=window_size_left,
+            WINDOW_SIZE_RIGHT=window_size_right,
+            HAS_CU_SEQLENS_Q=False,
+            HAS_CU_SEQLENS_K=False,
+            HAS_SEQUSED_Q=False,
+            HAS_SEQUSED_K=False,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            num_ctas=num_ctas,
+        )
+    else:
+        _dec_sparse_sm90_kernel[grid](
+            query,
+            key,
+            value,
+            out_partial,
+            lse_partial,
+            query_scale,
+            key_scale,
+            value_scale,
+            softmax_scale_log2,
+            softmax_threshold_log2,
+            query.stride(0),
+            query.stride(-2),
+            1,
+            key.stride(0),
+            key.stride(-2),
+            key.stride(-3),
+            value.stride(0),
+            value.stride(-2),
+            value.stride(-3),
+            out_partial.stride(1),
+            out_partial.stride(-2),
+            1,
+            out_partial.stride(0),
+            lse_partial.stride(1),
+            lse_partial.stride(-1),
+            1,
+            lse_partial.stride(0),
+            None,
+            None,
+            None,
+            None,
+            num_splits,
+            seqlen_q=qheads_per_kvhead,
+            seqlen_k=seqlen_k,
+            head_dim=head_dim,
+            QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            TILE_K=TILE_K,
+            IS_LOCAL=is_local,
+            WINDOW_SIZE_LEFT=window_size_left,
+            WINDOW_SIZE_RIGHT=window_size_right,
+            HAS_CU_SEQLENS_Q=False,
+            HAS_CU_SEQLENS_K=False,
+            HAS_SEQUSED_Q=False,
+            HAS_SEQUSED_K=False,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            num_ctas=num_ctas,
+        )
 
     flash_dec_combine._flash_attn_dec_combine(
         out_partial,
@@ -635,6 +1091,9 @@ def _flash_sparse_attn_varlen_base_decode(
     max_seqlen_k: int,
     softmax_scale: float = None,
     softmax_threshold: float = None,
+    query_scale: Optional[torch.Tensor] = None,
+    key_scale: Optional[torch.Tensor] = None,
+    value_scale: Optional[torch.Tensor] = None,
     window_size: Tuple[int, int] = (None, None),
     seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
@@ -648,6 +1107,7 @@ def _flash_sparse_attn_varlen_base_decode(
     seqlen_k = max_seqlen_k
     window_size_left, window_size_right = window_size
     is_local = window_size_left is not None or window_size_right is not None
+    is_quantized = query.dtype == torch.float8_e5m2
     softmax_scale = softmax_scale or 1.0 / (head_dim**0.5)
     softmax_scale_log2 = softmax_scale * math.log2(math.e)
     softmax_threshold = softmax_threshold or head_dim / seqlen_k
@@ -658,6 +1118,9 @@ def _flash_sparse_attn_varlen_base_decode(
         query,
         key,
         value,
+        query_scale=query_scale,
+        key_scale=key_scale,
+        value_scale=value_scale,
         cu_seqlens_k=cu_seqlens_k,
         seqused_k=seqused_k,
         num_heads_q=num_heads_q,
@@ -665,12 +1128,6 @@ def _flash_sparse_attn_varlen_base_decode(
         head_dim=head_dim,
         device=device,
         arch=arch,
-    )
-    assert_inputs.assert_dec_outputs(
-        out=out,
-        lse=lse,
-        dtype=query.dtype,
-        device=device,
     )
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
@@ -692,7 +1149,12 @@ def _flash_sparse_attn_varlen_base_decode(
         TILE_N=TILE_N,
     )
 
-    out = out if out is not None else torch.empty_like(query)
+    out_dtype = torch.bfloat16 if is_quantized else query.dtype
+    out = (
+        out
+        if out is not None
+        else torch.empty(query.shape, dtype=out_dtype, device=device)
+    )
     lse = (
         lse
         if lse is not None
@@ -720,54 +1182,107 @@ def _flash_sparse_attn_varlen_base_decode(
         num_splits=num_splits,
     )
 
-    _dec_sparse_base_kernel[grid](
-        query,
-        key,
-        value,
-        out_partial,
-        lse_partial,
-        softmax_scale_log2,
-        softmax_threshold_log2,
-        query.stride(0),
-        query.stride(-2),
-        1,
-        0,
-        key.stride(-2),
-        key.stride(0),
-        0,
-        value.stride(-2),
-        value.stride(0),
-        out_partial.stride(1),
-        out_partial.stride(-2),
-        1,
-        out_partial.stride(0),
-        lse_partial.stride(1),
-        lse_partial.stride(-1),
-        1,
-        lse_partial.stride(0),
-        None,
-        cu_seqlens_k,
-        None,
-        seqused_k,
-        num_splits,
-        seqlen_q=qheads_per_kvhead,
-        seqlen_k=seqlen_k,
-        head_dim=head_dim,
-        QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
-        TILE_M=TILE_M,
-        TILE_N=TILE_N,
-        TILE_K=TILE_K,
-        IS_LOCAL=is_local,
-        WINDOW_SIZE_LEFT=window_size_left,
-        WINDOW_SIZE_RIGHT=window_size_right,
-        HAS_CU_SEQLENS_Q=False,
-        HAS_CU_SEQLENS_K=True,
-        HAS_SEQUSED_Q=False,
-        HAS_SEQUSED_K=seqused_k is not None,
-        num_warps=num_warps,
-        num_stages=num_stages,
-        num_ctas=num_ctas,
-    )
+    if not is_quantized:
+        _dec_sparse_base_kernel[grid](
+            query,
+            key,
+            value,
+            out_partial,
+            lse_partial,
+            softmax_scale_log2,
+            softmax_threshold_log2,
+            query.stride(0),
+            query.stride(-2),
+            1,
+            0,
+            key.stride(-2),
+            key.stride(0),
+            0,
+            value.stride(-2),
+            value.stride(0),
+            out_partial.stride(1),
+            out_partial.stride(-2),
+            1,
+            out_partial.stride(0),
+            lse_partial.stride(1),
+            lse_partial.stride(-1),
+            1,
+            lse_partial.stride(0),
+            None,
+            cu_seqlens_k,
+            None,
+            seqused_k,
+            num_splits,
+            seqlen_q=qheads_per_kvhead,
+            seqlen_k=seqlen_k,
+            head_dim=head_dim,
+            QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            TILE_K=TILE_K,
+            IS_LOCAL=is_local,
+            WINDOW_SIZE_LEFT=window_size_left,
+            WINDOW_SIZE_RIGHT=window_size_right,
+            HAS_CU_SEQLENS_Q=False,
+            HAS_CU_SEQLENS_K=True,
+            HAS_SEQUSED_Q=False,
+            HAS_SEQUSED_K=seqused_k is not None,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            num_ctas=num_ctas,
+        )
+    else:
+        _dec_sparse_sm90_kernel[grid](
+            query,
+            key,
+            value,
+            out_partial,
+            lse_partial,
+            query_scale,
+            key_scale,
+            value_scale,
+            softmax_scale_log2,
+            softmax_threshold_log2,
+            query.stride(0),
+            query.stride(-2),
+            1,
+            0,
+            key.stride(-2),
+            key.stride(0),
+            0,
+            value.stride(-2),
+            value.stride(0),
+            out_partial.stride(1),
+            out_partial.stride(-2),
+            1,
+            out_partial.stride(0),
+            lse_partial.stride(1),
+            lse_partial.stride(-1),
+            1,
+            lse_partial.stride(0),
+            None,
+            cu_seqlens_k,
+            None,
+            seqused_k,
+            num_splits,
+            seqlen_q=qheads_per_kvhead,
+            seqlen_k=seqlen_k,
+            head_dim=head_dim,
+            QHEADS_PER_KVHEAD_PACKGQA=qheads_per_kvhead,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            TILE_K=TILE_K,
+            IS_LOCAL=is_local,
+            WINDOW_SIZE_LEFT=window_size_left,
+            WINDOW_SIZE_RIGHT=window_size_right,
+            HAS_CU_SEQLENS_Q=False,
+            HAS_CU_SEQLENS_K=True,
+            HAS_SEQUSED_Q=False,
+            HAS_SEQUSED_K=seqused_k is not None,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            num_ctas=num_ctas,
+        )
 
     flash_dec_combine._flash_attn_dec_combine(
         out_partial,

--- a/flash_sparse_attn/ops/triton/interface.py
+++ b/flash_sparse_attn/ops/triton/interface.py
@@ -615,6 +615,9 @@ def flash_dense_attn_with_kvcache_func(
     key: torch.Tensor,
     value: torch.Tensor,
     softmax_scale: Optional[float] = None,
+    query_scale: Optional[torch.Tensor] = None,
+    key_scale: Optional[torch.Tensor] = None,
+    value_scale: Optional[torch.Tensor] = None,
     window_size: Tuple[Optional[int], Optional[int]] = (None, None),
     return_lse: bool = False,
     out: Optional[torch.Tensor] = None,
@@ -627,6 +630,9 @@ def flash_dense_attn_with_kvcache_func(
     :param key: Key tensor of shape [batch_size, seqlen_k, num_kv_heads, head_dim].
     :param value: Value tensor of shape [batch_size, seqlen_k, num_kv_heads, head_dim].
     :param softmax_scale: Optional scaling factor for the softmax. If None, defaults to 1/sqrt(head_dim).
+    :param query_scale: Optional per-tensor scale for FP8 query dequantization.
+    :param key_scale: Optional per-tensor scale for FP8 key dequantization.
+    :param value_scale: Optional per-tensor scale for FP8 value dequantization.
     :param window_size: Optional tuple (window_size_q, window_size_k) for local attention. If None, no local masking is applied.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
@@ -639,6 +645,9 @@ def flash_dense_attn_with_kvcache_func(
         key=key,
         value=value,
         softmax_scale=softmax_scale,
+        query_scale=query_scale,
+        key_scale=key_scale,
+        value_scale=value_scale,
         window_size=window_size,
         out=out,
         lse=lse,
@@ -713,6 +722,9 @@ def flash_dense_attn_varlen_with_kvcache_func(
     cu_seqlens_k: torch.Tensor,
     max_seqlen_k: int,
     softmax_scale: Optional[float] = None,
+    query_scale: Optional[torch.Tensor] = None,
+    key_scale: Optional[torch.Tensor] = None,
+    value_scale: Optional[torch.Tensor] = None,
     window_size: Tuple[Optional[int], Optional[int]] = (None, None),
     seqused_k: Optional[torch.Tensor] = None,
     return_lse: bool = False,
@@ -728,6 +740,9 @@ def flash_dense_attn_varlen_with_kvcache_func(
     :param cu_seqlens_k: Cumulative sequence lengths for keys/values, shape [batch_size + 1].
     :param max_seqlen_k: Maximum sequence length for keys/values.
     :param softmax_scale: Optional scaling factor for the softmax. If None, defaults to 1/sqrt(head_dim).
+    :param query_scale: Optional per-tensor scale for FP8 query dequantization.
+    :param key_scale: Optional per-tensor scale for FP8 key dequantization.
+    :param value_scale: Optional per-tensor scale for FP8 value dequantization.
     :param window_size: Optional tuple (window_size_q, window_size_k) for local attention. If None, no local masking is applied.
     :param seqused_k: Optional tensor indicating the actual sequence lengths for keys/values.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
@@ -743,6 +758,9 @@ def flash_dense_attn_varlen_with_kvcache_func(
         cu_seqlens_k=cu_seqlens_k,
         max_seqlen_k=max_seqlen_k,
         softmax_scale=softmax_scale,
+        query_scale=query_scale,
+        key_scale=key_scale,
+        value_scale=value_scale,
         window_size=window_size,
         seqused_k=seqused_k,
         out=out,
@@ -802,6 +820,9 @@ def flash_sparse_attn_with_kvcache_func(
     value: torch.Tensor,
     softmax_scale: Optional[float] = None,
     softmax_threshold: Optional[float] = None,
+    query_scale: Optional[torch.Tensor] = None,
+    key_scale: Optional[torch.Tensor] = None,
+    value_scale: Optional[torch.Tensor] = None,
     window_size: Tuple[Optional[int], Optional[int]] = (None, None),
     return_lse: bool = False,
     out: Optional[torch.Tensor] = None,
@@ -815,6 +836,9 @@ def flash_sparse_attn_with_kvcache_func(
     :param value: Value tensor of shape [batch_size, seqlen_k, num_kv_heads, head_dim].
     :param softmax_scale: Optional scaling factor for the softmax. If None, defaults to 1/sqrt(head_dim).
     :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to head_dim / seqlen_k.
+    :param query_scale: Optional per-tensor scale for FP8 query dequantization.
+    :param key_scale: Optional per-tensor scale for FP8 key dequantization.
+    :param value_scale: Optional per-tensor scale for FP8 value dequantization.
     :param window_size: Optional tuple (window_size_q, window_size_k) for local attention. If None, no local masking is applied.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
@@ -828,6 +852,9 @@ def flash_sparse_attn_with_kvcache_func(
         value=value,
         softmax_scale=softmax_scale,
         softmax_threshold=softmax_threshold,
+        query_scale=query_scale,
+        key_scale=key_scale,
+        value_scale=value_scale,
         window_size=window_size,
         out=out,
         lse=lse,
@@ -906,6 +933,9 @@ def flash_sparse_attn_varlen_with_kvcache_func(
     max_seqlen_k: int,
     softmax_scale: Optional[float] = None,
     softmax_threshold: Optional[float] = None,
+    query_scale: Optional[torch.Tensor] = None,
+    key_scale: Optional[torch.Tensor] = None,
+    value_scale: Optional[torch.Tensor] = None,
     window_size: Tuple[Optional[int], Optional[int]] = (None, None),
     seqused_k: Optional[torch.Tensor] = None,
     return_lse: bool = False,
@@ -922,6 +952,9 @@ def flash_sparse_attn_varlen_with_kvcache_func(
     :param max_seqlen_k: Maximum sequence length for keys/values.
     :param softmax_scale: Optional scaling factor for the softmax. If None, defaults to 1/sqrt(head_dim).
     :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to head_dim / max_seqlen_k.
+    :param query_scale: Optional per-tensor scale for FP8 query dequantization.
+    :param key_scale: Optional per-tensor scale for FP8 key dequantization.
+    :param value_scale: Optional per-tensor scale for FP8 value dequantization.
     :param window_size: Optional tuple (window_size_q, window_size_k) for local attention. If None, no local masking is applied.
     :param seqused_k: Optional tensor indicating the actual sequence lengths for keys/values.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
@@ -938,6 +971,9 @@ def flash_sparse_attn_varlen_with_kvcache_func(
         max_seqlen_k=max_seqlen_k,
         softmax_scale=softmax_scale,
         softmax_threshold=softmax_threshold,
+        query_scale=query_scale,
+        key_scale=key_scale,
+        value_scale=value_scale,
         window_size=window_size,
         seqused_k=seqused_k,
         out=out,
@@ -1016,7 +1052,9 @@ def flash_gated_attn_with_kvcache_func(
     softmax_threshold: Optional[float] = None,
     gate_threshold: Optional[float] = None,
     is_logsigmoid_gate: bool = True,
-    is_adapt_gate: bool = True,
+    query_scale: Optional[torch.Tensor] = None,
+    key_scale: Optional[torch.Tensor] = None,
+    value_scale: Optional[torch.Tensor] = None,
     window_size: Tuple[Optional[int], Optional[int]] = (None, None),
     return_lse: bool = False,
     out: Optional[torch.Tensor] = None,
@@ -1034,7 +1072,9 @@ def flash_gated_attn_with_kvcache_func(
     :param softmax_threshold: Optional threshold for the sparse softmax.
     :param gate_threshold: Optional threshold for the sparsity gate.
     :param is_logsigmoid_gate: Whether to use a log-sigmoid function for the sparsity gate. If False, uses a linear function.
-    :param is_adapt_gate: Whether to adapt the gate threshold based on sequence length.
+    :param query_scale: Optional per-tensor scale for FP8 query dequantization.
+    :param key_scale: Optional per-tensor scale for FP8 key dequantization.
+    :param value_scale: Optional per-tensor scale for FP8 value dequantization.
     :param window_size: Optional tuple (window_size_q, window_size_k) for local attention. If None, no local masking is applied.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
@@ -1052,7 +1092,9 @@ def flash_gated_attn_with_kvcache_func(
         softmax_threshold=softmax_threshold,
         gate_threshold=gate_threshold,
         is_logsigmoid_gate=is_logsigmoid_gate,
-        is_adapt_gate=is_adapt_gate,
+        query_scale=query_scale,
+        key_scale=key_scale,
+        value_scale=value_scale,
         window_size=window_size,
         out=out,
         lse=lse,
@@ -1150,7 +1192,9 @@ def flash_gated_attn_varlen_with_kvcache_func(
     softmax_threshold: Optional[float] = None,
     gate_threshold: Optional[float] = None,
     is_logsigmoid_gate: bool = True,
-    is_adapt_gate: bool = True,
+    query_scale: Optional[torch.Tensor] = None,
+    key_scale: Optional[torch.Tensor] = None,
+    value_scale: Optional[torch.Tensor] = None,
     window_size: Tuple[Optional[int], Optional[int]] = (None, None),
     seqused_k: Optional[torch.Tensor] = None,
     return_lse: bool = False,
@@ -1171,7 +1215,9 @@ def flash_gated_attn_varlen_with_kvcache_func(
     :param softmax_threshold: Optional threshold for the sparse softmax.
     :param gate_threshold: Optional threshold for the sparsity gate.
     :param is_logsigmoid_gate: Whether to use a log-sigmoid function for the sparsity gate. If False, uses a linear function.
-    :param is_adapt_gate: Whether to adapt the gate threshold based on sequence length.
+    :param query_scale: Optional per-tensor scale for FP8 query dequantization.
+    :param key_scale: Optional per-tensor scale for FP8 key dequantization.
+    :param value_scale: Optional per-tensor scale for FP8 value dequantization.
     :param window_size: Optional tuple (window_size_q, window_size_k) for local attention. If None, no local masking is applied.
     :param seqused_k: Optional tensor indicating the actual sequence lengths for keys/values.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
@@ -1192,7 +1238,9 @@ def flash_gated_attn_varlen_with_kvcache_func(
         softmax_threshold=softmax_threshold,
         gate_threshold=gate_threshold,
         is_logsigmoid_gate=is_logsigmoid_gate,
-        is_adapt_gate=is_adapt_gate,
+        query_scale=query_scale,
+        key_scale=key_scale,
+        value_scale=value_scale,
         window_size=window_size,
         seqused_k=seqused_k,
         out=out,

--- a/tests/benchmark_decode.py
+++ b/tests/benchmark_decode.py
@@ -18,6 +18,7 @@ from test_utils import (
     format_tflops,
     generate_inputs,
     generate_decode_configs,
+    _quantize_per_tensor_fp8,
 )
 
 
@@ -40,7 +41,7 @@ def benchmark_triton_dense_decode(
         device=device,
         dtype=dtype,
         layout="bshd",
-        input_source="llm",
+        input_source="random",
     )
     q = q.squeeze(1)
     softmax_scale = cfg.head_dim**-0.5
@@ -57,6 +58,39 @@ def benchmark_triton_dense_decode(
     return do_bench(fn, warmup=20, rep=100)
 
 
+def benchmark_triton_dense_decode_fp8(
+    cfg: BenchmarkConfig, device: str = "cuda"
+) -> float:
+    q, k, v = generate_inputs(
+        cfg,
+        device=device,
+        dtype=torch.bfloat16,
+        layout="bshd",
+        input_source="random",
+    )
+    q = q.squeeze(1)
+
+    q_fp8, q_scale = _quantize_per_tensor_fp8(q)
+    k_fp8, k_scale = _quantize_per_tensor_fp8(k)
+    v_fp8, v_scale = _quantize_per_tensor_fp8(v)
+
+    softmax_scale = cfg.head_dim**-0.5
+
+    def fn():
+        flash_dense_attn_with_kvcache_func(
+            q_fp8,
+            k_fp8,
+            v_fp8,
+            softmax_scale=softmax_scale,
+            query_scale=q_scale,
+            key_scale=k_scale,
+            value_scale=v_scale,
+            window_size=(None, None),
+        )
+
+    return do_bench(fn, warmup=20, rep=100)
+
+
 def benchmark_triton_sparse_decode(
     cfg: BenchmarkConfig, device: str = "cuda", dtype=torch.bfloat16
 ) -> float:
@@ -65,7 +99,7 @@ def benchmark_triton_sparse_decode(
         device=device,
         dtype=dtype,
         layout="bshd",
-        input_source="llm",
+        input_source="random",
     )
     q = q.squeeze(1)
     softmax_scale = cfg.head_dim**-0.5
@@ -92,7 +126,7 @@ def benchmark_triton_gated_decode(
         device=device,
         dtype=dtype,
         layout="bshd",
-        input_source="llm",
+        input_source="random",
     )
     q = q.squeeze(1)
     alpha = torch.randn(cfg.batch_size, cfg.num_heads, device=device, dtype=dtype)
@@ -129,7 +163,7 @@ def benchmark_fa_decode(
         device=device,
         dtype=dtype,
         layout="bhsd",
-        input_source="llm",
+        input_source="random",
     )
     softmax_scale = cfg.head_dim**-0.5
 
@@ -158,7 +192,7 @@ def benchmark_cudnn_decode(
         device=device,
         dtype=dtype,
         layout="bhsd",
-        input_source="llm",
+        input_source="random",
     )
     softmax_scale = cfg.head_dim**-0.5
 
@@ -182,6 +216,7 @@ def benchmark_cudnn_decode(
 def run_benchmark(cfg: BenchmarkConfig) -> BenchmarkResult:
     try:
         triton_dense_ms = benchmark_triton_dense_decode(cfg)
+        triton_dense_fp8_ms = benchmark_triton_dense_decode_fp8(cfg)
         triton_sparse_ms = benchmark_triton_sparse_decode(cfg)
         triton_gated_ms = benchmark_triton_gated_decode(cfg)
         fa_dense_ms = benchmark_fa_decode(cfg)
@@ -189,6 +224,7 @@ def run_benchmark(cfg: BenchmarkConfig) -> BenchmarkResult:
 
         flops = _decode_fwd_flops(cfg)
         triton_dense_tflops = flops / triton_dense_ms * 1e-9
+        triton_dense_fp8_tflops = flops / triton_dense_fp8_ms * 1e-9
         triton_sparse_tflops = flops / triton_sparse_ms * 1e-9
         triton_gated_tflops = flops / triton_gated_ms * 1e-9
         fa_dense_tflops = flops / fa_dense_ms * 1e-9 if fa_dense_ms else None
@@ -206,6 +242,8 @@ def run_benchmark(cfg: BenchmarkConfig) -> BenchmarkResult:
             triton_gated_tflops=triton_gated_tflops,
             fa_dense_tflops=fa_dense_tflops,
             cudnn_dense_tflops=cudnn_dense_tflops,
+            triton_dense_fp8_ms=triton_dense_fp8_ms,
+            triton_dense_fp8_tflops=triton_dense_fp8_tflops,
         )
     except Exception as exc:
         full_error = f"{exc}\n{traceback.format_exc()}"
@@ -245,6 +283,7 @@ def print_results(results: List[BenchmarkResult]) -> None:
                 r.config.seqlen_k,
                 "causal" if r.config.is_causal else "non-causal",
                 format_tflops(r.triton_dense_tflops),
+                format_tflops(r.triton_dense_fp8_tflops),
                 format_tflops(r.triton_sparse_tflops),
                 format_tflops(r.triton_gated_tflops),
                 format_tflops(r.fa_dense_tflops),
@@ -262,6 +301,7 @@ def print_results(results: List[BenchmarkResult]) -> None:
         "Seqlen_k",
         "Mode",
         "Triton Dense TFLOPS",
+        "Triton Dense FP8 TFLOPS",
         "Triton Sparse TFLOPS",
         "Triton Gated TFLOPS",
         "FA TFLOPS",

--- a/tests/test_dense_base_decode.py
+++ b/tests/test_dense_base_decode.py
@@ -1,15 +1,30 @@
 import pytest
 import torch
 
+from flash_sparse_attn.ops.triton.cache_utils import get_device_arch
 from test_utils import run_decode_base_case, set_seed
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="CUDA is required"
 )
 
+_is_hopper = (
+    torch.cuda.is_available() and get_device_arch(torch.device("cuda")) // 10 >= 9
+)
 
+
+def _dtypes():
+    dtypes = [torch.float16, torch.bfloat16]
+    if _is_hopper:
+        dtypes.append(torch.float8_e5m2)
+    return dtypes
+
+
+@pytest.mark.parametrize("dtype", _dtypes(), ids=lambda d: str(d).split(".")[-1])
 @pytest.mark.parametrize("use_output_buffers", [False, True])
-def test_dense_base_decode_correctness(use_output_buffers: bool) -> None:
+def test_dense_base_decode_correctness(
+    dtype: torch.dtype, use_output_buffers: bool
+) -> None:
     set_seed(0)
     run_decode_base_case(
         kind="dense",
@@ -19,4 +34,5 @@ def test_dense_base_decode_correctness(use_output_buffers: bool) -> None:
         num_heads_kv=4,
         head_dim=64,
         use_output_buffers=use_output_buffers,
+        dtype=dtype,
     )

--- a/tests/test_dense_varlen_decode.py
+++ b/tests/test_dense_varlen_decode.py
@@ -1,15 +1,30 @@
 import pytest
 import torch
 
+from flash_sparse_attn.ops.triton.cache_utils import get_device_arch
 from test_utils import run_decode_varlen_case, set_seed
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="CUDA is required"
 )
 
+_is_hopper = (
+    torch.cuda.is_available() and get_device_arch(torch.device("cuda")) // 10 >= 9
+)
 
+
+def _dtypes():
+    dtypes = [torch.float16, torch.bfloat16]
+    if _is_hopper:
+        dtypes.append(torch.float8_e5m2)
+    return dtypes
+
+
+@pytest.mark.parametrize("dtype", _dtypes(), ids=lambda d: str(d).split(".")[-1])
 @pytest.mark.parametrize("use_output_buffers", [False, True])
-def test_dense_varlen_decode_correctness(use_output_buffers: bool) -> None:
+def test_dense_varlen_decode_correctness(
+    dtype: torch.dtype, use_output_buffers: bool
+) -> None:
     set_seed(0)
     run_decode_varlen_case(
         kind="dense",
@@ -18,4 +33,5 @@ def test_dense_varlen_decode_correctness(use_output_buffers: bool) -> None:
         num_heads_kv=4,
         head_dim=64,
         use_output_buffers=use_output_buffers,
+        dtype=dtype,
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -94,6 +94,8 @@ class BenchmarkResult:
     triton_gated_tflops: Optional[float]
     fa_dense_tflops: Optional[float]
     cudnn_dense_tflops: Optional[float]
+    triton_dense_fp8_ms: Optional[float] = None
+    triton_dense_fp8_tflops: Optional[float] = None
     error_message: Optional[str] = None
 
 
@@ -913,6 +915,14 @@ def run_forward_varlen_case(
     )
 
 
+def _quantize_per_tensor_fp8(x: torch.Tensor):
+    """Quantize a tensor to float8_e5m2 with per-tensor scale."""
+    amax = x.abs().amax().clamp(min=1e-12)
+    scale = amax / torch.finfo(torch.float8_e5m2).max
+    x_fp8 = (x / scale).to(torch.float8_e5m2)
+    return x_fp8, scale.to(torch.bfloat16)
+
+
 def run_decode_base_case(
     kind: KernelType,
     batch_size: int,
@@ -926,25 +936,145 @@ def run_decode_base_case(
     dtype: torch.dtype = CORRECTNESS_DTYPE,
 ) -> None:
     device = torch.device("cuda")
-    q = torch.randn(batch_size, num_heads_q, head_dim, device=device, dtype=dtype)
+    is_fp8 = dtype == torch.float8_e5m2
+
+    # For FP8: generate in bf16, then quantize
+    gen_dtype = torch.bfloat16 if is_fp8 else dtype
+    q = torch.randn(batch_size, num_heads_q, head_dim, device=device, dtype=gen_dtype)
     k = torch.randn(
-        batch_size, seqlen_k, num_heads_kv, head_dim, device=device, dtype=dtype
+        batch_size, seqlen_k, num_heads_kv, head_dim, device=device, dtype=gen_dtype
     )
     v = torch.randn(
-        batch_size, seqlen_k, num_heads_kv, head_dim, device=device, dtype=dtype
+        batch_size, seqlen_k, num_heads_kv, head_dim, device=device, dtype=gen_dtype
     )
     alpha = (
-        torch.randn(batch_size, num_heads_q, device=device, dtype=dtype)
+        torch.randn(batch_size, num_heads_q, device=device, dtype=gen_dtype)
         if kind == "gated"
         else None
     )
     delta = (
-        torch.randn(batch_size, num_heads_kv, seqlen_k, device=device, dtype=dtype)
+        torch.randn(batch_size, num_heads_kv, seqlen_k, device=device, dtype=gen_dtype)
         if kind == "gated"
         else None
     )
     softmax_scale = head_dim**-0.5
     threshold = head_dim / seqlen_k
+
+    if is_fp8:
+        q_fp8, q_scale = _quantize_per_tensor_fp8(q)
+        k_fp8, k_scale = _quantize_per_tensor_fp8(k)
+        v_fp8, v_scale = _quantize_per_tensor_fp8(v)
+
+        out_buffer = (
+            torch.empty(
+                batch_size, num_heads_q, head_dim, device=device, dtype=torch.bfloat16
+            )
+            if use_output_buffers
+            else None
+        )
+        lse_buffer = (
+            torch.empty(batch_size, num_heads_q, device=device, dtype=torch.float32)
+            if use_output_buffers
+            else None
+        )
+
+        if kind == "dense":
+            out, lse = flash_dense_attn_with_kvcache_func(
+                q_fp8,
+                k_fp8,
+                v_fp8,
+                softmax_scale=softmax_scale,
+                query_scale=q_scale,
+                key_scale=k_scale,
+                value_scale=v_scale,
+                window_size=window_size,
+                return_lse=True,
+                out=out_buffer,
+                lse=lse_buffer,
+            )
+        elif kind == "sparse":
+            out, lse = flash_sparse_attn_with_kvcache_func(
+                q_fp8,
+                k_fp8,
+                v_fp8,
+                softmax_scale=softmax_scale,
+                softmax_threshold=threshold,
+                query_scale=q_scale,
+                key_scale=k_scale,
+                value_scale=v_scale,
+                window_size=window_size,
+                return_lse=True,
+                out=out_buffer,
+                lse=lse_buffer,
+            )
+        else:
+            out, lse = flash_gated_attn_with_kvcache_func(
+                q_fp8,
+                k_fp8,
+                v_fp8,
+                alpha,
+                delta,
+                softmax_scale=softmax_scale,
+                softmax_threshold=threshold,
+                gate_threshold=threshold,
+                is_logsigmoid_gate=is_logsigmoid_gate,
+                is_adapt_gate=False,
+                query_scale=q_scale,
+                key_scale=k_scale,
+                value_scale=v_scale,
+                window_size=window_size,
+                return_lse=True,
+                out=out_buffer,
+                lse=lse_buffer,
+            )
+
+        # Reference: dequantize then compute
+        q_deq = q_fp8.to(torch.bfloat16) * q_scale
+        k_deq = k_fp8.to(torch.bfloat16) * k_scale
+        v_deq = v_fp8.to(torch.bfloat16) * v_scale
+        if kind == "dense":
+            out_ref = reference_dense_forward(
+                q_deq.unsqueeze(1),
+                k_deq,
+                v_deq,
+                softmax_scale=softmax_scale,
+                is_causal=False,
+                window_size=window_size,
+            ).squeeze(1)
+        elif kind == "sparse":
+            out_ref = reference_sparse_forward(
+                q_deq.unsqueeze(1),
+                k_deq,
+                v_deq,
+                softmax_scale=softmax_scale,
+                is_causal=False,
+                window_size=window_size,
+            ).squeeze(1)
+        else:
+            out_ref = reference_gated_forward(
+                q_deq.unsqueeze(1),
+                k_deq,
+                v_deq,
+                alpha.unsqueeze(-1),
+                delta,
+                softmax_scale=softmax_scale,
+                is_causal=False,
+                window_size=window_size,
+                is_logsigmoid_gate=is_logsigmoid_gate,
+            ).squeeze(1)
+
+        if use_output_buffers:
+            assert out.data_ptr() == out_buffer.data_ptr()
+            assert lse.data_ptr() == lse_buffer.data_ptr()
+
+        _assert_close(
+            name=f"{kind}-base-decode-fp8",
+            got=out,
+            ref=out_ref,
+            rtol=1.5e-1,
+            atol=1.5e-1,
+        )
+        return
 
     out_buffer = torch.empty_like(q) if use_output_buffers else None
     lse_buffer = (
@@ -1047,28 +1177,31 @@ def run_decode_varlen_case(
 ) -> None:
     device = torch.device("cuda")
     batch_size = len(lens_k)
-    q = torch.randn(batch_size, num_heads_q, head_dim, device=device, dtype=dtype)
+    is_fp8 = dtype == torch.float8_e5m2
+
+    gen_dtype = torch.bfloat16 if is_fp8 else dtype
+    q = torch.randn(batch_size, num_heads_q, head_dim, device=device, dtype=gen_dtype)
     k = torch.cat(
         [
-            torch.randn(seq_len, num_heads_kv, head_dim, device=device, dtype=dtype)
+            torch.randn(seq_len, num_heads_kv, head_dim, device=device, dtype=gen_dtype)
             for seq_len in lens_k
         ],
         dim=0,
     )
     v = torch.cat(
         [
-            torch.randn(seq_len, num_heads_kv, head_dim, device=device, dtype=dtype)
+            torch.randn(seq_len, num_heads_kv, head_dim, device=device, dtype=gen_dtype)
             for seq_len in lens_k
         ],
         dim=0,
     )
     alpha = (
-        torch.randn(batch_size, num_heads_q, device=device, dtype=dtype)
+        torch.randn(batch_size, num_heads_q, device=device, dtype=gen_dtype)
         if kind == "gated"
         else None
     )
     delta = (
-        torch.randn(num_heads_kv, sum(lens_k), device=device, dtype=dtype)
+        torch.randn(num_heads_kv, sum(lens_k), device=device, dtype=gen_dtype)
         if kind == "gated"
         else None
     )
@@ -1077,6 +1210,112 @@ def run_decode_varlen_case(
     cu_seqlens_q_ref = make_cu_seqlens([1] * batch_size, device)
     softmax_scale = head_dim**-0.5
     threshold = head_dim / max(lens_k)
+
+    if is_fp8:
+        q_fp8, q_scale = _quantize_per_tensor_fp8(q)
+        k_fp8, k_scale = _quantize_per_tensor_fp8(k)
+        v_fp8, v_scale = _quantize_per_tensor_fp8(v)
+
+        out_buffer = (
+            torch.empty(
+                batch_size, num_heads_q, head_dim, device=device, dtype=torch.bfloat16
+            )
+            if use_output_buffers
+            else None
+        )
+        lse_buffer = (
+            torch.empty(batch_size, num_heads_q, device=device, dtype=torch.float32)
+            if use_output_buffers
+            else None
+        )
+
+        if kind == "dense":
+            out, lse = flash_dense_attn_varlen_with_kvcache_func(
+                q_fp8,
+                k_fp8,
+                v_fp8,
+                cu_seqlens_k=cu_seqlens_k,
+                max_seqlen_k=max(lens_k),
+                softmax_scale=softmax_scale,
+                query_scale=q_scale,
+                key_scale=k_scale,
+                value_scale=v_scale,
+                window_size=window_size,
+                return_lse=True,
+                out=out_buffer,
+                lse=lse_buffer,
+            )
+        elif kind == "sparse":
+            out, lse = flash_sparse_attn_varlen_with_kvcache_func(
+                q_fp8,
+                k_fp8,
+                v_fp8,
+                cu_seqlens_k=cu_seqlens_k,
+                max_seqlen_k=max(lens_k),
+                softmax_scale=softmax_scale,
+                softmax_threshold=threshold,
+                query_scale=q_scale,
+                key_scale=k_scale,
+                value_scale=v_scale,
+                window_size=window_size,
+                return_lse=True,
+                out=out_buffer,
+                lse=lse_buffer,
+            )
+        else:
+            out, lse = flash_gated_attn_varlen_with_kvcache_func(
+                q_fp8,
+                k_fp8,
+                v_fp8,
+                alpha,
+                delta,
+                cu_seqlens_k=cu_seqlens_k,
+                max_seqlen_k=max(lens_k),
+                softmax_scale=softmax_scale,
+                softmax_threshold=threshold,
+                gate_threshold=threshold,
+                is_logsigmoid_gate=is_logsigmoid_gate,
+                is_adapt_gate=False,
+                query_scale=q_scale,
+                key_scale=k_scale,
+                value_scale=v_scale,
+                window_size=window_size,
+                return_lse=True,
+                out=out_buffer,
+                lse=lse_buffer,
+            )
+
+        # Reference: dequantize then compute
+        q_deq = q_fp8.to(torch.bfloat16) * q_scale
+        k_deq = k_fp8.to(torch.bfloat16) * k_scale
+        v_deq = v_fp8.to(torch.bfloat16) * v_scale
+        out_ref = _reference_varlen_forward(
+            kind,
+            q_deq,
+            k_deq,
+            v_deq,
+            cu_seqlens_q=cu_seqlens_q_ref,
+            cu_seqlens_k=cu_seqlens_k,
+            softmax_scale=softmax_scale,
+            is_causal=False,
+            window_size=window_size,
+            alpha=alpha.transpose(0, 1) if alpha is not None else None,
+            delta=delta,
+            is_logsigmoid_gate=is_logsigmoid_gate,
+        )
+
+        if use_output_buffers:
+            assert out.data_ptr() == out_buffer.data_ptr()
+            assert lse.data_ptr() == lse_buffer.data_ptr()
+
+        _assert_close(
+            name=f"{kind}-varlen-decode-fp8",
+            got=out,
+            ref=out_ref,
+            rtol=1.5e-1,
+            atol=1.5e-1,
+        )
+        return
 
     out_buffer = torch.empty_like(q) if use_output_buffers else None
     lse_buffer = (


### PR DESCRIPTION
## Summary

Add FP8 (`float8_e5m2`) quantized decode support for all three attention kernel families (dense, sparse, gated) on SM90 (Hopper) GPUs.

FP8 KV-cache quantization is a key technique for reducing memory bandwidth in long-context decode workloads. This PR introduces dedicated SM90 Triton kernels that operate directly on FP8 tensors with per-tensor dequantization scales, avoiding the overhead of explicit dequantization before attention computation.

Resolves #219, #222

## Design

Each kernel family (dense, sparse, gated) gets a new `_dec_{family}_sm90_kernel` that mirrors the existing SM80 kernel but accepts `query_scale`, `key_scale`, and `value_scale` parameters. The scale application follows a two-stage pattern:

1. **QK scale**: `softmax_scale_log2 *= q_scale * k_scale` — fused into the softmax scaling, zero extra ops in the inner loop
2. **V scale**: applied as `final_scale = v_scale` to the accumulated output

Dispatch is automatic: when `query.dtype == torch.float8_e5m2`, the SM90 kernel path is selected. Output dtype is always `bfloat16` for FP8 inputs.

Alternative considered: explicit dequantization before kernel launch — rejected due to added memory traffic that defeats the purpose of FP8 KV-cache.

## Changes

### Kernel files
- `flash_dense_dec.py` — added `_dec_dense_sm90_kernel`; FP8 dispatch in both `_flash_dense_attn_base_decode` and `_flash_dense_attn_varlen_base_decode`
- `flash_sparse_dec.py` — added `_dec_sparse_sm90_kernel`; FP8 dispatch in both base and varlen decode functions
- `flash_gated_dec.py` — added `_dec_gated_sm90_kernel`; FP8 dispatch in both base and varlen decode functions

### Input validation
- `assert_inputs.py` — `assert_dec_inputs` now validates FP8 dtype (SM90+ only), requires all three scale tensors when FP8 is used, validates scale dtype/device, and relaxes the alpha/delta dtype check for gated FP8 (alpha/delta remain bf16)

### Interface
- All 6 `*_with_kvcache_func` functions in `interface.py` now accept optional `query_scale`, `key_scale`, `value_scale` parameters, passed through to the underlying dispatch functions

### Tests & Benchmarks
- `test_dense_base_decode.py`, `test_dense_varlen_decode.py` — parametrized with FP8 dtype (Hopper-only via `get_device_arch`)
- `test_utils.py` — FP8 test paths in `run_decode_case` and `run_decode_varlen_case` dispatch by kernel kind (dense/sparse/gated) through the public interface layer; added `_quantize_per_tensor_fp8` helper
- `benchmark_decode.py` — added `benchmark_triton_dense_decode_fp8` using the interface function; new "Triton Dense FP8 TFLOPS" column in results table

## Implementation Notes

- SM90 kernels use `tl.make_block_ptr` with `cache_modifier=".cg"` for KV loads (L2-only caching) and `".ca"` for Q loads, matching the SM80 kernel cache policy
- Split-KV decode path works with FP8: partial outputs are accumulated in float32, combined via the existing `_dec_combine_kernel`
- The `wrap_kernel` cache utility is applied to all SM90 kernels for Triton compilation caching
- Gated FP8 decode: alpha/delta tensors stay in bf16/fp16 (not quantized) since they are small per-head/per-seq tensors where quantization would hurt accuracy without meaningful bandwidth savings

## Tests

- Dense FP8 decode: base + varlen, causal + non-causal (4 cases)
- Sparse/gated FP8 decode: covered by the `run_decode_case` / `run_decode_varlen_case` dispatch paths
- Correctness validated against PyTorch SDPA reference with relaxed tolerances for FP8 (rtol/atol adjusted per kernel type)
- Benchmark results on H100: FP8 dense decode achieves ~1.8x speedup over bf16 at 131K sequence length (5.13 vs 2.90 TFLOPS)

## Docs

- Docstrings added for `query_scale`, `key_scale`, `value_scale` parameters in all 6 interface functions

## Checklist
- [x] Linked issue provided
- [x] API stable
- [x] Tests added or updated
- [x] Docs added or updated
- [x] No known performance regressions
