### PR TITLE
[PERFORMANCE OPTIMIZATION] Add compile-time CHECK_NAN toggle to finalize for decode kernel fast-path   

### DIFF
--- a/flash_sparse_attn/ops/triton/activations.py
+++ b/flash_sparse_attn/ops/triton/activations.py
@@ -144,6 +144,7 @@ def finalize(
     scale_log2,
     final_scale,
     IS_LOG2: tl.constexpr,
+    CHECK_NAN: tl.constexpr,
 ):
     """
     Finalize online softmax by computing output scale and logsumexp.
@@ -152,18 +153,23 @@ def finalize(
     :param row_sum: Final sum values per row of shape [BLOCK_M].
     :param final_scale: Scaling factor to be applied to the output.
     :param IS_LOG2: Boolean flag indicating if the returned logsumexp should be in log2-space.
+    :param CHECK_NAN: Boolean flag indicating if nan values in row_sum should be checked and set to 1 to avoid returning nan.
 
     :return row_scale: Final scaling factors per row of shape [BLOCK_M].
     :return lse: Logsumexp values per row of shape [BLOCK_M].
     """
     # if row_sum is zero or nan, set it to 1 to avoid division by zero
-    acc_o_is_zero_or_nan = (row_sum == 0.0) | (row_sum != row_sum)
-    row_scale = tl.where(acc_o_is_zero_or_nan, 1.0, 1.0 / row_sum) * final_scale
-    lse = tl.where(
-        acc_o_is_zero_or_nan,
-        float("-inf"),
-        row_max * scale_log2 + tl.log2(row_sum),
-    )
+    if CHECK_NAN:
+        acc_o_is_zero_or_nan = (row_sum == 0.0) | (row_sum != row_sum)
+        row_scale = tl.where(acc_o_is_zero_or_nan, 1.0, final_scale / row_sum)
+        lse = tl.where(
+            acc_o_is_zero_or_nan,
+            float("-inf"),
+            row_max * scale_log2 + tl.log2(row_sum),
+        )
+    else:
+        row_scale = final_scale / row_sum
+        lse = row_max * scale_log2 + tl.log2(row_sum)
     if not IS_LOG2:
         # ln2 = math.log(2.0)
         ln2 = 0.6931471805599453

--- a/flash_sparse_attn/ops/triton/flash_dense_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_dec.py
@@ -452,12 +452,13 @@ def _dec_dense_base_kernel(
         scale_log2=softmax_scale_log2,
         final_scale=1.0,
         IS_LOG2=True,
+        CHECK_NAN=False,
     )
 
     # Store LSE
     tl.store(lse_ptrs, lse_tile, boundary_check=(0,), cache_modifier=".wb")
 
-    # Final rescale
+    # Finalize rescale
     acc_o = activations.rescale_o(acc_o, row_scale, LAZY_RESCALE=False)
 
     # Store output
@@ -842,12 +843,13 @@ def _dec_dense_sm90_kernel(
         scale_log2=softmax_scale_log2,
         final_scale=final_scale,
         IS_LOG2=True,
+        CHECK_NAN=False,
     )
 
     # Store LSE
     tl.store(lse_ptrs, lse_tile, boundary_check=(0,), cache_modifier=".wb")
 
-    # Final rescale
+    # Finalize rescale
     acc_o = activations.rescale_o(acc_o, row_scale, LAZY_RESCALE=False)
 
     # Store output

--- a/flash_sparse_attn/ops/triton/flash_dense_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_fwd.py
@@ -574,8 +574,8 @@ def _fwd_dense_base_kernel(
         scale_log2=softmax_scale_log2,
         final_scale=1.0,
         IS_LOG2=IS_SPLIT_KV,
+        CHECK_NAN=True,
     )
-    acc_o = activations.rescale_o(acc_o, row_scale, LAZY_RESCALE=False)
 
     # Store LSE
     if PACK_GQA:
@@ -587,6 +587,9 @@ def _fwd_dense_base_kernel(
         )
     else:
         tl.store(lse_ptrs, lse_tile, boundary_check=(0,), cache_modifier=".wb")
+
+    # Finalize rescale
+    acc_o = activations.rescale_o(acc_o, row_scale, LAZY_RESCALE=False)
 
     # Store output
     # When IS_SPLIT_KV, store float32 partial results.

--- a/flash_sparse_attn/ops/triton/flash_gated_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_dec.py
@@ -739,12 +739,13 @@ def _dec_gated_base_kernel(
         scale_log2=softmax_scale_log2,
         final_scale=1.0,
         IS_LOG2=True,
+        CHECK_NAN=False,
     )
 
     # Store LSE
     tl.store(lse_ptrs, lse_tile, boundary_check=(0,), cache_modifier=".wb")
 
-    # Final rescale
+    # Finalize rescale
     acc_o = activations.rescale_o(acc_o, row_scale, LAZY_RESCALE=False)
 
     # Store output
@@ -1335,12 +1336,13 @@ def _dec_gated_sm90_kernel(
         scale_log2=softmax_scale_log2,
         final_scale=final_scale,
         IS_LOG2=True,
+        CHECK_NAN=False,
     )
 
     # Store LSE
     tl.store(lse_ptrs, lse_tile, boundary_check=(0,), cache_modifier=".wb")
 
-    # Final rescale
+    # Finalize rescale
     acc_o = activations.rescale_o(acc_o, row_scale, LAZY_RESCALE=False)
 
     # Store output

--- a/flash_sparse_attn/ops/triton/flash_gated_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_fwd.py
@@ -922,8 +922,8 @@ def _fwd_gated_base_kernel(
         scale_log2=softmax_scale_log2,
         final_scale=1.0,
         IS_LOG2=IS_SPLIT_KV,
+        CHECK_NAN=True,
     )
-    acc_o = activations.rescale_o(acc_o, row_scale, LAZY_RESCALE=False)
 
     # Store LSE
     if PACK_GQA:
@@ -935,6 +935,9 @@ def _fwd_gated_base_kernel(
         )
     else:
         tl.store(lse_ptrs, lse_tile, boundary_check=(0,), cache_modifier=".wb")
+
+    # Finalize rescale
+    acc_o = activations.rescale_o(acc_o, row_scale, LAZY_RESCALE=False)
 
     # Store output
     # When IS_SPLIT_KV, store float32 partial results.

--- a/flash_sparse_attn/ops/triton/flash_sparse_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_dec.py
@@ -469,12 +469,13 @@ def _dec_sparse_base_kernel(
         scale_log2=softmax_scale_log2,
         final_scale=1.0,
         IS_LOG2=True,
+        CHECK_NAN=False,
     )
 
     # Store LSE
     tl.store(lse_ptrs, lse_tile, boundary_check=(0,), cache_modifier=".wb")
 
-    # Final rescale
+    # Finalize rescale
     acc_o = activations.rescale_o(acc_o, row_scale, LAZY_RESCALE=False)
 
     # Store output
@@ -866,12 +867,13 @@ def _dec_sparse_sm90_kernel(
         scale_log2=softmax_scale_log2,
         final_scale=final_scale,
         IS_LOG2=True,
+        CHECK_NAN=False,
     )
 
     # Store LSE
     tl.store(lse_ptrs, lse_tile, boundary_check=(0,), cache_modifier=".wb")
 
-    # Final rescale
+    # Finalize rescale
     acc_o = activations.rescale_o(acc_o, row_scale, LAZY_RESCALE=False)
 
     # Store output

--- a/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
@@ -603,8 +603,8 @@ def _fwd_base_sparse_kernel(
         scale_log2=softmax_scale_log2,
         final_scale=1.0,
         IS_LOG2=IS_SPLIT_KV,
+        CHECK_NAN=True,
     )
-    acc_o = activations.rescale_o(acc_o, row_scale, LAZY_RESCALE=False)
 
     # Store LSE
     if PACK_GQA:
@@ -616,6 +616,9 @@ def _fwd_base_sparse_kernel(
         )
     else:
         tl.store(lse_ptrs, lse_tile, boundary_check=(0,), cache_modifier=".wb")
+
+    # Finalize rescale
+    acc_o = activations.rescale_o(acc_o, row_scale, LAZY_RESCALE=False)
 
     # Store output
     # When IS_SPLIT_KV, store float32 partial results.


### PR DESCRIPTION
## Summary

Add a compile-time `CHECK_NAN` constexpr parameter to the `finalize` function and propagate it through all forward and decoding Triton kernels. This allows the NaN/zero guard in the online-softmax finalization to be toggled per call-site, eliminating unnecessary branch and comparison instructions in decode kernels where `row_sum` is guaranteed non-zero by construction.

- **Forward kernels** (`flash_{dense,sparse,gated}_fwd.py`): `CHECK_NAN=True` — retains the safety guard since variable-length padding can produce all-zero rows.
- **Decode kernels** (`flash_{dense,sparse,gated}_dec.py`): `CHECK_NAN=False` — skips the guard because decode always processes at least one valid KV entry per head.

## Baseline

In the original `finalize` implementation, every call-site unconditionally executes:

```python
acc_o_is_zero_or_nan = (row_sum == 0.0) | (row_sum != row_sum)
row_scale = tl.where(acc_o_is_zero_or_nan, 1.0, 1.0 / row_sum) * final_scale
lse = tl.where(acc_o_is_zero_or_nan, float("-inf"), row_max * scale_log2 + tl.log2(row_sum))
```

This introduces two comparisons, two `tl.where` selects, and a multiply that are redundant on the decode path.

**Environment:** NVIDIA GPU with compute capability >= 8.0, Triton compiler.

## Approach

1. **`activations.py` — `finalize` function** (commit `047b71b`):
   - Added `CHECK_NAN: tl.constexpr` parameter.
   - When `CHECK_NAN=True`: original NaN/zero guard logic is preserved.
   - When `CHECK_NAN=False`: directly computes `row_scale = final_scale / row_sum` and `lse = row_max * scale_log2 + tl.log2(row_sum)` with no branching.
   - Also simplified `1.0 / row_sum * final_scale` → `final_scale / row_sum` (single division) in the guarded path.

2. **Decode kernels** (commit `4f4d63e`):
   - All 6 decode kernel functions (SM80 + SM90 variants for dense, sparse, gated) pass `CHECK_NAN=False` to `finalize`.
   - Minor comment normalization: `"Final rescale"` → `"Finalize rescale"` for consistency.

3. **Forward kernels** (commit `8c43e1e`):
   - All 3 forward kernel functions (dense, sparse, gated) pass `CHECK_NAN=True` to `finalize`.
   - Moved `rescale_o` call after LSE store (no semantic change — reordering independent operations for consistency with decode kernels).

## Results

The `CHECK_NAN=False` path eliminates per-row overhead in decode kernels:
- Removes 2 comparison ops (`== 0.0`, `!= row_sum`) per row tile.
- Removes 2 `tl.where` select ops per row tile.
- Reduces 1 multiply + 1 division → 1 division in `row_scale` computation.

Since `CHECK_NAN` is a `tl.constexpr`, the dead branch is eliminated at compile time — no runtime cost for the flag itself.

**Reproduce benchmarks:**
```bash
python tests/benchmark_forward.py
python tests/benchmark_decode.py
```

## Impact

- **Throughput:** Marginal improvement in decode kernel latency due to fewer ALU instructions in the finalization epilogue. The effect is most visible at small `seqlen_k` where finalization is a larger fraction of total kernel time.
- **Memory:** No change — no additional buffers or registers required.
- **Hardware:** All SM80+ GPUs benefit. SM90 FP8 decode path also updated.
- **Correctness:** Forward path retains full NaN/zero protection. Decode path relies on the invariant that at least one valid KV entry exists (enforced by input validation in `assert_dec_inputs`).

## Risks

- If a decode call-site is ever invoked with `seqlen_k=0` (empty KV cache), the `CHECK_NAN=False` path would produce `inf`/`nan` in LSE and output instead of the previous graceful `-inf` / `1.0` fallback. This is mitigated by existing input assertions that reject zero-length sequences.
- The `rescale_o` reordering in forward kernels is between two independent operations (LSE store and output rescale), so there is no correctness risk.

## Checklist

- [x] Linked issue provided #219 #222
- [x] Benchmarks included and reproducible
- [x] No accuracy regression
- [x] Docs updated
