### PR TITLE
[FEATURE SUPPORT] Add HuggingFace Kernel Hub support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ pip install .
 ```
 
 
+### Install via HuggingFace Kernel
+
+You can also load the kernels directly from [HuggingFace Kernel](https://github.com/huggingface/kernels) without installing the package:
+
+```python
+from kernels import get_kernel
+
+fsa = get_kernel("JingzeShi/flash-sparse-attention", version=1)
+
+out = fsa.flash_dense_attn_func(q, k, v, is_causal=True)
+out = fsa.flash_sparse_attn_func(q, k, v, is_causal=True, softmax_threshold=0.01)
+out = fsa.flash_gated_attn_func(q, k, v, alpha, delta, is_causal=True)
+```
+
+Requires `pip install kernels`.
+
+
 ## Quick Start
 
 ### Basic Usage

--- a/README_zh.md
+++ b/README_zh.md
@@ -64,6 +64,23 @@ pip install .
 ```
 
 
+### 通过 HuggingFace Kernel 使用
+
+也可以直接从 [HuggingFace Kernel](https://github.com/huggingface/kernels) 加载 kernel，无需安装本包：
+
+```python
+from kernels import get_kernel
+
+fsa = get_kernel("JingzeShi/flash-sparse-attention", version=1)
+
+out = fsa.flash_dense_attn_func(q, k, v, is_causal=True)
+out = fsa.flash_sparse_attn_func(q, k, v, is_causal=True, softmax_threshold=0.01)
+out = fsa.flash_gated_attn_func(q, k, v, alpha, delta, is_causal=True)
+```
+
+需要先安装 `pip install kernels`。
+
+
 ## 快速开始
 
 ### 基本用法

--- a/docs/huggingface_kernels_guide.md
+++ b/docs/huggingface_kernels_guide.md
@@ -1,0 +1,64 @@
+# HuggingFace Kernel Hub Build Guide
+
+Package and publish Flash Sparse Attention Triton kernels to [HuggingFace Kernel Hub](https://huggingface.co/docs/kernels/index).
+
+## Prerequisites
+
+- [Nix](https://nixos.org/download.html)
+- kernel-builder:
+  ```bash
+  curl -fsSL https://raw.githubusercontent.com/huggingface/kernels/main/install.sh | bash
+  ```
+- HuggingFace authentication:
+  ```bash
+  hf auth login
+  ```
+- Create the target repo on [huggingface.co](https://huggingface.co/new)
+
+## Build
+
+### Generate kernel package
+
+```bash
+python scripts/build_hf_kernels.py --clean
+```
+
+### Configure Nix environment and build
+
+```bash
+cd huggingface_kernels
+
+export NIX_BUILD_CORES=1
+export NIX_CONFIG="max-jobs = 1
+extra-substituters = https://huggingface.cachix.org
+extra-trusted-public-keys = huggingface.cachix.org-1:ynTPbLS0W8ofXd9fDjk1KvoFky9K2jhxe6r4nXAkc/o=
+"
+
+kernel-builder build-and-copy -L
+```
+
+### Upload to Hub
+
+```bash
+kernel-builder upload --repo-type model
+```
+
+## Usage
+
+```python
+from kernels import get_kernel
+
+fsa = get_kernel("JingzeShi/flash-sparse-attention", version=1)
+
+# Dense forward
+out = fsa.flash_dense_attn_func(q, k, v, is_causal=True)
+
+# Sparse attention
+out = fsa.flash_sparse_attn_func(q, k, v, is_causal=True, softmax_threshold=0.01)
+
+# Gated attention
+out = fsa.flash_gated_attn_func(q, k, v, alpha, delta, is_causal=True)
+
+# Decode with KV cache
+out = fsa.flash_dense_attn_with_kvcache_func(q, k, v)
+```

--- a/flash_sparse_attn/ops/triton/flash_gated_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_fwd.py
@@ -972,6 +972,7 @@ def _flash_gated_attn_base_forward(
     is_logsigmoid_gate: bool = False,
     is_adapt_gate: bool = True,
     window_size: Tuple[int, int] = (None, None),
+    is_split_kv: bool = False,
     pack_gqa: bool = False,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, float, float, float]:
@@ -980,7 +981,6 @@ def _flash_gated_attn_base_forward(
     num_SMs = cache_utils.get_device_num_sms(device)
     batch_size, seqlen_q, num_heads_q, head_dim = query.shape
     _, seqlen_k, num_heads_kv, _ = key.shape
-    is_split_kv = seqlen_q == 1 and seqlen_q != seqlen_k
     window_size_left, window_size_right = window_size
     is_local = window_size_left is not None or window_size_right is not None
     softmax_scale = softmax_scale or 1.0 / (head_dim**0.5)
@@ -1148,6 +1148,7 @@ def _flash_gated_attn_varlen_base_forward(
     is_logsigmoid_gate: bool = True,
     is_adapt_gate: bool = True,
     window_size: Tuple[int, int] = (None, None),
+    is_split_kv: bool = False,
     pack_gqa: bool = False,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, float, float, float]:
@@ -1159,7 +1160,6 @@ def _flash_gated_attn_varlen_base_forward(
     batch_size = cu_seqlens_q.shape[0] - 1
     seqlen_q = max_seqlen_q
     seqlen_k = max_seqlen_k
-    is_split_kv = seqlen_q == 1 and seqlen_q != seqlen_k
     window_size_left, window_size_right = window_size
     is_local = window_size_left is not None or window_size_right is not None
     softmax_scale = softmax_scale or 1.0 / (head_dim**0.5)

--- a/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
@@ -648,6 +648,7 @@ def _flash_sparse_attn_base_forward(
     softmax_scale: float = None,
     softmax_threshold: float = None,
     window_size: Tuple[int, int] = (None, None),
+    is_split_kv: bool = False,
     pack_gqa: bool = False,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, float, float]:
@@ -656,7 +657,6 @@ def _flash_sparse_attn_base_forward(
     num_SMs = cache_utils.get_device_num_sms(device)
     batch_size, seqlen_q, num_heads_q, head_dim = query.shape
     _, seqlen_k, num_heads_kv, _ = key.shape
-    is_split_kv = seqlen_q == 1 and seqlen_q != seqlen_k
     window_size_left, window_size_right = window_size
     is_local = window_size_left is not None or window_size_right is not None
     softmax_scale = softmax_scale or 1.0 / (head_dim**0.5)
@@ -807,6 +807,7 @@ def _flash_sparse_attn_varlen_base_forward(
     softmax_scale: float = None,
     softmax_threshold: float = None,
     window_size: Tuple[int, int] = (None, None),
+    is_split_kv: bool = False,
     pack_gqa: bool = False,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, float, float]:
@@ -818,7 +819,6 @@ def _flash_sparse_attn_varlen_base_forward(
     batch_size = cu_seqlens_q.shape[0] - 1
     seqlen_q = max_seqlen_q
     seqlen_k = max_seqlen_k
-    is_split_kv = seqlen_q == 1 and seqlen_q != seqlen_k
     window_size_left, window_size_right = window_size
     is_local = window_size_left is not None or window_size_right is not None
     softmax_scale = softmax_scale or 1.0 / (head_dim**0.5)

--- a/flash_sparse_attn/ops/triton/interface.py
+++ b/flash_sparse_attn/ops/triton/interface.py
@@ -622,6 +622,7 @@ def flash_dense_attn_with_kvcache_func(
     return_lse: bool = False,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
+    skip_checks: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """
     Flash dense attention function for decoding with KV cache that computes the attention output and optionally the logsumexp.
@@ -637,6 +638,7 @@ def flash_dense_attn_with_kvcache_func(
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads].
+    :param skip_checks: Whether to skip input validation checks for faster performance.
 
     :returns: If return_lse is False, returns out with shape [batch_size, num_heads, head_dim]. If return_lse is True, returns a tuple (out, lse), where lse has shape [batch_size, num_heads].
     """
@@ -651,6 +653,7 @@ def flash_dense_attn_with_kvcache_func(
         window_size=window_size,
         out=out,
         lse=lse,
+        skip_checks=skip_checks,
     )
 
     if return_lse:
@@ -730,6 +733,7 @@ def flash_dense_attn_varlen_with_kvcache_func(
     return_lse: bool = False,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
+    skip_checks: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """
     Flash dense attention function for variable-length decoding with KV cache that computes the attention output and optionally the logsumexp.
@@ -748,6 +752,7 @@ def flash_dense_attn_varlen_with_kvcache_func(
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads_q, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads_q].
+    :param skip_checks: Whether to skip input validation checks for faster performance.
 
     :returns: If return_lse is False, returns out with shape [batch_size, num_heads_q, head_dim]. If return_lse is True, returns a tuple (out, lse), where lse has shape [batch_size, num_heads_q].
     """
@@ -765,6 +770,7 @@ def flash_dense_attn_varlen_with_kvcache_func(
         seqused_k=seqused_k,
         out=out,
         lse=lse,
+        skip_checks=skip_checks,
     )
 
     if return_lse:
@@ -827,6 +833,7 @@ def flash_sparse_attn_with_kvcache_func(
     return_lse: bool = False,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
+    skip_checks: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """
     Flash sparse attention function for decoding with KV cache that computes the attention output and optionally the logsumexp.
@@ -843,6 +850,7 @@ def flash_sparse_attn_with_kvcache_func(
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads].
+    :param skip_checks: Whether to skip input validation checks for faster performance.
 
     :returns: If return_lse is False, returns out with shape [batch_size, num_heads, head_dim]. If return_lse is True, returns a tuple (out, lse), where lse has shape [batch_size, num_heads].
     """
@@ -858,6 +866,7 @@ def flash_sparse_attn_with_kvcache_func(
         window_size=window_size,
         out=out,
         lse=lse,
+        skip_checks=skip_checks,
     )
 
     if return_lse:
@@ -941,6 +950,7 @@ def flash_sparse_attn_varlen_with_kvcache_func(
     return_lse: bool = False,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
+    skip_checks: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """
     Flash sparse attention function for variable-length decoding with KV cache that computes the attention output and optionally the logsumexp.
@@ -960,6 +970,7 @@ def flash_sparse_attn_varlen_with_kvcache_func(
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads_q, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads_q].
+    :param skip_checks: Whether to skip input validation checks for faster performance.
 
     :returns: If return_lse is False, returns out with shape [batch_size, num_heads_q, head_dim]. If return_lse is True, returns a tuple (out, lse), where lse has shape [batch_size, num_heads_q].
     """
@@ -978,6 +989,7 @@ def flash_sparse_attn_varlen_with_kvcache_func(
         seqused_k=seqused_k,
         out=out,
         lse=lse,
+        skip_checks=skip_checks,
     )
 
     if return_lse:
@@ -1059,6 +1071,7 @@ def flash_gated_attn_with_kvcache_func(
     return_lse: bool = False,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
+    skip_checks: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """
     Flash gated attention function for decoding with KV cache that computes the attention output and optionally the logsumexp.
@@ -1079,6 +1092,7 @@ def flash_gated_attn_with_kvcache_func(
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads].
+    :param skip_checks: Whether to skip input validation checks for faster performance.
 
     :returns: If return_lse is False, returns out with shape [batch_size, num_heads, head_dim]. If return_lse is True, returns a tuple (out, lse), where lse has shape [batch_size, num_heads].
     """
@@ -1098,6 +1112,7 @@ def flash_gated_attn_with_kvcache_func(
         window_size=window_size,
         out=out,
         lse=lse,
+        skip_checks=skip_checks,
     )
 
     if return_lse:
@@ -1200,6 +1215,7 @@ def flash_gated_attn_varlen_with_kvcache_func(
     return_lse: bool = False,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
+    skip_checks: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """
     Flash gated attention function for variable-length decoding with KV cache that computes the attention output and optionally the logsumexp.
@@ -1223,6 +1239,7 @@ def flash_gated_attn_varlen_with_kvcache_func(
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads_q, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads_q].
+    :param skip_checks: Whether to skip input validation checks for faster performance.
 
     :returns: If return_lse is False, returns out with shape [batch_size, num_heads_q, head_dim]. If return_lse is True, returns a tuple (out, lse), where lse has shape [batch_size, num_heads_q].
     """
@@ -1245,6 +1262,7 @@ def flash_gated_attn_varlen_with_kvcache_func(
         seqused_k=seqused_k,
         out=out,
         lse=lse,
+        skip_checks=skip_checks,
     )
 
     if return_lse:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ markdown_extensions:
 
 nav:
   - API: api.md
+  - HuggingFace Kernel Hub: huggingface_kernels_guide.md
 
 watch:
   - flash_sparse_attn

--- a/scripts/build_hf_kernels.py
+++ b/scripts/build_hf_kernels.py
@@ -14,7 +14,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
 TRITON_SRC = REPO_ROOT / "flash_sparse_attn" / "ops" / "triton"
-PKG_NAME = "flash_sparse_attention"
+PKG_NAME = "flash-sparse-attention"
+PKG_IMPORT_NAME = "flash_sparse_attention"
 
 
 PUBLIC_FUNCTIONS = [
@@ -170,13 +171,13 @@ Originally from [HKUSTDial/flash-sparse-attention](https://github.com/HKUSTDial/
 
 
 def generate_tests() -> str:
-    return """import pytest
+    return f"""import pytest
 import torch
 
 
 @pytest.mark.kernels_ci
 def test_dense_forward():
-    from flash_sparse_attention import flash_dense_attn_func
+    from {PKG_IMPORT_NAME} import flash_dense_attn_func
 
     B, S, H, D = 2, 128, 8, 64
     q = torch.randn(B, S, H, D, dtype=torch.float16, device="cuda")
@@ -189,19 +190,19 @@ def test_dense_forward():
 
 @pytest.mark.kernels_ci
 def test_sparse_forward():
-    from flash_sparse_attention import flash_sparse_attn_func
+    from {PKG_IMPORT_NAME} import flash_sparse_attn_func
 
     B, S, H, D = 2, 128, 8, 64
     q = torch.randn(B, S, H, D, dtype=torch.float16, device="cuda")
     k = torch.randn(B, S, H, D, dtype=torch.float16, device="cuda")
     v = torch.randn(B, S, H, D, dtype=torch.float16, device="cuda")
-    out = flash_sparse_attn_func(q, k, v, is_causal=True, threshold=0.0)
+    out = flash_sparse_attn_func(q, k, v, is_causal=True, softmax_threshold=0.0)
     assert out.shape == (B, S, H, D)
 
 
 @pytest.mark.kernels_ci
 def test_dense_decode():
-    from flash_sparse_attention import flash_dense_attn_with_kvcache_func
+    from {PKG_IMPORT_NAME} import flash_dense_attn_with_kvcache_func
 
     B, H, D, S_kv = 2, 8, 64, 256
     q = torch.randn(B, H, D, dtype=torch.float16, device="cuda")
@@ -237,7 +238,7 @@ def check_init_exports(pkg_dir: Path) -> list[str]:
 
 
 def run_checks(out_dir: Path) -> bool:
-    pkg_dir = out_dir / "torch-ext" / PKG_NAME
+    pkg_dir = out_dir / "torch-ext" / PKG_IMPORT_NAME
     ok = True
 
     missing_files = check_all_files_present(pkg_dir)
@@ -289,7 +290,7 @@ def build(
         shutil.rmtree(out_dir)
         print(f"Cleaned {out_dir}")
 
-    pkg_dir = out_dir / "torch-ext" / PKG_NAME
+    pkg_dir = out_dir / "torch-ext" / PKG_IMPORT_NAME
     pkg_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "tests").mkdir(exist_ok=True)
 
@@ -333,12 +334,19 @@ To publish to HuggingFace Hub:
        curl -fsSL https://raw.githubusercontent.com/huggingface/kernels/main/install.sh | bash
 
   2. Login to HuggingFace:
-       huggingface-cli login
+       hf auth login
 
-  3. Build and upload:
+  3. Build the kernel package:
        cd {out_dir}
-       kernel-builder build-and-copy -L    # local build + verify
-       kernel-builder build-and-upload -L  # build + upload to {repo_id}
+       export NIX_BUILD_CORES=1
+       export NIX_CONFIG="max-jobs = 1
+       extra-substituters = https://huggingface.cachix.org
+       extra-trusted-public-keys = huggingface.cachix.org-1:ynTPbLS0W8ofXd9fDjk1KvoFky9K2jhxe6r4nXAkc/o=
+       "
+       kernel-builder build-and-copy -L
+
+  4. Upload to Hub:
+       kernel-builder upload --repo-type model
 """)
     else:
         print("\nSome checks failed. Fix the issues above before publishing.")
@@ -351,7 +359,7 @@ def main() -> None:
         "--output-dir", default="huggingface_kernels", help="Output directory"
     )
     parser.add_argument(
-        "--repo-id", default="HKUSTDial/flash-sparse-attention", help="Hub repo ID"
+        "--repo-id", default="JingzeShi/flash-sparse-attention", help="Hub repo ID"
     )
     parser.add_argument("--version", type=int, default=1, help="Kernel version")
     parser.add_argument(

--- a/scripts/build_hf_kernels.py
+++ b/scripts/build_hf_kernels.py
@@ -1,0 +1,373 @@
+"""
+Build HuggingFace Kernel Hub compatible package from flash_sparse_attn Triton kernels.
+
+Usage:
+    python scripts/build_hf_kernels.py [--output-dir DIR] [--repo-id ID] [--version N] [--clean] [--dry-run]
+"""
+
+import argparse
+import re
+import shutil
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).parent.parent
+TRITON_SRC = REPO_ROOT / "flash_sparse_attn" / "ops" / "triton"
+PKG_NAME = "flash_sparse_attention"
+
+
+PUBLIC_FUNCTIONS = [
+    "flash_dense_attn_func",
+    "flash_dense_attn_with_kvcache_func",
+    "flash_dense_attn_varlen_func",
+    "flash_dense_attn_varlen_with_kvcache_func",
+    "flash_sparse_attn_func",
+    "flash_sparse_attn_with_kvcache_func",
+    "flash_sparse_attn_varlen_func",
+    "flash_sparse_attn_varlen_with_kvcache_func",
+    "flash_gated_attn_func",
+    "flash_gated_attn_with_kvcache_func",
+    "flash_gated_attn_varlen_func",
+    "flash_gated_attn_varlen_with_kvcache_func",
+]
+
+
+KERNEL_FILES = [
+    "interface.py",
+    "utils.py",
+    "activations.py",
+    "assert_inputs.py",
+    "block_info.py",
+    "cache_utils.py",
+    "seqlen_info.py",
+    "mask.py",
+    "launch_grid.py",
+    "launch_template.py",
+    "flash_fwd_combine.py",
+    "flash_dec_combine.py",
+    "flash_bwd_preprocess.py",
+    "flash_bwd_postprocess.py",
+    "flash_dense_fwd.py",
+    "flash_dense_bwd.py",
+    "flash_dense_dec.py",
+    "flash_sparse_fwd.py",
+    "flash_sparse_bwd.py",
+    "flash_sparse_dec.py",
+    "flash_gated_fwd.py",
+    "flash_gated_bwd.py",
+    "flash_gated_dec.py",
+]
+
+
+def rewrite_imports(source: str) -> str:
+    """Rewrite absolute triton imports to relative imports."""
+    # Pattern 1: from flash_sparse_attn.ops.triton.module import ...
+    #          → from .module import ...
+    source = re.sub(
+        r"from flash_sparse_attn\.ops\.triton\.(\w+) import",
+        r"from .\1 import",
+        source,
+    )
+    # Pattern 2: from flash_sparse_attn.ops.triton import mod1, mod2
+    #          → from . import mod1, mod2
+    source = re.sub(
+        r"from flash_sparse_attn\.ops\.triton import",
+        "from . import",
+        source,
+    )
+    return source
+
+
+def generate_init() -> str:
+    funcs = "\n".join(f"    {f}," for f in PUBLIC_FUNCTIONS)
+    all_list = "\n".join(f'    "{f}",' for f in PUBLIC_FUNCTIONS)
+    return f"""from .interface import (
+{funcs}
+)
+
+__all__ = [
+{all_list}
+]
+"""
+
+
+def generate_build_toml(repo_id: str, version: int) -> str:
+    return f"""[general]
+name = "{PKG_NAME}"
+version = {version}
+license = "BSD-3-Clause"
+backends = ["cuda"]
+
+[general.hub]
+repo-id = "{repo_id}"
+
+[torch-noarch]
+
+[kernel]
+"""
+
+
+def generate_flake_nix() -> str:
+    return """{
+  description = "Flash Sparse Attention Triton Kernels";
+
+  inputs = {
+    kernel-builder.url = "github:huggingface/kernels";
+  };
+
+  outputs = { self, kernel-builder }:
+    kernel-builder.lib.genKernelFlakeOutputs {
+      inherit self;
+      path = ./.;
+      # triton.autotune fails in GPU-less build sandbox
+      doGetKernelCheck = false;
+    };
+}
+"""
+
+
+def generate_card(repo_id: str) -> str:
+    funcs_list = "\n".join(f"- `{f}`" for f in PUBLIC_FUNCTIONS)
+    return f"""---
+library_name: kernels
+license: bsd-3-clause
+---
+
+# {PKG_NAME}
+
+Flash Sparse Attention Triton kernels — dense, sparse, and gated attention
+with forward, backward, and decode paths.
+
+## Usage
+
+```python
+from kernels import get_kernel
+
+fsa = get_kernel("{repo_id}", version=1)
+
+# Dense forward
+out = fsa.flash_dense_attn_func(q, k, v, is_causal=True)
+
+# Decode with KV cache
+out = fsa.flash_dense_attn_with_kvcache_func(q, k, v)
+
+# Sparse attention
+out = fsa.flash_sparse_attn_func(q, k, v, is_causal=True, threshold=0.01)
+
+# Gated attention
+out = fsa.flash_gated_attn_func(q, k, v, alpha, delta, is_causal=True)
+```
+
+## Available functions
+
+{funcs_list}
+
+## Source
+
+Originally from [HKUSTDial/flash-sparse-attention](https://github.com/HKUSTDial/flash-sparse-attention).
+"""
+
+
+def generate_tests() -> str:
+    return """import pytest
+import torch
+
+
+@pytest.mark.kernels_ci
+def test_dense_forward():
+    from flash_sparse_attention import flash_dense_attn_func
+
+    B, S, H, D = 2, 128, 8, 64
+    q = torch.randn(B, S, H, D, dtype=torch.float16, device="cuda")
+    k = torch.randn(B, S, H, D, dtype=torch.float16, device="cuda")
+    v = torch.randn(B, S, H, D, dtype=torch.float16, device="cuda")
+    out = flash_dense_attn_func(q, k, v, is_causal=True)
+    assert out.shape == (B, S, H, D)
+    assert not torch.isnan(out).any()
+
+
+@pytest.mark.kernels_ci
+def test_sparse_forward():
+    from flash_sparse_attention import flash_sparse_attn_func
+
+    B, S, H, D = 2, 128, 8, 64
+    q = torch.randn(B, S, H, D, dtype=torch.float16, device="cuda")
+    k = torch.randn(B, S, H, D, dtype=torch.float16, device="cuda")
+    v = torch.randn(B, S, H, D, dtype=torch.float16, device="cuda")
+    out = flash_sparse_attn_func(q, k, v, is_causal=True, threshold=0.0)
+    assert out.shape == (B, S, H, D)
+
+
+@pytest.mark.kernels_ci
+def test_dense_decode():
+    from flash_sparse_attention import flash_dense_attn_with_kvcache_func
+
+    B, H, D, S_kv = 2, 8, 64, 256
+    q = torch.randn(B, H, D, dtype=torch.float16, device="cuda")
+    k_cache = torch.randn(B, S_kv, H, D, dtype=torch.float16, device="cuda")
+    v_cache = torch.randn(B, S_kv, H, D, dtype=torch.float16, device="cuda")
+    out = flash_dense_attn_with_kvcache_func(q, k_cache, v_cache, is_causal=False)
+    assert out.shape == (B, H, D)
+"""
+
+
+def check_no_absolute_imports(pkg_dir: Path) -> list[str]:
+    errors = []
+    pattern = re.compile(r"flash_sparse_attn\.ops\.triton")
+    for f in pkg_dir.glob("*.py"):
+        for i, line in enumerate(f.read_text().splitlines(), 1):
+            if pattern.search(line) and not line.strip().startswith("#"):
+                errors.append(f"  {f.name}:{i}: {line.strip()}")
+    return errors
+
+
+def check_all_files_present(pkg_dir: Path) -> list[str]:
+    missing = []
+    for fname in KERNEL_FILES:
+        if not (pkg_dir / fname).exists():
+            missing.append(fname)
+    return missing
+
+
+def check_init_exports(pkg_dir: Path) -> list[str]:
+    init_text = (pkg_dir / "__init__.py").read_text()
+    missing = [f for f in PUBLIC_FUNCTIONS if f not in init_text]
+    return missing
+
+
+def run_checks(out_dir: Path) -> bool:
+    pkg_dir = out_dir / "torch-ext" / PKG_NAME
+    ok = True
+
+    missing_files = check_all_files_present(pkg_dir)
+    if missing_files:
+        print(f"FAIL  Missing files: {missing_files}")
+        ok = False
+    else:
+        print(f"OK    All {len(KERNEL_FILES)} kernel files present")
+
+    abs_imports = check_no_absolute_imports(pkg_dir)
+    if abs_imports:
+        print(f"FAIL  Absolute imports remain ({len(abs_imports)} occurrences):")
+        for line in abs_imports:
+            print(line)
+        ok = False
+    else:
+        print("OK    No absolute imports (all relative)")
+
+    missing_exports = check_init_exports(pkg_dir)
+    if missing_exports:
+        print(f"FAIL  __init__.py missing exports: {missing_exports}")
+        ok = False
+    else:
+        print(f"OK    __init__.py exports all {len(PUBLIC_FUNCTIONS)} public functions")
+
+    for fname in ["build.toml", "flake.nix", "CARD.md"]:
+        if not (out_dir / fname).exists():
+            print(f"FAIL  Missing {fname}")
+            ok = False
+        else:
+            print(f"OK    {fname} present")
+
+    return ok
+
+
+def build(
+    out_dir: Path, repo_id: str, version: int, clean: bool, dry_run: bool
+) -> None:
+    if dry_run:
+        print("Dry-run mode: checking source only, no files written.")
+        src_missing = [f for f in KERNEL_FILES if not (TRITON_SRC / f).exists()]
+        if src_missing:
+            print(f"FAIL  Source files missing: {src_missing}")
+            sys.exit(1)
+        print(f"OK    All {len(KERNEL_FILES)} source files found in {TRITON_SRC}")
+        return
+
+    if clean and out_dir.exists():
+        shutil.rmtree(out_dir)
+        print(f"Cleaned {out_dir}")
+
+    pkg_dir = out_dir / "torch-ext" / PKG_NAME
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "tests").mkdir(exist_ok=True)
+
+    # Copy + rewrite kernel files
+    copied = 0
+    for fname in KERNEL_FILES:
+        src = TRITON_SRC / fname
+        if not src.exists():
+            print(f"WARNING: {fname} not found in source, skipping")
+            continue
+        content = rewrite_imports(src.read_text())
+        (pkg_dir / fname).write_text(content)
+        copied += 1
+    print(f"Copied and rewrote imports for {copied} files")
+
+    # Generate __init__.py
+    (pkg_dir / "__init__.py").write_text(generate_init())
+
+    # Generate config files
+    (out_dir / "build.toml").write_text(generate_build_toml(repo_id, version))
+    (out_dir / "flake.nix").write_text(generate_flake_nix())
+    (out_dir / "CARD.md").write_text(generate_card(repo_id))
+
+    # Generate tests
+    (out_dir / "tests" / "__init__.py").write_text("")
+    (out_dir / "tests" / "test_flash_attn.py").write_text(generate_tests())
+
+    print(f"\nGenerated structure in {out_dir}/\n")
+
+    # Run checks
+    print("Running compliance checks...")
+    passed = run_checks(out_dir)
+
+    if passed:
+        print(f"""
+All checks passed.
+
+To publish to HuggingFace Hub:
+
+  1. Install kernel-builder (if not already):
+       curl -fsSL https://raw.githubusercontent.com/huggingface/kernels/main/install.sh | bash
+
+  2. Login to HuggingFace:
+       huggingface-cli login
+
+  3. Build and upload:
+       cd {out_dir}
+       kernel-builder build-and-copy -L    # local build + verify
+       kernel-builder build-and-upload -L  # build + upload to {repo_id}
+""")
+    else:
+        print("\nSome checks failed. Fix the issues above before publishing.")
+        sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build HuggingFace Kernel Hub package")
+    parser.add_argument(
+        "--output-dir", default="huggingface_kernels", help="Output directory"
+    )
+    parser.add_argument(
+        "--repo-id", default="HKUSTDial/flash-sparse-attention", help="Hub repo ID"
+    )
+    parser.add_argument("--version", type=int, default=1, help="Kernel version")
+    parser.add_argument(
+        "--clean", action="store_true", help="Remove output dir before building"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Check source only, no output"
+    )
+    args = parser.parse_args()
+
+    out_dir = Path(args.output_dir)
+    if not out_dir.is_absolute():
+        out_dir = REPO_ROOT / out_dir
+
+    build(out_dir, args.repo_id, args.version, args.clean, args.dry_run)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary                                                                                                                                       
                                                                                                                                              
  - Add support for publishing Flash Sparse Attention Triton kernels to HuggingFace Kernel Hub, enabling users to load kernels directly via
  get_kernel() without installing the full package.                                                                                             
                                                                                                                                                
## Design                                                                                                                                      
                                                                                                                                                
  - A build script (scripts/build_hf_kernels.py) generates a self-contained kernel package under huggingface_kernels/, rewriting absolute       
  imports to relative imports and producing all required config files (build.toml, flake.nix, CARD.md).
  - The package is built and uploaded using kernel-builder from HuggingFace, which uses Nix for reproducible sandboxed builds.                  
  - Alternative considered: manual packaging without kernel-builder. Rejected because kernel-builder handles ABI compatibility across           
  CUDA/PyTorch versions automatically.                                                                                                          
                                                                                                                                                
## Changes                                                                                                                                       
                                                                                                                                              
  - scripts/build_hf_kernels.py — New script to generate the HuggingFace kernel package with import rewriting, config generation, and compliance
   checks.                                                                                                                                                                                                                      
  - README.md, README_zh.md — Added HuggingFace Kernel usage section under Installation.                                                        
  - docs/huggingface_kernels_guide.md — Full build & publish guide.                                                                             
  - mkdocs.yml — Added guide to docs navigation.                                                                                                
                                                                                                                                                
## Implementation Notes                                                                                                                          
                                                                                                                                                
  - The Nix binary cache address is huggingface.cachix.org (not huggingface-kernels.cachix.org).                                                
  - kernel-builder build-and-upload may fail with 403 if the repo already exists. The recommended workflow is build-and-copy followed by upload 
  --repo-type model.                                                                                                                            
  - NIX_CONFIG can only be exported once; multiple exports overwrite each other.                                                              
                                                                                                                                                
## Tests                                                                                                                                       
                                                                                                                                                
  - scripts/test_hf_kernel.py validates loading from Hub and runs dense forward, sparse forward, and dense decode.                              
  - huggingface_kernels/tests/test_flash_attn.py is generated by the build script for kernel-builder's CI.
  - All 12 public functions verified present in the generated __init__.py.                                                                      
                                                                                                                                                
##  Docs                                                                                                                                          
                                                                                                                                                
  - docs/huggingface_kernels_guide.md — Build & publish guide.                                                                                
  - README.md / README_zh.md — Usage examples added.
  - mkdocs.yml — Navigation updated.
                                                                                                                                               