### PR TITLE
Refactor MASK_CAUSAL parameter to use IS_CAUSAL

### DIFF
--- a/flash_sparse_attn/ops/triton/flash_dense_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_bwd.py
@@ -510,7 +510,7 @@ def _bwd_dense_kernel(
                     TILE_M=TILE_M,
                     TILE_N=TILE_N,
                     IS_MASK=True,
-                    MASK_CAUSAL=True,
+                    MASK_CAUSAL=IS_CAUSAL,
                     MASK_LOCAL=True if IS_LOCAL else False,
                 )
             )

--- a/flash_sparse_attn/ops/triton/flash_dense_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_fwd.py
@@ -449,7 +449,7 @@ def _fwd_dense_kernel(
                 TILE_N=TILE_N,
                 QHEAD_PER_KVHEAD_PACKGQA=QHEAD_PER_KVHEAD_PACKGQA,
                 IS_MASK=True,
-                MASK_CAUSAL=True,
+                MASK_CAUSAL=IS_CAUSAL,
                 MASK_LOCAL=True if IS_LOCAL else False,
                 CHECK_INF=True,
             )

--- a/flash_sparse_attn/ops/triton/flash_gated_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_bwd.py
@@ -760,7 +760,7 @@ def _bwd_gated_kernel(
                 TILE_M=TILE_M,
                 TILE_N=TILE_N,
                 IS_MASK=True,
-                MASK_CAUSAL=True,
+                MASK_CAUSAL=IS_CAUSAL,
                 MASK_LOCAL=True if IS_LOCAL else False,
                 IS_LOGSIGMOID_GATE=IS_LOGSIGMOID_GATE,
             )

--- a/flash_sparse_attn/ops/triton/flash_gated_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_fwd.py
@@ -664,7 +664,7 @@ def _fwd_gated_kernel(
                 TILE_N=TILE_N,
                 QHEAD_PER_KVHEAD_PACKGQA=QHEAD_PER_KVHEAD_PACKGQA,
                 IS_MASK=True,
-                MASK_CAUSAL=True,
+                MASK_CAUSAL=IS_CAUSAL,
                 MASK_LOCAL=True if IS_LOCAL else False,
                 IS_LOGSIGMOID_GATE=IS_LOGSIGMOID_GATE,
                 CHECK_INF=True,

--- a/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
@@ -545,7 +545,7 @@ def _bwd_sparse_kernel(
                     TILE_M=TILE_M,
                     TILE_N=TILE_N,
                     IS_MASK=True,
-                    MASK_CAUSAL=True,
+                    MASK_CAUSAL=IS_CAUSAL,
                     MASK_LOCAL=True if IS_LOCAL else False,
                 )
             )

--- a/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
@@ -471,7 +471,7 @@ def _fwd_sparse_kernel(
                     TILE_N=TILE_N,
                     QHEAD_PER_KVHEAD_PACKGQA=QHEAD_PER_KVHEAD_PACKGQA,
                     IS_MASK=True,
-                    MASK_CAUSAL=True,
+                    MASK_CAUSAL=IS_CAUSAL,
                     MASK_LOCAL=True if IS_LOCAL else False,
                     CHECK_INF=True,
                 )


### PR DESCRIPTION
## Summary
- This change refactors the MASK_CAUSAL parameter to utilize the IS_CAUSAL variable in kernel configurations for both dense and sparse operations.

## Root Cause
- The previous implementation used a hardcoded value for MASK_CAUSAL, which could lead to inconsistencies.

## Changes
- Updated the MASK_CAUSAL parameter in multiple kernel functions to reference IS_CAUSAL instead of a static True value.

## Reproduction
- No specific bug reproduction steps as this is a refactor, but ensure that kernel operations function as expected with the new parameterization.

## Tests
- Existing tests should cover the functionality; validation performed through regression testing.

## Compatibility
- No backward compatibility issues anticipated.

## Checklist
- [ ] Linked issue provided
- [ ] Adds or updates tests
- [ ] Updates docs if needed
- [ ] No perf regressions

