### PR TITLE
[Feature] Fused FP8 Projection Kernels (forward + backward)

### DIFF
--- a/flash_sparse_attn/ops/triton/flash_proj_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_proj_bwd.py
@@ -1,0 +1,28 @@
+"""
+Requires: triton-kernels == 3.6
+    git clone https://github.com/triton-lang/kernels.git && cd kernels
+    git checkout v3.6.0
+    pip install -e .
+"""
+
+import torch
+from triton_kernels.matmul_ogs import matmul_ogs, PrecisionConfig
+
+
+def _flash_proj_backward(
+    dout: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    batch_size, seqlen, out_features = dout.shape
+    in_features = input.shape[-1]
+
+    dy = dout.view(batch_size * seqlen, out_features)
+    x = input.view(batch_size * seqlen, in_features)
+
+    precision_config = PrecisionConfig(out_dtype=dy.dtype)
+
+    dx = matmul_ogs(dy, weight, None, precision_config=precision_config)
+    dw = matmul_ogs(dy.T, x, None, precision_config=precision_config)
+
+    return dx.view(batch_size, seqlen, in_features), dw

--- a/flash_sparse_attn/ops/triton/flash_proj_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_proj_fwd.py
@@ -1,0 +1,52 @@
+"""
+Requires: triton-kernels == 3.6
+    git clone https://github.com/triton-lang/kernels.git && cd kernels
+    git checkout v3.6.0
+    pip install -e .
+"""
+
+import torch
+from triton_kernels.matmul_ogs import matmul_ogs, PrecisionConfig, FlexCtx
+from triton_kernels.numerics import InFlexData, OutFlexData
+
+
+def _flash_proj_forward(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    out_dtype: torch.dtype = torch.float8_e5m2,
+    prev_scale: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    batch_size, seqlen, in_features = input.shape
+    out_features = weight.shape[0]
+    device = input.device
+
+    x = input.view(batch_size * seqlen, in_features)
+
+    if prev_scale is None:
+        expected_scale = torch.tensor([1.0], dtype=torch.float32, device=device)
+    else:
+        expected_scale = prev_scale.view(1).float()
+
+    actual_scale = torch.zeros(1, dtype=torch.float32, device=device)
+
+    out_flex = OutFlexData(
+        dtype=out_dtype,
+        expected_scale=expected_scale,
+        actual_scale=actual_scale,
+        checksum_scale=None,
+    )
+
+    precision_config = PrecisionConfig(
+        flex_ctx=FlexCtx(
+            lhs_data=InFlexData(),
+            rhs_data=InFlexData(),
+            out_data=out_flex,
+        ),
+        out_dtype=out_dtype,
+    )
+
+    out = matmul_ogs(x, weight.T, None, precision_config=precision_config)
+
+    descale = precision_config.flex_ctx.out_data.actual_scale.clone()
+
+    return out.view(batch_size, seqlen, out_features), descale

--- a/flash_sparse_attn/ops/triton/interface.py
+++ b/flash_sparse_attn/ops/triton/interface.py
@@ -38,6 +38,8 @@ from flash_sparse_attn.ops.triton.flash_gated_dec import (
     _flash_gated_attn_decode,
     _flash_gated_attn_varlen_decode,
 )
+from flash_sparse_attn.ops.triton.flash_proj_fwd import _flash_proj_forward
+from flash_sparse_attn.ops.triton.flash_proj_bwd import _flash_proj_backward
 from flash_sparse_attn.ops.triton.utils import ensure_contiguous
 from flash_sparse_attn.ops.triton import quant
 
@@ -812,6 +814,36 @@ class FlashGatedAttnVarlenFunc(torch.autograd.Function):
         )
 
         return dq, dk, dv, da, dd, *((None,) * 20)
+
+
+class FlashProjFunc(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        out_dtype: torch.dtype = torch.float8_e4m3fn,
+        prev_scale: Optional[torch.Tensor] = None,
+    ):
+        out, descale = _flash_proj_forward(
+            input=input,
+            weight=weight,
+            out_dtype=out_dtype,
+            prev_scale=prev_scale,
+        )
+
+        ctx.save_for_backward(input, weight)
+
+        return out, descale
+
+    @staticmethod
+    def backward(ctx, dout: torch.Tensor, _dscale: torch.Tensor):
+        input, weight = ctx.saved_tensors
+        dout = dout.to(input.dtype)
+
+        dinput, dweight = _flash_proj_backward(dout=dout, input=input, weight=weight)
+
+        return dinput, dweight, None, None
 
 
 def flash_dense_attn_func(
@@ -1745,3 +1777,22 @@ def flash_gated_attn_varlen_with_kvcache_func(
     if return_lse:
         return out, lse
     return out
+
+
+def flash_proj_func(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    out_dtype: torch.dtype = torch.float8_e5m2,
+    prev_scale: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Fused linear projection with quantized output and per-tensor scale.
+
+    :param input: Input tensor of shape [batch_size, seqlen, in_features].
+    :param weight: Weights tensor of shape [out_features, in_features].
+    :param out_dtype: Target output dtype.
+    :param prev_scale: Per-tensor scale from the previous forward.
+
+    :returns: Tuple of (out, actual_scale), where out has shape [batch_size, seqlen, out_features].
+    """
+    return FlashProjFunc.apply(input, weight, out_dtype, prev_scale)


### PR DESCRIPTION
Closes #308

## Summary

Add fused FP8 projection forward/backward kernels using `triton-kernels` `matmul_ogs`, enabling an end-to-end low-precision attention pipeline on Hopper (SM90+).

## Changes

- **`flash_proj_fwd.py`** — Forward projection (`input @ weight.T`) with `OutFlexData` dynamic scaling, producing FP8 output + descale factor. Supports delayed scaling via optional `prev_scale`.
- **`flash_proj_bwd.py`** — Backward pass computing `dX = dY @ W` and `dW = dY.T @ X` through `matmul_ogs`.

## How it works

The forward kernel directly emits FP8 output with a `descale` tensor that can be passed as `query_scale` / `key_scale` / `value_scale` to existing FP8 decode kernels, eliminating redundant BF16 ↔ FP8 round-trips between projection and attention.

## Dependencies

- `triton-kernels == 3.6` (`triton-lang/kernels` v3.6.0)