### PR TITLE
Refine tile-level sparse softmax skipping

### DIFF
--- a/flash_sparse_attn/ops/triton/activations.py
+++ b/flash_sparse_attn/ops/triton/activations.py
@@ -131,7 +131,7 @@ def online_sparse_softmax(
 
     # Update skip condition based on threshold
     row_max_diff_log2 = (row_max_curr - row_max) * scale_log2
-    skip_softmax = tl.min(row_max_diff_log2 < softmax_threshold_log2)
+    skip_softmax = tl.max(row_max_diff_log2 - softmax_threshold_log2) < 0.0
 
     # Return zero attention weights
     if skip_softmax:

--- a/flash_sparse_attn/ops/triton/activations.py
+++ b/flash_sparse_attn/ops/triton/activations.py
@@ -104,7 +104,6 @@ def online_softmax(
 @triton.jit
 def online_sparse_softmax(
     acc_s,
-    block_max,
     row_max,
     row_sum,
     scale_log2,
@@ -112,18 +111,16 @@ def online_sparse_softmax(
     CHECK_INF: tl.constexpr,
 ):
     """
-    Apply online sparse softmax to acc_s, and update block_max, row_max and row_sum.
+    Apply online sparse softmax to acc_s, and update row_max and row_sum.
 
     :param acc_s: Attention scores tensor of shape [BLOCK_M, BLOCK_N].
-    :param block_max: Running block-wise maximum scalar, init to -inf.
     :param row_max: Current maximum values per row of shape [BLOCK_M], init to -inf.
     :param row_sum: Current sum values per row of shape [BLOCK_M], init to 0.
     :param scale_log2: Log2 of the scaling factor to be applied to acc_s.
-    :param softmax_threshold_log2: Threshold in log2-domain for block-level skip. If > -inf and block max is below threshold relative to running max, skip softmax update.
+    :param softmax_threshold_log2: Threshold in log2-domain for block-level skip.
     :param CHECK_INF: Boolean flag indicating if -inf row_max should be clamped to 0.
 
     :return p: Softmax probabilities tensor of shape [BLOCK_M, BLOCK_N].
-    :return block_max_new: Updated block-wise maximum scalar.
     :return row_max_new: Updated maximum values per row of shape [BLOCK_M].
     :return row_sum_new: Updated sum values per row of shape [BLOCK_M].
     :return row_scale: Scaling factors per row of shape [BLOCK_M].
@@ -132,24 +129,17 @@ def online_sparse_softmax(
     # Compute current row max
     row_max_curr = tl.max(acc_s, axis=1)
 
-    # Compute current block max
-    block_max_curr = tl.max(row_max_curr)
-
     # Update skip condition based on threshold
-    block_max_diff_log2 = (block_max_curr - block_max) * scale_log2
-    skip_softmax = block_max_diff_log2 < softmax_threshold_log2
+    row_max_diff_log2 = (row_max_curr - row_max) * scale_log2
+    skip_softmax = tl.min(row_max_diff_log2 < softmax_threshold_log2)
 
     # Return zero attention weights
     if skip_softmax:
         p = acc_s * 0.0
-        block_max_new = block_max
         row_max_new = row_max
         row_sum_new = row_sum
         row_scale = row_max * 0.0 + 1.0
     else:
-        # Update block max
-        block_max_new = tl.maximum(block_max_curr, block_max)
-
         # Update row max
         row_max_new = tl.maximum(row_max_curr, row_max)
 
@@ -170,7 +160,7 @@ def online_sparse_softmax(
         row_sum_cur = tl.sum(p, axis=1)
         row_sum_new = row_sum * row_scale + row_sum_cur
 
-    return p, block_max_new, row_max_new, row_sum_new, row_scale, skip_softmax
+    return p, row_max_new, row_sum_new, row_scale, skip_softmax
 
 
 @triton.jit

--- a/flash_sparse_attn/ops/triton/flash_gated_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_bwd.py
@@ -118,7 +118,7 @@ def _bwd_inner_gated_kernel(
         )
 
         # Update skip condition based on threshold
-        skip_softmax = tl.min(p_log2 < softmax_threshold_log2[None, :])
+        skip_softmax = tl.max(p_log2 - softmax_threshold_log2[None, :]) < 0.0
 
         if not skip_softmax:
             # Compute attention weights

--- a/flash_sparse_attn/ops/triton/flash_gated_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_bwd.py
@@ -36,7 +36,6 @@ def _bwd_inner_gated_kernel(
     acc_dk,
     acc_dv,
     acc_dd,
-    block_max,
     k_tile,
     v_tile,
     d_tile,
@@ -107,8 +106,11 @@ def _bwd_inner_gated_kernel(
                 MASK_LOCAL=MASK_LOCAL,
             )
 
-        # Compute current block max
-        block_max_curr = tl.max(acc_s)
+        # Load LSE
+        lse_log2 = ptrs_sched.load_lse(config, lse_ptrs, m_block)
+
+        # Compute attention weights in log2-domain
+        p_log2 = acc_s * config.softmax_scale_log2 - lse_log2[None, :]
 
         # Compute softmax threshold for this m_block
         softmax_threshold_log2 = config.get_softmax_threshold_log2(
@@ -116,20 +118,11 @@ def _bwd_inner_gated_kernel(
         )
 
         # Update skip condition based on threshold
-        block_max_diff_log2 = (block_max_curr - block_max) * config.softmax_scale_log2
-        skip_softmax = block_max_diff_log2 < softmax_threshold_log2
+        skip_softmax = tl.min(p_log2 < softmax_threshold_log2[None, :])
 
         if not skip_softmax:
-            # Update block max
-            block_max = tl.maximum(block_max_curr, block_max)
-
-            # Load LSE
-            lse_log2 = ptrs_sched.load_lse(config, lse_ptrs, m_block)
-
             # Compute attention weights
-            p = activations.exp2(
-                acc_s * config.softmax_scale_log2 - lse_log2[None, :]
-            ).to(q_tile.dtype)
+            p = activations.exp2(p_log2).to(q_tile.dtype)
 
             # Load output gradients tile
             do_tile = ptrs_sched.load_do(config, do_ptrs, m_block)
@@ -168,7 +161,6 @@ def _bwd_inner_gated_kernel(
         acc_dk,
         acc_dv,
         acc_dd,
-        block_max,
         gate_max,
     )
 
@@ -401,7 +393,6 @@ def _bwd_gated_kernel(
 
     # Initialize accumulators
     gate_max = tl.full((), float("-inf"), dtype=tl.float32)
-    block_max = tl.full((), float("-inf"), dtype=tl.float32)
     acc_dk = tl.zeros((TILE_N, TILE_K), dtype=tl.float32)
     acc_dv = tl.zeros((TILE_N, TILE_K), dtype=tl.float32)
     acc_dd = tl.zeros((TILE_N,), dtype=tl.float32)
@@ -426,7 +417,6 @@ def _bwd_gated_kernel(
                 acc_dk,
                 acc_dv,
                 acc_dd,
-                block_max,
                 gate_max,
             ) = _bwd_inner_gated_kernel(
                 config=config,
@@ -436,7 +426,6 @@ def _bwd_gated_kernel(
                 acc_dk=acc_dk,
                 acc_dv=acc_dv,
                 acc_dd=acc_dd,
-                block_max=block_max,
                 k_tile=k_tile,
                 v_tile=v_tile,
                 d_tile=d_tile,
@@ -465,7 +454,6 @@ def _bwd_gated_kernel(
                 acc_dk,
                 acc_dv,
                 acc_dd,
-                block_max,
                 gate_max,
             ) = _bwd_inner_gated_kernel(
                 config=config,
@@ -475,7 +463,6 @@ def _bwd_gated_kernel(
                 acc_dk=acc_dk,
                 acc_dv=acc_dv,
                 acc_dd=acc_dd,
-                block_max=block_max,
                 k_tile=k_tile,
                 v_tile=v_tile,
                 d_tile=d_tile,
@@ -506,7 +493,6 @@ def _bwd_gated_kernel(
                     acc_dk,
                     acc_dv,
                     acc_dd,
-                    block_max,
                     gate_max,
                 ) = _bwd_inner_gated_kernel(
                     config=config,
@@ -516,7 +502,6 @@ def _bwd_gated_kernel(
                     acc_dk=acc_dk,
                     acc_dv=acc_dv,
                     acc_dd=acc_dd,
-                    block_max=block_max,
                     k_tile=k_tile,
                     v_tile=v_tile,
                     d_tile=d_tile,
@@ -549,7 +534,6 @@ def _bwd_gated_kernel(
                     acc_dk,
                     acc_dv,
                     acc_dd,
-                    block_max,
                     gate_max,
                 ) = _bwd_inner_gated_kernel(
                     config=config,
@@ -559,7 +543,6 @@ def _bwd_gated_kernel(
                     acc_dk=acc_dk,
                     acc_dv=acc_dv,
                     acc_dd=acc_dd,
-                    block_max=block_max,
                     k_tile=k_tile,
                     v_tile=v_tile,
                     d_tile=d_tile,
@@ -589,7 +572,6 @@ def _bwd_gated_kernel(
                     acc_dk,
                     acc_dv,
                     acc_dd,
-                    block_max,
                     gate_max,
                 ) = _bwd_inner_gated_kernel(
                     config=config,
@@ -599,7 +581,6 @@ def _bwd_gated_kernel(
                     acc_dk=acc_dk,
                     acc_dv=acc_dv,
                     acc_dd=acc_dd,
-                    block_max=block_max,
                     k_tile=k_tile,
                     v_tile=v_tile,
                     d_tile=d_tile,
@@ -683,7 +664,7 @@ def _flash_gated_attn_backward(
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
     softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else head_dim / seqlen_k
+        softmax_threshold if softmax_threshold is not None else 1 / seqlen_k
     )
     gate_threshold = (
         gate_threshold if gate_threshold is not None else head_dim / seqlen_k
@@ -996,7 +977,7 @@ def _flash_gated_attn_varlen_backward(
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
     softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else head_dim / seqlen_k
+        softmax_threshold if softmax_threshold is not None else 1 / seqlen_k
     )
     gate_threshold = (
         gate_threshold if gate_threshold is not None else head_dim / seqlen_k

--- a/flash_sparse_attn/ops/triton/flash_gated_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_dec.py
@@ -43,7 +43,6 @@ def _dec_inner_gated_kernel(
     gate_max,
     row_max,
     row_sum,
-    block_max,
     n_block,
     n_block_min,
     IS_MASK: tl.constexpr,
@@ -77,10 +76,9 @@ def _dec_inner_gated_kernel(
             )
 
         # Apply online softmax
-        p, block_max, row_max, row_sum, row_scale, skip_softmax = (
+        p, row_max, row_sum, row_scale, skip_softmax = (
             softmax_sched.online_sparse_softmax(
                 acc_s=acc_s,
-                block_max=block_max,
                 row_max=row_max,
                 row_sum=row_sum,
                 softmax_threshold_log2=config.softmax_threshold_log2,
@@ -134,7 +132,6 @@ def _dec_inner_gated_kernel(
         gate_max,
         row_max,
         row_sum,
-        block_max,
     )
 
 
@@ -311,7 +308,6 @@ def _dec_gated_kernel(
     gate_max = tl.full((), float("-inf"), dtype=tl.float32)
     row_max = tl.full((TILE_M,), float("-inf"), dtype=tl.float32)
     row_sum = tl.zeros((TILE_M,), dtype=tl.float32)
-    block_max = tl.full((), float("-inf"), dtype=tl.float32)
     acc_o = tl.zeros((TILE_M, TILE_K), dtype=tl.float32)
 
     # Load query tile
@@ -364,7 +360,6 @@ def _dec_gated_kernel(
             gate_max,
             row_max,
             row_sum,
-            block_max,
         ) = _dec_inner_gated_kernel(
             config=config,
             ptrs_sched=ptrs_sched,
@@ -383,7 +378,6 @@ def _dec_gated_kernel(
             gate_max=gate_max,
             row_max=row_max,
             row_sum=row_sum,
-            block_max=block_max,
             n_block=n_block,
             n_block_min=block_sched.n_block_max_no_mask,
             IS_MASK=True,
@@ -431,7 +425,6 @@ def _dec_gated_kernel(
                 gate_max,
                 row_max,
                 row_sum,
-                block_max,
             ) = _dec_inner_gated_kernel(
                 config=config,
                 ptrs_sched=ptrs_sched,
@@ -450,7 +443,6 @@ def _dec_gated_kernel(
                 gate_max=gate_max,
                 row_max=row_max,
                 row_sum=row_sum,
-                block_max=block_max,
                 n_block=n_block,
                 n_block_min=block_sched.n_block_min,
                 IS_MASK=False,
@@ -505,7 +497,6 @@ def _dec_gated_kernel(
                     gate_max,
                     row_max,
                     row_sum,
-                    block_max,
                 ) = _dec_inner_gated_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
@@ -524,7 +515,6 @@ def _dec_gated_kernel(
                     gate_max=gate_max,
                     row_max=row_max,
                     row_sum=row_sum,
-                    block_max=block_max,
                     n_block=n_block,
                     n_block_min=block_sched.n_block_window_max_no_mask,
                     IS_MASK=True,
@@ -581,7 +571,6 @@ def _dec_gated_kernel(
                     gate_max,
                     row_max,
                     row_sum,
-                    block_max,
                 ) = _dec_inner_gated_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
@@ -600,7 +589,6 @@ def _dec_gated_kernel(
                     gate_max=gate_max,
                     row_max=row_max,
                     row_sum=row_sum,
-                    block_max=block_max,
                     n_block=n_block,
                     n_block_min=block_sched.n_block_window_min_no_mask,
                     IS_MASK=False,
@@ -654,7 +642,6 @@ def _dec_gated_kernel(
                     gate_max,
                     row_max,
                     row_sum,
-                    block_max,
                 ) = _dec_inner_gated_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
@@ -673,7 +660,6 @@ def _dec_gated_kernel(
                     gate_max=gate_max,
                     row_max=row_max,
                     row_sum=row_sum,
-                    block_max=block_max,
                     n_block=n_block,
                     n_block_min=block_sched.n_block_window_min,
                     IS_MASK=True,
@@ -745,7 +731,7 @@ def _flash_gated_attn_decode(
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
     softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else head_dim / seqlen_k
+        softmax_threshold if softmax_threshold is not None else 1 / seqlen_k
     )
     gate_threshold = (
         gate_threshold if gate_threshold is not None else head_dim / seqlen_k
@@ -961,7 +947,7 @@ def _flash_gated_attn_varlen_decode(
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
     softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else head_dim / seqlen_k
+        softmax_threshold if softmax_threshold is not None else 1 / seqlen_k
     )
     gate_threshold = (
         gate_threshold if gate_threshold is not None else head_dim / seqlen_k

--- a/flash_sparse_attn/ops/triton/flash_gated_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_fwd.py
@@ -43,7 +43,6 @@ def _fwd_inner_gated_kernel(
     gate_max,
     row_max,
     row_sum,
-    block_max,
     n_block,
     n_block_min,
     IS_MASK: tl.constexpr,
@@ -79,10 +78,9 @@ def _fwd_inner_gated_kernel(
             )
 
         # Apply online sparse softmax
-        p, block_max, row_max, row_sum, row_scale, skip_softmax = (
+        p, row_max, row_sum, row_scale, skip_softmax = (
             softmax_sched.online_sparse_softmax(
                 acc_s=acc_s,
-                block_max=block_max,
                 row_max=row_max,
                 row_sum=row_sum,
                 softmax_threshold_log2=config.softmax_threshold_log2,
@@ -135,7 +133,6 @@ def _fwd_inner_gated_kernel(
         gate_max,
         row_max,
         row_sum,
-        block_max,
     )
 
 
@@ -329,7 +326,6 @@ def _fwd_gated_kernel(
     gate_max = tl.full((), float("-inf"), dtype=tl.float32)
     row_max = tl.full((TILE_M,), float("-inf"), dtype=tl.float32)
     row_sum = tl.zeros((TILE_M,), dtype=tl.float32)
-    block_max = tl.full((), float("-inf"), dtype=tl.float32)
     acc_o = tl.zeros((TILE_M, TILE_K), dtype=tl.float32)
 
     # Load query tile
@@ -384,7 +380,6 @@ def _fwd_gated_kernel(
                 gate_max,
                 row_max,
                 row_sum,
-                block_max,
             ) = _fwd_inner_gated_kernel(
                 config=config,
                 ptrs_sched=ptrs_sched,
@@ -403,7 +398,6 @@ def _fwd_gated_kernel(
                 gate_max=gate_max,
                 row_max=row_max,
                 row_sum=row_sum,
-                block_max=block_max,
                 n_block=n_block,
                 n_block_min=block_sched.n_block_max_no_mask,
                 IS_MASK=True,
@@ -425,7 +419,6 @@ def _fwd_gated_kernel(
             gate_max,
             row_max,
             row_sum,
-            block_max,
         ) = _fwd_inner_gated_kernel(
             config=config,
             ptrs_sched=ptrs_sched,
@@ -444,7 +437,6 @@ def _fwd_gated_kernel(
             gate_max=gate_max,
             row_max=row_max,
             row_sum=row_sum,
-            block_max=block_max,
             n_block=n_block,
             n_block_min=n_block,
             IS_MASK=True,
@@ -493,7 +485,6 @@ def _fwd_gated_kernel(
                 gate_max,
                 row_max,
                 row_sum,
-                block_max,
             ) = _fwd_inner_gated_kernel(
                 config=config,
                 ptrs_sched=ptrs_sched,
@@ -512,7 +503,6 @@ def _fwd_gated_kernel(
                 gate_max=gate_max,
                 row_max=row_max,
                 row_sum=row_sum,
-                block_max=block_max,
                 n_block=n_block,
                 n_block_min=block_sched.n_block_min,
                 IS_MASK=False,
@@ -568,7 +558,6 @@ def _fwd_gated_kernel(
                     gate_max,
                     row_max,
                     row_sum,
-                    block_max,
                 ) = _fwd_inner_gated_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
@@ -587,7 +576,6 @@ def _fwd_gated_kernel(
                     gate_max=gate_max,
                     row_max=row_max,
                     row_sum=row_sum,
-                    block_max=block_max,
                     n_block=n_block,
                     n_block_min=block_sched.n_block_window_max_no_mask,
                     IS_MASK=True,
@@ -645,7 +633,6 @@ def _fwd_gated_kernel(
                     gate_max,
                     row_max,
                     row_sum,
-                    block_max,
                 ) = _fwd_inner_gated_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
@@ -664,7 +651,6 @@ def _fwd_gated_kernel(
                     gate_max=gate_max,
                     row_max=row_max,
                     row_sum=row_sum,
-                    block_max=block_max,
                     n_block=n_block,
                     n_block_min=block_sched.n_block_window_min_no_mask,
                     IS_MASK=False,
@@ -719,7 +705,6 @@ def _fwd_gated_kernel(
                     gate_max,
                     row_max,
                     row_sum,
-                    block_max,
                 ) = _fwd_inner_gated_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
@@ -738,7 +723,6 @@ def _fwd_gated_kernel(
                     gate_max=gate_max,
                     row_max=row_max,
                     row_sum=row_sum,
-                    block_max=block_max,
                     n_block=n_block,
                     n_block_min=block_sched.n_block_window_min,
                     IS_MASK=True,
@@ -815,7 +799,7 @@ def _flash_gated_attn_forward(
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
     softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else head_dim / seqlen_k
+        softmax_threshold if softmax_threshold is not None else 1 / seqlen_k
     )
     gate_threshold = (
         gate_threshold if gate_threshold is not None else head_dim / seqlen_k
@@ -1063,7 +1047,7 @@ def _flash_gated_attn_varlen_forward(
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
     softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else head_dim / seqlen_k
+        softmax_threshold if softmax_threshold is not None else 1 / seqlen_k
     )
     gate_threshold = (
         gate_threshold if gate_threshold is not None else head_dim / seqlen_k

--- a/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
@@ -33,7 +33,6 @@ def _bwd_inner_sparse_kernel(
     mask_sched,
     acc_dk,
     acc_dv,
-    block_max,
     k_tile,
     v_tile,
     q_ptrs,
@@ -61,8 +60,11 @@ def _bwd_inner_sparse_kernel(
             MASK_LOCAL=MASK_LOCAL,
         )
 
-    # Compute current block max
-    block_max_curr = tl.max(acc_s)
+    # Load LSE
+    lse_log2 = ptrs_sched.load_lse(config, lse_ptrs, m_block)
+
+    # Compute attention weights in log2-domain
+    p_log2 = acc_s * config.softmax_scale_log2 - lse_log2[None, :]
 
     # Compute softmax threshold for this m_block
     softmax_threshold_log2 = config.get_softmax_threshold_log2(
@@ -70,20 +72,11 @@ def _bwd_inner_sparse_kernel(
     )
 
     # Update skip condition based on threshold
-    block_max_diff_log2 = (block_max_curr - block_max) * config.softmax_scale_log2
-    skip_softmax = block_max_diff_log2 < softmax_threshold_log2
+    skip_softmax = tl.min(p_log2 < softmax_threshold_log2[None, :])
 
     if not skip_softmax:
-        # Update block max
-        block_max = tl.maximum(block_max_curr, block_max)
-
-        # Load LSE
-        lse_log2 = ptrs_sched.load_lse(config, lse_ptrs, m_block)
-
         # Compute attention weights
-        p = activations.exp2(acc_s * config.softmax_scale_log2 - lse_log2[None, :]).to(
-            q_tile.dtype
-        )
+        p = activations.exp2(p_log2).to(q_tile.dtype)
 
         # Load output gradients tile
         do_tile = ptrs_sched.load_do(config, do_ptrs, m_block)
@@ -109,7 +102,7 @@ def _bwd_inner_sparse_kernel(
         # Compute key gradients
         acc_dk += tl.dot(ds, q_tile)
 
-    return acc_dk, acc_dv, block_max
+    return acc_dk, acc_dv
 
 
 @triton.jit(repr=kernel_repr.bwd_sparse_repr)
@@ -299,7 +292,6 @@ def _bwd_sparse_kernel(
     dv_ptrs = ptrs_sched.make_dv_ptrs(config)
 
     # Initialize accumulators
-    block_max = tl.full((), float("-inf"), dtype=tl.float32)
     acc_dk = tl.zeros((TILE_N, TILE_K), dtype=tl.float32)
     acc_dv = tl.zeros((TILE_N, TILE_K), dtype=tl.float32)
 
@@ -314,13 +306,12 @@ def _bwd_sparse_kernel(
         for m_block in tl.range(
             block_sched.m_block_min, block_sched.m_block_min_no_mask
         ):
-            acc_dk, acc_dv, block_max = _bwd_inner_sparse_kernel(
+            acc_dk, acc_dv = _bwd_inner_sparse_kernel(
                 config=config,
                 ptrs_sched=ptrs_sched,
                 mask_sched=mask_sched,
                 acc_dk=acc_dk,
                 acc_dv=acc_dv,
-                block_max=block_max,
                 k_tile=k_tile,
                 v_tile=v_tile,
                 q_ptrs=q_ptrs,
@@ -339,13 +330,12 @@ def _bwd_sparse_kernel(
         for m_block in tl.range(
             block_sched.m_block_min_no_mask, block_sched.m_block_max
         ):
-            acc_dk, acc_dv, block_max = _bwd_inner_sparse_kernel(
+            acc_dk, acc_dv = _bwd_inner_sparse_kernel(
                 config=config,
                 ptrs_sched=ptrs_sched,
                 mask_sched=mask_sched,
                 acc_dk=acc_dk,
                 acc_dv=acc_dv,
-                block_max=block_max,
                 k_tile=k_tile,
                 v_tile=v_tile,
                 q_ptrs=q_ptrs,
@@ -366,13 +356,12 @@ def _bwd_sparse_kernel(
                 block_sched.m_block_window_min,
                 block_sched.m_block_window_min_no_mask,
             ):
-                acc_dk, acc_dv, block_max = _bwd_inner_sparse_kernel(
+                acc_dk, acc_dv = _bwd_inner_sparse_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
                     mask_sched=mask_sched,
                     acc_dk=acc_dk,
                     acc_dv=acc_dv,
-                    block_max=block_max,
                     k_tile=k_tile,
                     v_tile=v_tile,
                     q_ptrs=q_ptrs,
@@ -395,13 +384,12 @@ def _bwd_sparse_kernel(
                 block_sched.m_block_window_min_no_mask,
                 block_sched.m_block_window_max_no_mask,
             ):
-                acc_dk, acc_dv, block_max = _bwd_inner_sparse_kernel(
+                acc_dk, acc_dv = _bwd_inner_sparse_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
                     mask_sched=mask_sched,
                     acc_dk=acc_dk,
                     acc_dv=acc_dv,
-                    block_max=block_max,
                     k_tile=k_tile,
                     v_tile=v_tile,
                     q_ptrs=q_ptrs,
@@ -421,13 +409,12 @@ def _bwd_sparse_kernel(
                 block_sched.m_block_window_max_no_mask,
                 block_sched.m_block_window_max,
             ):
-                acc_dk, acc_dv, block_max = _bwd_inner_sparse_kernel(
+                acc_dk, acc_dv = _bwd_inner_sparse_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
                     mask_sched=mask_sched,
                     acc_dk=acc_dk,
                     acc_dv=acc_dv,
-                    block_max=block_max,
                     k_tile=k_tile,
                     v_tile=v_tile,
                     q_ptrs=q_ptrs,
@@ -494,7 +481,7 @@ def _flash_sparse_attn_backward(
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
     softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else head_dim / seqlen_k
+        softmax_threshold if softmax_threshold is not None else 1 / seqlen_k
     )
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
@@ -763,7 +750,7 @@ def _flash_sparse_attn_varlen_backward(
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
     softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else head_dim / seqlen_k
+        softmax_threshold if softmax_threshold is not None else 1 / seqlen_k
     )
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:

--- a/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
@@ -72,7 +72,7 @@ def _bwd_inner_sparse_kernel(
     )
 
     # Update skip condition based on threshold
-    skip_softmax = tl.min(p_log2 < softmax_threshold_log2[None, :])
+    skip_softmax = tl.max(p_log2 - softmax_threshold_log2[None, :]) < 0.0
 
     if not skip_softmax:
         # Compute attention weights

--- a/flash_sparse_attn/ops/triton/flash_sparse_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_dec.py
@@ -37,7 +37,6 @@ def _dec_inner_sparse_kernel(
     acc_o,
     row_max,
     row_sum,
-    block_max,
     n_block,
     n_block_min,
     IS_MASK: tl.constexpr,
@@ -61,15 +60,12 @@ def _dec_inner_sparse_kernel(
         )
 
     # Apply online sparse softmax
-    p, block_max, row_max, row_sum, row_scale, skip_softmax = (
-        softmax_sched.online_sparse_softmax(
-            acc_s=acc_s,
-            block_max=block_max,
-            row_max=row_max,
-            row_sum=row_sum,
-            softmax_threshold_log2=config.softmax_threshold_log2,
-            CHECK_INF=CHECK_INF,
-        )
+    p, row_max, row_sum, row_scale, skip_softmax = softmax_sched.online_sparse_softmax(
+        acc_s=acc_s,
+        row_max=row_max,
+        row_sum=row_sum,
+        softmax_threshold_log2=config.softmax_threshold_log2,
+        CHECK_INF=CHECK_INF,
     )
 
     if not skip_softmax:
@@ -85,7 +81,7 @@ def _dec_inner_sparse_kernel(
         # Update output accumulator
         acc_o += tl.dot(p.to(v_tile.dtype), v_tile)
 
-    return k_tile, acc_o, row_max, row_sum, block_max
+    return k_tile, acc_o, row_max, row_sum
 
 
 @triton.jit(repr=kernel_repr.dec_sparse_repr)
@@ -239,10 +235,8 @@ def _dec_sparse_kernel(
     v_ptrs = ptrs_sched.make_v_ptrs(config)
 
     # Initialize accumulators
-    # TODO: Need to share block_max across threads
     row_max = tl.full((TILE_M,), float("-inf"), dtype=tl.float32)
     row_sum = tl.zeros((TILE_M,), dtype=tl.float32)
-    block_max = tl.full((), float("-inf"), dtype=tl.float32)
     acc_o = tl.zeros((TILE_M, TILE_K), dtype=tl.float32)
 
     # Load query tile
@@ -255,7 +249,7 @@ def _dec_sparse_kernel(
     for n_block in tl.range(
         block_sched.n_block_max - 1, block_sched.n_block_max_no_mask - 1, -1
     ):
-        k_tile, acc_o, row_max, row_sum, block_max = _dec_inner_sparse_kernel(
+        k_tile, acc_o, row_max, row_sum = _dec_inner_sparse_kernel(
             config=config,
             ptrs_sched=ptrs_sched,
             mask_sched=mask_sched,
@@ -267,7 +261,6 @@ def _dec_sparse_kernel(
             acc_o=acc_o,
             row_max=row_max,
             row_sum=row_sum,
-            block_max=block_max,
             n_block=n_block,
             n_block_min=block_sched.n_block_max_no_mask,
             IS_MASK=True,
@@ -283,7 +276,7 @@ def _dec_sparse_kernel(
         for n_block in tl.range(
             block_sched.n_block_max_no_mask - 1, block_sched.n_block_min - 1, -1
         ):
-            k_tile, acc_o, row_max, row_sum, block_max = _dec_inner_sparse_kernel(
+            k_tile, acc_o, row_max, row_sum = _dec_inner_sparse_kernel(
                 config=config,
                 ptrs_sched=ptrs_sched,
                 mask_sched=mask_sched,
@@ -295,7 +288,6 @@ def _dec_sparse_kernel(
                 acc_o=acc_o,
                 row_max=row_max,
                 row_sum=row_sum,
-                block_max=block_max,
                 n_block=n_block,
                 n_block_min=block_sched.n_block_min,
                 IS_MASK=False,
@@ -316,7 +308,7 @@ def _dec_sparse_kernel(
                 block_sched.n_block_window_max_no_mask - 1,
                 -1,
             ):
-                k_tile, acc_o, row_max, row_sum, block_max = _dec_inner_sparse_kernel(
+                k_tile, acc_o, row_max, row_sum = _dec_inner_sparse_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
                     mask_sched=mask_sched,
@@ -328,7 +320,6 @@ def _dec_sparse_kernel(
                     acc_o=acc_o,
                     row_max=row_max,
                     row_sum=row_sum,
-                    block_max=block_max,
                     n_block=n_block,
                     n_block_min=block_sched.n_block_window_max_no_mask,
                     IS_MASK=True,
@@ -351,7 +342,7 @@ def _dec_sparse_kernel(
                 block_sched.n_block_window_min_no_mask - 1,
                 -1,
             ):
-                k_tile, acc_o, row_max, row_sum, block_max = _dec_inner_sparse_kernel(
+                k_tile, acc_o, row_max, row_sum = _dec_inner_sparse_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
                     mask_sched=mask_sched,
@@ -363,7 +354,6 @@ def _dec_sparse_kernel(
                     acc_o=acc_o,
                     row_max=row_max,
                     row_sum=row_sum,
-                    block_max=block_max,
                     n_block=n_block,
                     n_block_min=block_sched.n_block_window_min_no_mask,
                     IS_MASK=False,
@@ -383,7 +373,7 @@ def _dec_sparse_kernel(
                 block_sched.n_block_window_min - 1,
                 -1,
             ):
-                k_tile, acc_o, row_max, row_sum, block_max = _dec_inner_sparse_kernel(
+                k_tile, acc_o, row_max, row_sum = _dec_inner_sparse_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
                     mask_sched=mask_sched,
@@ -395,7 +385,6 @@ def _dec_sparse_kernel(
                     acc_o=acc_o,
                     row_max=row_max,
                     row_sum=row_sum,
-                    block_max=block_max,
                     n_block=n_block,
                     n_block_min=block_sched.n_block_window_min,
                     IS_MASK=True,
@@ -463,7 +452,7 @@ def _flash_sparse_attn_decode(
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
     softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else head_dim / seqlen_k
+        softmax_threshold if softmax_threshold is not None else 1 / seqlen_k
     )
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
@@ -662,7 +651,7 @@ def _flash_sparse_attn_varlen_decode(
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
     softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else head_dim / seqlen_k
+        softmax_threshold if softmax_threshold is not None else 1 / seqlen_k
     )
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:

--- a/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
@@ -37,7 +37,6 @@ def _fwd_inner_sparse_kernel(
     acc_o,
     row_max,
     row_sum,
-    block_max,
     n_block,
     n_block_min,
     IS_MASK: tl.constexpr,
@@ -63,15 +62,12 @@ def _fwd_inner_sparse_kernel(
         )
 
     # Apply online sparse softmax
-    p, block_max, row_max, row_sum, row_scale, skip_softmax = (
-        softmax_sched.online_sparse_softmax(
-            acc_s=acc_s,
-            block_max=block_max,
-            row_max=row_max,
-            row_sum=row_sum,
-            softmax_threshold_log2=config.softmax_threshold_log2,
-            CHECK_INF=CHECK_INF,
-        )
+    p, row_max, row_sum, row_scale, skip_softmax = softmax_sched.online_sparse_softmax(
+        acc_s=acc_s,
+        row_max=row_max,
+        row_sum=row_sum,
+        softmax_threshold_log2=config.softmax_threshold_log2,
+        CHECK_INF=CHECK_INF,
     )
 
     if not skip_softmax:
@@ -87,7 +83,7 @@ def _fwd_inner_sparse_kernel(
         # Update output accumulator
         acc_o += tl.dot(p.to(v_tile.dtype), v_tile)
 
-    return k_tile, acc_o, row_max, row_sum, block_max
+    return k_tile, acc_o, row_max, row_sum
 
 
 @triton.jit(repr=kernel_repr.fwd_sparse_repr)
@@ -253,7 +249,6 @@ def _fwd_sparse_kernel(
     # Initialize accumulators
     row_max = tl.full((TILE_M,), float("-inf"), dtype=tl.float32)
     row_sum = tl.zeros((TILE_M,), dtype=tl.float32)
-    block_max = tl.full((), float("-inf"), dtype=tl.float32)
     acc_o = tl.zeros((TILE_M, TILE_K), dtype=tl.float32)
 
     # Load query tile
@@ -268,7 +263,7 @@ def _fwd_sparse_kernel(
         for n_block in tl.range(
             block_sched.n_block_max - 1, block_sched.n_block_max_no_mask - 1, -1
         ):
-            k_tile, acc_o, row_max, row_sum, block_max = _fwd_inner_sparse_kernel(
+            k_tile, acc_o, row_max, row_sum = _fwd_inner_sparse_kernel(
                 config=config,
                 ptrs_sched=ptrs_sched,
                 mask_sched=mask_sched,
@@ -280,7 +275,6 @@ def _fwd_sparse_kernel(
                 acc_o=acc_o,
                 row_max=row_max,
                 row_sum=row_sum,
-                block_max=block_max,
                 n_block=n_block,
                 n_block_min=block_sched.n_block_max_no_mask,
                 IS_MASK=True,
@@ -295,7 +289,7 @@ def _fwd_sparse_kernel(
         # block_sched.n_block_max_no_mask = n_block
         n_block_max_no_mask = n_block
 
-        k_tile, acc_o, row_max, row_sum, block_max = _fwd_inner_sparse_kernel(
+        k_tile, acc_o, row_max, row_sum = _fwd_inner_sparse_kernel(
             config=config,
             ptrs_sched=ptrs_sched,
             mask_sched=mask_sched,
@@ -307,7 +301,6 @@ def _fwd_sparse_kernel(
             acc_o=acc_o,
             row_max=row_max,
             row_sum=row_sum,
-            block_max=block_max,
             n_block=n_block,
             n_block_min=n_block,
             IS_MASK=True,
@@ -324,7 +317,7 @@ def _fwd_sparse_kernel(
         for n_block in tl.range(
             n_block_max_no_mask - 1, block_sched.n_block_min - 1, -1
         ):
-            k_tile, acc_o, row_max, row_sum, block_max = _fwd_inner_sparse_kernel(
+            k_tile, acc_o, row_max, row_sum = _fwd_inner_sparse_kernel(
                 config=config,
                 ptrs_sched=ptrs_sched,
                 mask_sched=mask_sched,
@@ -336,7 +329,6 @@ def _fwd_sparse_kernel(
                 acc_o=acc_o,
                 row_max=row_max,
                 row_sum=row_sum,
-                block_max=block_max,
                 n_block=n_block,
                 n_block_min=block_sched.n_block_min,
                 IS_MASK=False,
@@ -358,7 +350,7 @@ def _fwd_sparse_kernel(
                 block_sched.n_block_window_max_no_mask - 1,
                 -1,
             ):
-                k_tile, acc_o, row_max, row_sum, block_max = _fwd_inner_sparse_kernel(
+                k_tile, acc_o, row_max, row_sum = _fwd_inner_sparse_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
                     mask_sched=mask_sched,
@@ -370,7 +362,6 @@ def _fwd_sparse_kernel(
                     acc_o=acc_o,
                     row_max=row_max,
                     row_sum=row_sum,
-                    block_max=block_max,
                     n_block=n_block,
                     n_block_min=block_sched.n_block_window_max_no_mask,
                     IS_MASK=True,
@@ -394,7 +385,7 @@ def _fwd_sparse_kernel(
                 block_sched.n_block_window_min_no_mask - 1,
                 -1,
             ):
-                k_tile, acc_o, row_max, row_sum, block_max = _fwd_inner_sparse_kernel(
+                k_tile, acc_o, row_max, row_sum = _fwd_inner_sparse_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
                     mask_sched=mask_sched,
@@ -406,7 +397,6 @@ def _fwd_sparse_kernel(
                     acc_o=acc_o,
                     row_max=row_max,
                     row_sum=row_sum,
-                    block_max=block_max,
                     n_block=n_block,
                     n_block_min=block_sched.n_block_window_min_no_mask,
                     IS_MASK=False,
@@ -427,7 +417,7 @@ def _fwd_sparse_kernel(
                 block_sched.n_block_window_min - 1,
                 -1,
             ):
-                k_tile, acc_o, row_max, row_sum, block_max = _fwd_inner_sparse_kernel(
+                k_tile, acc_o, row_max, row_sum = _fwd_inner_sparse_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
                     mask_sched=mask_sched,
@@ -439,7 +429,6 @@ def _fwd_sparse_kernel(
                     acc_o=acc_o,
                     row_max=row_max,
                     row_sum=row_sum,
-                    block_max=block_max,
                     n_block=n_block,
                     n_block_min=block_sched.n_block_window_min,
                     IS_MASK=True,
@@ -511,7 +500,7 @@ def _flash_sparse_attn_forward(
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
     softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else head_dim / seqlen_k
+        softmax_threshold if softmax_threshold is not None else 1 / seqlen_k
     )
     qhead_per_kvhead = num_heads_q // num_heads_kv
     qhead_per_kvhead_packgqa = num_heads_q // num_heads_kv if pack_gqa else 1
@@ -738,7 +727,7 @@ def _flash_sparse_attn_varlen_forward(
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
     softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else head_dim / seqlen_k
+        softmax_threshold if softmax_threshold is not None else 1 / seqlen_k
     )
     qhead_per_kvhead = num_heads_q // num_heads_kv
     qhead_per_kvhead_packgqa = num_heads_q // num_heads_kv if pack_gqa else 1

--- a/flash_sparse_attn/ops/triton/scheduler.py
+++ b/flash_sparse_attn/ops/triton/scheduler.py
@@ -2374,7 +2374,6 @@ class SoftmaxScheduler:
     def online_sparse_softmax(
         self,
         acc_s,
-        block_max,
         row_max,
         row_sum,
         softmax_threshold_log2,
@@ -2382,7 +2381,6 @@ class SoftmaxScheduler:
     ):
         return activations.online_sparse_softmax(
             acc_s=acc_s,
-            block_max=block_max,
             row_max=row_max,
             row_sum=row_sum,
             scale_log2=self.softmax_scale_log2,

--- a/flash_sparse_attn/ops/triton/seqlen_info.py
+++ b/flash_sparse_attn/ops/triton/seqlen_info.py
@@ -136,7 +136,7 @@ def get_softmax_threshold(
     :param TILE_M: Tile size along the M dimension.
     :param QHEAD_PER_KVHEAD_PACKGQA: Ratio of query heads to key/value heads for packed GQA.
 
-    :return softmax_threshold_log2: Lower-bound scalar softmax threshold in log2-domain for the given block.
+    :return softmax_threshold_log2: softmax threshold of shape [TILE_M] in log2-domain for the given block.
     """
     if IS_CAUSAL:
         offs_m = m_block * TILE_M + tl.arange(0, TILE_M)
@@ -144,9 +144,9 @@ def get_softmax_threshold(
         if QHEAD_PER_KVHEAD_PACKGQA > 1:
             q_idx = q_idx // QHEAD_PER_KVHEAD_PACKGQA
         causal_offset = seqlen_k - seqlen_q
-        s_thr = tl.min(softmax_threshold * (q_idx + causal_offset + 1.0) / seqlen_k)
+        s_thr = softmax_threshold * (q_idx + causal_offset + 1.0) / seqlen_k
     else:
-        s_thr = tl.full((), softmax_threshold, dtype=tl.float32)
+        s_thr = tl.full((TILE_M,), softmax_threshold, dtype=tl.float32)
     softmax_threshold_log2 = tl.log2(s_thr)
     return softmax_threshold_log2
 


### PR DESCRIPTION
## Summary

This PR refines the sparse softmax skip logic used by the Triton sparse and gated attention kernels.

The forward/decode path now removes the running block_max state from online sparse softmax and uses per-row threshold comparisons while preserving tile-level control flow. A tile is skipped only when every row in the tile falls below its own threshold.

The backward path now avoids replaying a forward-style block-max history. Instead, it computes the final softmax probability in log2 space from the attention score and LSE, and skips low-contribution tiles directly from that probability criterion.

## Changes

- Remove block_max from online_sparse_softmax and its scheduler wrapper.
- Return per-row softmax thresholds from get_softmax_threshold.
- Update sparse forward/decode kernels to use the simplified online sparse softmax state.
- Update gated forward/decode kernels to match the same sparse softmax path.
- Update sparse and gated backward kernels to use probability-based tile skipping.

## Validation

- python -m py_compile flash_sparse_attn/ops/triton/activations.py flash_sparse_attn/ops/triton/seqlen_info.py flash_sparse_attn/ops/triton/scheduler.py flash_sparse_attn/ops/triton/flash_sparse_fwd.py flash_sparse_attn/ops/triton/flash_sparse_bwd.py flash_sparse_attn/ops/triton/flash_sparse_dec.py flash_sparse_attn/ops/triton/flash_gated_fwd.py flash_sparse_attn/ops/triton/flash_gated_bwd.py flash_sparse_attn/ops/triton/flash_gated_dec.py

Fixes #313