### PR TITLE
Support sink-aware flexible local windows

### DIFF
--- a/flash_sparse_attn/ops/triton/assert_inputs.py
+++ b/flash_sparse_attn/ops/triton/assert_inputs.py
@@ -104,6 +104,9 @@ def assert_fwd_inputs(
         )
     if window_sizes is not None:
         assert window_sizes.dtype == torch.int32, "window_sizes must be int32"
+        assert window_sizes.ndim == 2 and window_sizes.shape[1] == 3, (
+            "window_sizes must have shape [num_kv_heads, 3]"
+        )
 
 
 def assert_bwd_inputs(
@@ -225,6 +228,9 @@ def assert_bwd_inputs(
         )
     if window_sizes is not None:
         assert window_sizes.dtype == torch.int32, "window_sizes must be int32"
+        assert window_sizes.ndim == 2 and window_sizes.shape[1] == 3, (
+            "window_sizes must have shape [num_kv_heads, 3]"
+        )
 
 
 def assert_dec_inputs(
@@ -316,3 +322,6 @@ def assert_dec_inputs(
         assert seqused_k.dtype == torch.int32, "seqused_k must be int32"
     if window_sizes is not None:
         assert window_sizes.dtype == torch.int32, "window_sizes must be int32"
+        assert window_sizes.ndim == 2 and window_sizes.shape[1] == 3, (
+            "window_sizes must have shape [num_kv_heads, 3]"
+        )

--- a/flash_sparse_attn/ops/triton/assert_inputs.py
+++ b/flash_sparse_attn/ops/triton/assert_inputs.py
@@ -105,7 +105,7 @@ def assert_fwd_inputs(
     if window_sizes is not None:
         assert window_sizes.dtype == torch.int32, "window_sizes must be int32"
         assert window_sizes.ndim == 2 and window_sizes.shape[1] == 3, (
-            "window_sizes must have shape [num_kv_heads, 3]"
+            "window_sizes must have shape [num_kv_heads, 3] with columns [window_dist, window_right, window_left]"
         )
 
 
@@ -229,7 +229,7 @@ def assert_bwd_inputs(
     if window_sizes is not None:
         assert window_sizes.dtype == torch.int32, "window_sizes must be int32"
         assert window_sizes.ndim == 2 and window_sizes.shape[1] == 3, (
-            "window_sizes must have shape [num_kv_heads, 3]"
+            "window_sizes must have shape [num_kv_heads, 3] with columns [window_dist, window_right, window_left]"
         )
 
 
@@ -323,5 +323,5 @@ def assert_dec_inputs(
     if window_sizes is not None:
         assert window_sizes.dtype == torch.int32, "window_sizes must be int32"
         assert window_sizes.ndim == 2 and window_sizes.shape[1] == 3, (
-            "window_sizes must have shape [num_kv_heads, 3]"
+            "window_sizes must have shape [num_kv_heads, 3] with columns [window_dist, window_right, window_left]"
         )

--- a/flash_sparse_attn/ops/triton/assert_inputs.py
+++ b/flash_sparse_attn/ops/triton/assert_inputs.py
@@ -104,8 +104,8 @@ def assert_fwd_inputs(
         )
     if window_sizes is not None:
         assert window_sizes.dtype == torch.int32, "window_sizes must be int32"
-        assert window_sizes.ndim == 2 and window_sizes.shape[1] == 3, (
-            "window_sizes must have shape [num_kv_heads, 3] with columns [window_dist, window_right, window_left]"
+        assert window_sizes.ndim == 2 and window_sizes.shape[1] == 4, (
+            "window_sizes must have shape [num_kv_heads, 4] with columns [window_sink, window_left, window_right, window_dist]"
         )
 
 
@@ -228,8 +228,8 @@ def assert_bwd_inputs(
         )
     if window_sizes is not None:
         assert window_sizes.dtype == torch.int32, "window_sizes must be int32"
-        assert window_sizes.ndim == 2 and window_sizes.shape[1] == 3, (
-            "window_sizes must have shape [num_kv_heads, 3] with columns [window_dist, window_right, window_left]"
+        assert window_sizes.ndim == 2 and window_sizes.shape[1] == 4, (
+            "window_sizes must have shape [num_kv_heads, 4] with columns [window_sink, window_left, window_right, window_dist]"
         )
 
 
@@ -322,6 +322,6 @@ def assert_dec_inputs(
         assert seqused_k.dtype == torch.int32, "seqused_k must be int32"
     if window_sizes is not None:
         assert window_sizes.dtype == torch.int32, "window_sizes must be int32"
-        assert window_sizes.ndim == 2 and window_sizes.shape[1] == 3, (
-            "window_sizes must have shape [num_kv_heads, 3] with columns [window_dist, window_right, window_left]"
+        assert window_sizes.ndim == 2 and window_sizes.shape[1] == 4, (
+            "window_sizes must have shape [num_kv_heads, 4] with columns [window_sink, window_left, window_right, window_dist]"
         )

--- a/flash_sparse_attn/ops/triton/block_info.py
+++ b/flash_sparse_attn/ops/triton/block_info.py
@@ -149,15 +149,14 @@ def get_n_block_min_causal_local_mask(
     IS_LOCAL: tl.constexpr,
     QHEAD_PER_KVHEAD_PACKGQA: tl.constexpr,
 ):
-    if not IS_LOCAL:
-        return n_block_min
-    else:
-        m_idx_min = m_block * TILE_M
-        if QHEAD_PER_KVHEAD_PACKGQA > 1:
-            m_idx_min = m_idx_min // QHEAD_PER_KVHEAD_PACKGQA
-        n_idx = m_idx_min + seqlen_k - seqlen_q
-        n_idx_right = n_idx - window_size_dist - window_size_right
-        return tl.maximum(n_block_min, n_idx_right // TILE_N)
+    m_idx_min = m_block * TILE_M
+    if QHEAD_PER_KVHEAD_PACKGQA > 1:
+        m_idx_min = m_idx_min // QHEAD_PER_KVHEAD_PACKGQA
+    n_idx = m_idx_min + seqlen_k - seqlen_q
+    n_idx_right = (
+        n_idx if not IS_LOCAL else n_idx - window_size_dist - window_size_right
+    )
+    return tl.maximum(n_block_min, n_idx_right // TILE_N)
 
 
 @triton.jit
@@ -204,9 +203,10 @@ def get_m_block_min_causal_local_mask(
     else:
         n_idx_max = (n_block + 1) * TILE_N
         m_idx = n_idx_max + seqlen_q - seqlen_k
-        m_idx_right = (
-            m_idx if IS_CAUSAL else m_idx + window_size_dist + window_size_right
-        )
+        if IS_LOCAL:
+            m_idx_right = m_idx + window_size_dist + window_size_right
+        else:
+            m_idx_right = m_idx
         return tl.maximum(m_block_min, tl.cdiv(m_idx_right, TILE_M))
 
 

--- a/flash_sparse_attn/ops/triton/block_info.py
+++ b/flash_sparse_attn/ops/triton/block_info.py
@@ -40,11 +40,13 @@ def get_n_block_min_max(
         if QHEAD_PER_KVHEAD_PACKGQA > 1:
             m_idx_min = m_idx_min // QHEAD_PER_KVHEAD_PACKGQA
         n_idx = m_idx_min + seqlen_k - seqlen_q
+        n_idx_dist = n_idx - window_size_dist
+        n_block_min = tl.maximum(n_idx_dist // TILE_N, 0)
         n_idx_left = n_idx - window_size_dist - window_size_right - window_size_left
         n_block_window_min = tl.maximum(n_idx_left // TILE_N, 0)
     if IS_SPLIT_KV:
         if IS_LOCAL:
-            n_block_min = tl.maximum(n_block_min, n_block_window_min)
+            n_block_min = n_block_window_min
             n_block_max_with_diag = n_block_max
             n_block_max = tl.maximum(n_block_window_max, n_block_min)
         total_n_blocks = tl.maximum(n_block_max - n_block_min, 0)
@@ -97,6 +99,8 @@ def get_m_block_min_max(
     if IS_LOCAL:
         n_idx_max = (n_block + 1) * TILE_N
         m_idx = n_idx_max + seqlen_q - seqlen_k
+        m_idx_dist = m_idx + window_size_dist
+        m_block_max = tl.minimum(m_block_max, tl.cdiv(m_idx_dist, TILE_M))
         m_idx_left = m_idx + window_size_dist + window_size_right + window_size_left
         m_block_window_max = tl.minimum(m_block_window_max, tl.cdiv(m_idx_left, TILE_M))
     if IS_SPLIT_QO:
@@ -105,7 +109,6 @@ def get_m_block_min_max(
             m_idx = n_idx_max + seqlen_q - seqlen_k
             m_block_min_no_mask = tl.maximum(m_block_min, tl.cdiv(m_idx, TILE_M))
             m_block_window_min = tl.maximum(m_block_window_min, m_block_min_no_mask)
-            m_block_window_max = tl.minimum(m_block_window_max, m_block_max)
             win_blocks = tl.maximum(m_block_window_max - m_block_window_min, 0)
             base = win_blocks // num_splits
             extra = win_blocks % num_splits
@@ -121,6 +124,7 @@ def get_m_block_min_max(
             )
             # First split keeps diagonal, others skip it
             m_block_min = tl.where(split_idx == 0, m_block_min, m_block_window_min)
+            m_block_max = tl.where(split_idx == 0, m_block_max, m_block_window_min)
         else:
             total_m_blocks = tl.maximum(m_block_max - m_block_min, 0)
             base = total_m_blocks // num_splits

--- a/flash_sparse_attn/ops/triton/block_info.py
+++ b/flash_sparse_attn/ops/triton/block_info.py
@@ -11,6 +11,7 @@ def get_n_block_min_max(
     num_splits,
     window_size_left,
     window_size_right,
+    window_size_dist,
     TILE_N: tl.constexpr,
     TILE_M: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
@@ -30,7 +31,7 @@ def get_n_block_min_max(
         n_idx = m_idx_max + seqlen_k - seqlen_q
         n_block_max = tl.minimum(n_block_max, tl.cdiv(n_idx, TILE_N))
         if IS_LOCAL:
-            n_idx_right = n_idx - window_size_right
+            n_idx_right = n_idx - window_size_dist - window_size_right
             n_block_window_max = tl.minimum(
                 n_block_window_max, tl.maximum(tl.cdiv(n_idx_right, TILE_N), 0)
             )
@@ -39,7 +40,7 @@ def get_n_block_min_max(
         if QHEAD_PER_KVHEAD_PACKGQA > 1:
             m_idx_min = m_idx_min // QHEAD_PER_KVHEAD_PACKGQA
         n_idx = m_idx_min + seqlen_k - seqlen_q
-        n_idx_left = n_idx - window_size_left
+        n_idx_left = n_idx - window_size_dist - window_size_right - window_size_left
         n_block_window_min = tl.maximum(n_idx_left // TILE_N, 0)
     if IS_SPLIT_KV:
         if IS_LOCAL:
@@ -75,6 +76,7 @@ def get_m_block_min_max(
     num_splits,
     window_size_left,
     window_size_right,
+    window_size_dist,
     TILE_N: tl.constexpr,
     TILE_M: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
@@ -90,47 +92,38 @@ def get_m_block_min_max(
         m_idx = n_idx_min + seqlen_q - seqlen_k
         m_block_min = tl.maximum(m_block_min, m_idx // TILE_M)
         if IS_LOCAL:
-            m_idx_right = m_idx + window_size_right
-            m_block_window_min = tl.maximum(m_block_window_min, m_idx_right // TILE_M)
+            m_idx_right = m_idx + window_size_dist + window_size_right
+            m_block_window_min = tl.maximum(
+                m_block_window_min, tl.cdiv(m_idx_right, TILE_M)
+            )
     if IS_LOCAL:
         n_idx_max = (n_block + 1) * TILE_N
+        n_idx_max = tl.minimum(n_idx_max, seqlen_k)
         m_idx = n_idx_max + seqlen_q - seqlen_k
-        m_idx_left = m_idx + window_size_left
+        m_idx_left = m_idx + window_size_dist + window_size_right + window_size_left
         m_block_window_max = tl.minimum(m_block_window_max, tl.cdiv(m_idx_left, TILE_M))
     if IS_SPLIT_QO:
         if IS_LOCAL:
-            n_idx_max = (n_block + 1) * TILE_N
-            m_idx = n_idx_max + seqlen_q - seqlen_k
-            m_block_min_no_mask = tl.maximum(m_block_min, tl.cdiv(m_idx, TILE_M))
-            m_block_window_min = tl.maximum(m_block_window_min, m_block_min_no_mask)
-            m_block_window_max = tl.minimum(m_block_window_max, m_block_max)
-            win_blocks = tl.maximum(m_block_window_max - m_block_window_min, 0)
-            base = win_blocks // num_splits
-            extra = win_blocks % num_splits
-            win_off = tl.where(
-                split_idx < extra,
-                split_idx * (base + 1),
-                extra * (base + 1) + (split_idx - extra) * base,
+            m_block_max = tl.minimum(m_block_max, m_block_window_max)
+            m_block_min_with_diag = m_block_min
+            m_block_min = tl.minimum(m_block_window_min, m_block_max)
+        total_m_blocks = tl.maximum(m_block_max - m_block_min, 0)
+        base = total_m_blocks // num_splits
+        extra = total_m_blocks % num_splits
+        m_block_min_new = m_block_min + tl.where(
+            split_idx < extra,
+            split_idx * (base + 1),
+            extra * (base + 1) + (split_idx - extra) * base,
+        )
+        m_block_count = tl.where(split_idx < extra, base + 1, base)
+        m_block_max = tl.minimum(m_block_min_new + m_block_count, m_block_max)
+        m_block_min = m_block_min_new
+        if IS_LOCAL:
+            m_block_min = tl.where(
+                split_idx <= 0,
+                m_block_min_with_diag,
+                m_block_min,
             )
-            win_cnt = tl.where(split_idx < extra, base + 1, base)
-            m_block_window_min = m_block_window_min + win_off
-            m_block_window_max = tl.minimum(
-                m_block_window_min + win_cnt, m_block_window_max
-            )
-            # First split keeps diagonal, others skip it
-            m_block_min = tl.where(split_idx == 0, m_block_min, m_block_window_min)
-        else:
-            total_m_blocks = tl.maximum(m_block_max - m_block_min, 0)
-            base = total_m_blocks // num_splits
-            extra = total_m_blocks % num_splits
-            m_block_min_new = m_block_min + tl.where(
-                split_idx < extra,
-                split_idx * (base + 1),
-                extra * (base + 1) + (split_idx - extra) * base,
-            )
-            m_block_count = tl.where(split_idx < extra, base + 1, base)
-            m_block_max = tl.minimum(m_block_min_new + m_block_count, m_block_max)
-            m_block_min = m_block_min_new
     return m_block_min, m_block_max, m_block_window_min, m_block_window_max
 
 
@@ -141,17 +134,21 @@ def get_n_block_min_causal_local_mask(
     m_block,
     n_block_min,
     window_size_right,
+    window_size_dist,
     TILE_N: tl.constexpr,
     TILE_M: tl.constexpr,
     IS_LOCAL: tl.constexpr,
     QHEAD_PER_KVHEAD_PACKGQA: tl.constexpr,
 ):
-    m_idx_min = m_block * TILE_M
-    if QHEAD_PER_KVHEAD_PACKGQA > 1:
-        m_idx_min = m_idx_min // QHEAD_PER_KVHEAD_PACKGQA
-    n_idx = m_idx_min + seqlen_k - seqlen_q
-    n_idx_right = n_idx if not IS_LOCAL else n_idx - window_size_right
-    return tl.maximum(n_block_min, n_idx_right // TILE_N)
+    if not IS_LOCAL:
+        return n_block_min
+    else:
+        m_idx_min = m_block * TILE_M
+        if QHEAD_PER_KVHEAD_PACKGQA > 1:
+            m_idx_min = m_idx_min // QHEAD_PER_KVHEAD_PACKGQA
+        n_idx = m_idx_min + seqlen_k - seqlen_q
+        n_idx_right = n_idx - window_size_dist - window_size_right
+        return tl.maximum(n_block_min, n_idx_right // TILE_N)
 
 
 @triton.jit
@@ -161,6 +158,8 @@ def get_n_block_min_before_local_mask(
     m_block,
     n_block_min,
     window_size_left,
+    window_size_right,
+    window_size_dist,
     TILE_N: tl.constexpr,
     TILE_M: tl.constexpr,
     IS_LOCAL: tl.constexpr,
@@ -174,7 +173,7 @@ def get_n_block_min_before_local_mask(
             m_idx_max = tl.cdiv(m_idx_max, QHEAD_PER_KVHEAD_PACKGQA)
         m_idx_max = tl.minimum(m_idx_max, seqlen_q)
         n_idx = m_idx_max + seqlen_k - seqlen_q
-        n_idx_left = n_idx - window_size_left
+        n_idx_left = n_idx - window_size_dist - window_size_right - window_size_left
         return tl.maximum(n_block_min, tl.cdiv(n_idx_left, TILE_N))
 
 
@@ -185,6 +184,7 @@ def get_m_block_min_causal_local_mask(
     n_block,
     m_block_min,
     window_size_right,
+    window_size_dist,
     TILE_N: tl.constexpr,
     TILE_M: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
@@ -195,7 +195,9 @@ def get_m_block_min_causal_local_mask(
     else:
         n_idx_max = (n_block + 1) * TILE_N
         m_idx = n_idx_max + seqlen_q - seqlen_k
-        m_idx_right = m_idx if IS_CAUSAL else m_idx + window_size_right
+        m_idx_right = (
+            m_idx if IS_CAUSAL else m_idx + window_size_dist + window_size_right
+        )
         return tl.maximum(m_block_min, tl.cdiv(m_idx_right, TILE_M))
 
 
@@ -206,6 +208,8 @@ def get_m_block_max_before_local_mask(
     n_block,
     m_block_max,
     window_size_left,
+    window_size_right,
+    window_size_dist,
     TILE_N: tl.constexpr,
     TILE_M: tl.constexpr,
     IS_LOCAL: tl.constexpr,
@@ -215,5 +219,5 @@ def get_m_block_max_before_local_mask(
     else:
         n_idx_min = n_block * TILE_N
         m_idx = n_idx_min + seqlen_q - seqlen_k
-        m_idx_left = m_idx + window_size_left
+        m_idx_left = m_idx + window_size_dist + window_size_right + window_size_left
         return tl.minimum(m_block_max, m_idx_left // TILE_M)

--- a/flash_sparse_attn/ops/triton/block_info.py
+++ b/flash_sparse_attn/ops/triton/block_info.py
@@ -93,37 +93,46 @@ def get_m_block_min_max(
         m_block_min = tl.maximum(m_block_min, m_idx // TILE_M)
         if IS_LOCAL:
             m_idx_right = m_idx + window_size_dist + window_size_right
-            m_block_window_min = tl.maximum(
-                m_block_window_min, tl.cdiv(m_idx_right, TILE_M)
-            )
+            m_block_window_min = tl.maximum(m_block_window_min, m_idx_right // TILE_M)
     if IS_LOCAL:
         n_idx_max = (n_block + 1) * TILE_N
-        n_idx_max = tl.minimum(n_idx_max, seqlen_k)
         m_idx = n_idx_max + seqlen_q - seqlen_k
         m_idx_left = m_idx + window_size_dist + window_size_right + window_size_left
         m_block_window_max = tl.minimum(m_block_window_max, tl.cdiv(m_idx_left, TILE_M))
     if IS_SPLIT_QO:
         if IS_LOCAL:
-            m_block_max = tl.minimum(m_block_max, m_block_window_max)
-            m_block_min_with_diag = m_block_min
-            m_block_min = tl.minimum(m_block_window_min, m_block_max)
-        total_m_blocks = tl.maximum(m_block_max - m_block_min, 0)
-        base = total_m_blocks // num_splits
-        extra = total_m_blocks % num_splits
-        m_block_min_new = m_block_min + tl.where(
-            split_idx < extra,
-            split_idx * (base + 1),
-            extra * (base + 1) + (split_idx - extra) * base,
-        )
-        m_block_count = tl.where(split_idx < extra, base + 1, base)
-        m_block_max = tl.minimum(m_block_min_new + m_block_count, m_block_max)
-        m_block_min = m_block_min_new
-        if IS_LOCAL:
-            m_block_min = tl.where(
-                split_idx <= 0,
-                m_block_min_with_diag,
-                m_block_min,
+            n_idx_max = (n_block + 1) * TILE_N
+            m_idx = n_idx_max + seqlen_q - seqlen_k
+            m_block_min_no_mask = tl.maximum(m_block_min, tl.cdiv(m_idx, TILE_M))
+            m_block_window_min = tl.maximum(m_block_window_min, m_block_min_no_mask)
+            m_block_window_max = tl.minimum(m_block_window_max, m_block_max)
+            win_blocks = tl.maximum(m_block_window_max - m_block_window_min, 0)
+            base = win_blocks // num_splits
+            extra = win_blocks % num_splits
+            win_off = tl.where(
+                split_idx < extra,
+                split_idx * (base + 1),
+                extra * (base + 1) + (split_idx - extra) * base,
             )
+            win_cnt = tl.where(split_idx < extra, base + 1, base)
+            m_block_window_min = m_block_window_min + win_off
+            m_block_window_max = tl.minimum(
+                m_block_window_min + win_cnt, m_block_window_max
+            )
+            # First split keeps diagonal, others skip it
+            m_block_min = tl.where(split_idx == 0, m_block_min, m_block_window_min)
+        else:
+            total_m_blocks = tl.maximum(m_block_max - m_block_min, 0)
+            base = total_m_blocks // num_splits
+            extra = total_m_blocks % num_splits
+            m_block_min_new = m_block_min + tl.where(
+                split_idx < extra,
+                split_idx * (base + 1),
+                extra * (base + 1) + (split_idx - extra) * base,
+            )
+            m_block_count = tl.where(split_idx < extra, base + 1, base)
+            m_block_max = tl.minimum(m_block_min_new + m_block_count, m_block_max)
+            m_block_min = m_block_min_new
     return m_block_min, m_block_max, m_block_window_min, m_block_window_max
 
 

--- a/flash_sparse_attn/ops/triton/block_info.py
+++ b/flash_sparse_attn/ops/triton/block_info.py
@@ -9,6 +9,7 @@ def get_n_block_min_max(
     m_block,
     split_idx,
     num_splits,
+    window_size_sink,
     window_size_left,
     window_size_right,
     window_size_dist,
@@ -23,6 +24,8 @@ def get_n_block_min_max(
     n_block_min = 0
     n_block_window_max = n_block_max
     n_block_window_min = n_block_min
+    n_block_sink_min = 0
+    n_block_sink_max = 0
     if IS_CAUSAL or IS_LOCAL:
         m_idx_max = (m_block + 1) * TILE_M
         if QHEAD_PER_KVHEAD_PACKGQA > 1:
@@ -36,14 +39,21 @@ def get_n_block_min_max(
                 n_block_window_max, tl.maximum(tl.cdiv(n_idx_right, TILE_N), 0)
             )
     if IS_LOCAL:
+        n_block_sink_max = tl.minimum(
+            tl.cdiv(window_size_sink, TILE_N),
+            tl.maximum(tl.cdiv(n_idx, TILE_N), 0),
+        )
+        n_block_sink_exclude_max = tl.cdiv(window_size_sink, TILE_N)
         m_idx_min = m_block * TILE_M
         if QHEAD_PER_KVHEAD_PACKGQA > 1:
             m_idx_min = m_idx_min // QHEAD_PER_KVHEAD_PACKGQA
         n_idx = m_idx_min + seqlen_k - seqlen_q
         n_idx_dist = n_idx - window_size_dist
         n_block_min = tl.maximum(n_idx_dist // TILE_N, 0)
+        n_block_min = tl.maximum(n_block_min, n_block_sink_exclude_max)
         n_idx_left = n_idx - window_size_dist - window_size_right - window_size_left
         n_block_window_min = tl.maximum(n_idx_left // TILE_N, 0)
+        n_block_window_min = tl.maximum(n_block_window_min, n_block_sink_exclude_max)
     if IS_SPLIT_KV:
         if IS_LOCAL:
             n_block_min = n_block_window_min
@@ -66,7 +76,16 @@ def get_n_block_min_max(
                 n_block_max_with_diag,
                 n_block_max,
             )
-    return n_block_min, n_block_max, n_block_window_min, n_block_window_max
+        if IS_SPLIT_KV:
+            n_block_sink_max = tl.where(split_idx == 0, n_block_sink_max, 0)
+    return (
+        n_block_min,
+        n_block_max,
+        n_block_window_min,
+        n_block_window_max,
+        n_block_sink_min,
+        n_block_sink_max,
+    )
 
 
 @triton.jit
@@ -76,6 +95,7 @@ def get_m_block_min_max(
     n_block,
     split_idx,
     num_splits,
+    window_size_sink,
     window_size_left,
     window_size_right,
     window_size_dist,
@@ -89,6 +109,8 @@ def get_m_block_min_max(
     m_block_min = 0
     m_block_window_max = m_block_max
     m_block_window_min = m_block_min
+    m_block_sink_min = 0
+    m_block_sink_max = 0
     if IS_CAUSAL or IS_LOCAL:
         n_idx_min = n_block * TILE_N
         m_idx = n_idx_min + seqlen_q - seqlen_k
@@ -97,12 +119,23 @@ def get_m_block_min_max(
             m_idx_right = m_idx + window_size_dist + window_size_right
             m_block_window_min = tl.maximum(m_block_window_min, m_idx_right // TILE_M)
     if IS_LOCAL:
+        n_block_sink_exclude_max = tl.cdiv(window_size_sink, TILE_N)
+        is_sink_block = n_block < n_block_sink_exclude_max
+        n_idx_min = n_block * TILE_N
+        m_idx_sink = n_idx_min + seqlen_q - seqlen_k
+        m_block_sink_min = tl.maximum(m_idx_sink // TILE_M, 0)
+        m_block_sink_max = tl.where(is_sink_block, tl.cdiv(seqlen_q, TILE_M), 0)
+        m_block_sink_min = tl.where(is_sink_block, m_block_sink_min, 0)
         n_idx_max = (n_block + 1) * TILE_N
         m_idx = n_idx_max + seqlen_q - seqlen_k
         m_idx_dist = m_idx + window_size_dist
         m_block_max = tl.minimum(m_block_max, tl.cdiv(m_idx_dist, TILE_M))
         m_idx_left = m_idx + window_size_dist + window_size_right + window_size_left
         m_block_window_max = tl.minimum(m_block_window_max, tl.cdiv(m_idx_left, TILE_M))
+        m_block_min = tl.where(is_sink_block, 0, m_block_min)
+        m_block_max = tl.where(is_sink_block, 0, m_block_max)
+        m_block_window_min = tl.where(is_sink_block, 0, m_block_window_min)
+        m_block_window_max = tl.where(is_sink_block, 0, m_block_window_max)
     if IS_SPLIT_QO:
         if IS_LOCAL:
             n_idx_max = (n_block + 1) * TILE_N
@@ -123,8 +156,9 @@ def get_m_block_min_max(
                 m_block_window_min + win_cnt, m_block_window_max
             )
             # First split keeps diagonal, others skip it
-            m_block_min = tl.where(split_idx == 0, m_block_min, m_block_window_min)
-            m_block_max = tl.where(split_idx == 0, m_block_max, m_block_window_min)
+            m_block_min = tl.where(split_idx == 0, m_block_min, m_block_max)
+            m_block_sink_max = tl.where(split_idx == 0, m_block_sink_max, 0)
+            m_block_sink_min = tl.where(split_idx == 0, m_block_sink_min, 0)
         else:
             total_m_blocks = tl.maximum(m_block_max - m_block_min, 0)
             base = total_m_blocks // num_splits
@@ -137,7 +171,14 @@ def get_m_block_min_max(
             m_block_count = tl.where(split_idx < extra, base + 1, base)
             m_block_max = tl.minimum(m_block_min_new + m_block_count, m_block_max)
             m_block_min = m_block_min_new
-    return m_block_min, m_block_max, m_block_window_min, m_block_window_max
+    return (
+        m_block_min,
+        m_block_max,
+        m_block_window_min,
+        m_block_window_max,
+        m_block_sink_min,
+        m_block_sink_max,
+    )
 
 
 @triton.jit

--- a/flash_sparse_attn/ops/triton/flash_dec_combine.py
+++ b/flash_sparse_attn/ops/triton/flash_dec_combine.py
@@ -123,8 +123,8 @@ def _dec_combine_kernel(
 
         # Compute normalized exponentials
         new_e_max = tl.maximum(lse_s, e_max)
-        old_scale = tl.exp2(e_max - new_e_max)
-        exp_logic = tl.exp2(lse_s - new_e_max)
+        old_scale = tl.where(e_max == float("-inf"), 0.0, tl.exp2(e_max - new_e_max))
+        exp_logic = tl.where(lse_s == float("-inf"), 0.0, tl.exp2(lse_s - new_e_max))
 
         # Load partial outputs
         o_s = tl.sum(out_part_desc.load([s, 0]), axis=0)

--- a/flash_sparse_attn/ops/triton/flash_dense_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_bwd.py
@@ -430,6 +430,7 @@ def _bwd_dense_kernel(
                     MASK_SINK=False,
                 )
 
+        # Process m_blocks with local sink masking
         if block_sched.m_block_sink_max > block_sched.m_block_sink_min:
             for m_block in tl.range(
                 block_sched.m_block_sink_min,

--- a/flash_sparse_attn/ops/triton/flash_dense_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_bwd.py
@@ -44,6 +44,7 @@ def _bwd_inner_dense_kernel(
     IS_MASK: tl.constexpr,
     MASK_CAUSAL: tl.constexpr,
     MASK_LOCAL: tl.constexpr,
+    MASK_SINK: tl.constexpr,
 ):
     # Load query tile
     q_tile = ptrs_sched.load_q(config, q_ptrs, m_block)
@@ -61,6 +62,7 @@ def _bwd_inner_dense_kernel(
             iter_block=m_block,
             MASK_CAUSAL=MASK_CAUSAL,
             MASK_LOCAL=MASK_LOCAL,
+            MASK_SINK=MASK_SINK,
         )
 
     # Compute attention weights
@@ -169,7 +171,12 @@ def _bwd_dense_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
+    (
+        window_size_sink,
+        window_size_left,
+        window_size_right,
+        window_size_dist,
+    ) = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -183,6 +190,7 @@ def _bwd_dense_kernel(
         value_scale=value_scale,
         n_block=grid_idx.n_block,
         batch_idx=grid_idx.batch_idx,
+        window_size_sink=window_size_sink,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
         window_size_dist=window_size_dist,
@@ -312,6 +320,7 @@ def _bwd_dense_kernel(
                 IS_MASK=True,
                 MASK_CAUSAL=IS_CAUSAL,
                 MASK_LOCAL=True if IS_LOCAL else False,
+                MASK_SINK=False,
             )
 
     # Process m_blocks without masking
@@ -336,6 +345,7 @@ def _bwd_dense_kernel(
                 IS_MASK=False,
                 MASK_CAUSAL=False,
                 MASK_LOCAL=False,
+                MASK_SINK=False,
             )
 
     if IS_LOCAL:
@@ -362,6 +372,7 @@ def _bwd_dense_kernel(
                     IS_MASK=True,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
                 )
 
         # Process m_blocks without masking
@@ -390,6 +401,7 @@ def _bwd_dense_kernel(
                     IS_MASK=False,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=False,
+                    MASK_SINK=False,
                 )
 
         # Process m_blocks with local left masking
@@ -415,6 +427,32 @@ def _bwd_dense_kernel(
                     IS_MASK=True,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
+                )
+
+        if block_sched.m_block_sink_max > block_sched.m_block_sink_min:
+            for m_block in tl.range(
+                block_sched.m_block_sink_min,
+                block_sched.m_block_sink_max,
+            ):
+                acc_dk, acc_dv = _bwd_inner_dense_kernel(
+                    config=config,
+                    ptrs_sched=ptrs_sched,
+                    mask_sched=mask_sched,
+                    acc_dk=acc_dk,
+                    acc_dv=acc_dv,
+                    k_tile=k_tile,
+                    v_tile=v_tile,
+                    q_ptrs=q_ptrs,
+                    do_ptrs=do_ptrs,
+                    dq_accum_ptrs=dq_accum_ptrs,
+                    lse_ptrs=lse_ptrs,
+                    dpsum_ptrs=dpsum_ptrs,
+                    m_block=m_block,
+                    IS_MASK=True,
+                    MASK_CAUSAL=False,
+                    MASK_LOCAL=True,
+                    MASK_SINK=True,
                 )
 
     # Store value gradients
@@ -472,7 +510,7 @@ def _flash_dense_attn_backward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(
@@ -741,7 +779,7 @@ def _flash_dense_attn_varlen_backward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(

--- a/flash_sparse_attn/ops/triton/flash_dense_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_bwd.py
@@ -169,7 +169,7 @@ def _bwd_dense_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right = grid_idx.load_window_sizes(
+    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -185,6 +185,7 @@ def _bwd_dense_kernel(
         batch_idx=grid_idx.batch_idx,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
+        window_size_dist=window_size_dist,
         head_dim=head_dim,
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
@@ -471,7 +472,7 @@ def _flash_dense_attn_backward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(
@@ -735,7 +736,7 @@ def _flash_dense_attn_varlen_backward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(

--- a/flash_sparse_attn/ops/triton/flash_dense_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_bwd.py
@@ -526,6 +526,11 @@ def _flash_dense_attn_backward(
             num_SMs=num_SMs,
             TILE_M=TILE_N,
             TILE_N=TILE_M,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_M
+            )
+            if is_local
+            else None,
         )
         if is_split_qo
         else 1
@@ -790,6 +795,11 @@ def _flash_dense_attn_varlen_backward(
             num_SMs=num_SMs,
             TILE_M=TILE_N,
             TILE_N=TILE_M,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_M
+            )
+            if is_local
+            else None,
         )
         if is_split_qo
         else 1

--- a/flash_sparse_attn/ops/triton/flash_dense_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_dec.py
@@ -138,7 +138,7 @@ def _dec_dense_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right = grid_idx.load_window_sizes(
+    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -153,6 +153,7 @@ def _dec_dense_kernel(
         batch_idx=grid_idx.batch_idx,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
+        window_size_dist=window_size_dist,
         head_dim=head_dim,
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
@@ -450,7 +451,7 @@ def _flash_dense_attn_decode(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(
@@ -644,7 +645,7 @@ def _flash_dense_attn_varlen_decode(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(

--- a/flash_sparse_attn/ops/triton/flash_dense_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_dec.py
@@ -498,6 +498,9 @@ def _flash_dense_attn_decode(
         num_SMs=num_SMs,
         TILE_M=TILE_M,
         TILE_N=TILE_N,
+        max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+        if is_local
+        else None,
     )
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype
@@ -692,6 +695,9 @@ def _flash_dense_attn_varlen_decode(
         num_SMs=num_SMs,
         TILE_M=TILE_M,
         TILE_N=TILE_N,
+        max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+        if is_local
+        else None,
     )
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype

--- a/flash_sparse_attn/ops/triton/flash_dense_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_dec.py
@@ -41,6 +41,7 @@ def _dec_inner_dense_kernel(
     n_block_min,
     IS_MASK: tl.constexpr,
     MASK_LOCAL: tl.constexpr,
+    MASK_SINK: tl.constexpr,
     CHECK_INF: tl.constexpr,
 ):
     # Compute attention scores
@@ -57,6 +58,7 @@ def _dec_inner_dense_kernel(
             acc_s=acc_s,
             iter_block=n_block,
             MASK_LOCAL=MASK_LOCAL,
+            MASK_SINK=MASK_SINK,
         )
 
     # Apply online softmax
@@ -138,7 +140,12 @@ def _dec_dense_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
+    (
+        window_size_sink,
+        window_size_left,
+        window_size_right,
+        window_size_dist,
+    ) = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -151,6 +158,7 @@ def _dec_dense_kernel(
         key_scale=key_scale,
         value_scale=value_scale,
         batch_idx=grid_idx.batch_idx,
+        window_size_sink=window_size_sink,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
         window_size_dist=window_size_dist,
@@ -261,7 +269,8 @@ def _dec_dense_kernel(
             n_block=n_block,
             n_block_min=block_sched.n_block_max_no_mask,
             IS_MASK=True,
-            MASK_LOCAL=False,
+            MASK_LOCAL=True if IS_LOCAL else False,
+            MASK_SINK=False,
             CHECK_INF=True,
         )
 
@@ -289,6 +298,7 @@ def _dec_dense_kernel(
                 n_block_min=block_sched.n_block_min,
                 IS_MASK=False,
                 MASK_LOCAL=False,
+                MASK_SINK=False,
                 CHECK_INF=False,
             )
 
@@ -321,6 +331,7 @@ def _dec_dense_kernel(
                     n_block_min=block_sched.n_block_window_max_no_mask,
                     IS_MASK=True,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
                     CHECK_INF=True,
                 )
 
@@ -355,6 +366,7 @@ def _dec_dense_kernel(
                     n_block_min=block_sched.n_block_window_min_no_mask,
                     IS_MASK=False,
                     MASK_LOCAL=False,
+                    MASK_SINK=False,
                     CHECK_INF=False,
                 )
 
@@ -386,6 +398,34 @@ def _dec_dense_kernel(
                     n_block_min=block_sched.n_block_window_min,
                     IS_MASK=True,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
+                    CHECK_INF=True,
+                )
+
+        if block_sched.n_block_sink_max > block_sched.n_block_sink_min:
+            k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_sink_max - 1)
+            for n_block in tl.range(
+                block_sched.n_block_sink_max - 1,
+                block_sched.n_block_sink_min - 1,
+                -1,
+            ):
+                k_tile, acc_o, row_max, row_sum = _dec_inner_dense_kernel(
+                    config=config,
+                    ptrs_sched=ptrs_sched,
+                    mask_sched=mask_sched,
+                    softmax_sched=softmax_sched,
+                    q_tile=q_tile,
+                    k_tile=k_tile,
+                    k_ptrs=k_ptrs,
+                    v_ptrs=v_ptrs,
+                    acc_o=acc_o,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    n_block=n_block,
+                    n_block_min=block_sched.n_block_sink_min,
+                    IS_MASK=True,
+                    MASK_LOCAL=True,
+                    MASK_SINK=True,
                     CHECK_INF=True,
                 )
 
@@ -451,7 +491,7 @@ def _flash_dense_attn_decode(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(
@@ -573,7 +613,7 @@ def _flash_dense_attn_decode(
         None,
         None,
         num_splits,
-        seqlen_q=qhead_per_kvhead,
+        seqlen_q=1,
         seqlen_k=seqlen_k,
         head_dim=head_dim,
         SEQLEN_Q_CACHE=0,
@@ -648,7 +688,7 @@ def _flash_dense_attn_varlen_decode(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(
@@ -770,7 +810,7 @@ def _flash_dense_attn_varlen_decode(
         None,
         seqused_k,
         num_splits,
-        seqlen_q=qhead_per_kvhead,
+        seqlen_q=1,
         seqlen_k=seqlen_k,
         head_dim=head_dim,
         SEQLEN_Q_CACHE=0,

--- a/flash_sparse_attn/ops/triton/flash_dense_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_dec.py
@@ -402,8 +402,11 @@ def _dec_dense_kernel(
                     CHECK_INF=True,
                 )
 
+        # Process n_blocks with local sink masking
         if block_sched.n_block_sink_max > block_sched.n_block_sink_min:
+            # Load key tile
             k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_sink_max - 1)
+
             for n_block in tl.range(
                 block_sched.n_block_sink_max - 1,
                 block_sched.n_block_sink_min - 1,

--- a/flash_sparse_attn/ops/triton/flash_dense_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_fwd.py
@@ -146,7 +146,7 @@ def _fwd_dense_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right = grid_idx.load_window_sizes(
+    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -162,6 +162,7 @@ def _fwd_dense_kernel(
         batch_idx=grid_idx.batch_idx,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
+        window_size_dist=window_size_dist,
         head_dim=head_dim,
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
@@ -499,7 +500,7 @@ def _flash_dense_attn_forward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(
@@ -721,7 +722,7 @@ def _flash_dense_attn_varlen_forward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(

--- a/flash_sparse_attn/ops/triton/flash_dense_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_fwd.py
@@ -448,8 +448,11 @@ def _fwd_dense_kernel(
                     CHECK_INF=True,
                 )
 
+        # Process n_blocks with local sink masking
         if block_sched.n_block_sink_max > block_sched.n_block_sink_min:
+            # Load key tile
             k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_sink_max - 1)
+
             for n_block in tl.range(
                 block_sched.n_block_sink_max - 1,
                 block_sched.n_block_sink_min - 1,

--- a/flash_sparse_attn/ops/triton/flash_dense_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_fwd.py
@@ -236,7 +236,7 @@ def _fwd_dense_kernel(
 
     # Early exit if no n_blocks to process
     if block_sched.is_empty():
-        ptrs_sched.store_empty(config, out_ptrs, lse_ptrs)
+        ptrs_sched.store_empty(config, out_ptrs, lse_ptrs, IS_SPLIT_KV=IS_SPLIT_KV)
         return
 
     q_ptrs = ptrs_sched.make_q_ptrs(config)

--- a/flash_sparse_attn/ops/triton/flash_dense_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_fwd.py
@@ -42,6 +42,7 @@ def _fwd_inner_dense_kernel(
     IS_MASK: tl.constexpr,
     MASK_CAUSAL: tl.constexpr,
     MASK_LOCAL: tl.constexpr,
+    MASK_SINK: tl.constexpr,
     CHECK_INF: tl.constexpr,
 ):
     # Compute attention scores
@@ -59,6 +60,7 @@ def _fwd_inner_dense_kernel(
             iter_block=n_block,
             MASK_CAUSAL=MASK_CAUSAL,
             MASK_LOCAL=MASK_LOCAL,
+            MASK_SINK=MASK_SINK,
         )
 
     # Apply online softmax
@@ -146,7 +148,12 @@ def _fwd_dense_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
+    (
+        window_size_sink,
+        window_size_left,
+        window_size_right,
+        window_size_dist,
+    ) = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -160,6 +167,7 @@ def _fwd_dense_kernel(
         value_scale=value_scale,
         m_block=grid_idx.m_block,
         batch_idx=grid_idx.batch_idx,
+        window_size_sink=window_size_sink,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
         window_size_dist=window_size_dist,
@@ -277,6 +285,7 @@ def _fwd_dense_kernel(
                 IS_MASK=True,
                 MASK_CAUSAL=IS_CAUSAL,
                 MASK_LOCAL=True if IS_LOCAL else False,
+                MASK_SINK=False,
                 CHECK_INF=True,
             )
     else:
@@ -303,6 +312,7 @@ def _fwd_dense_kernel(
             IS_MASK=True,
             MASK_CAUSAL=False,
             MASK_LOCAL=False,
+            MASK_SINK=False,
             CHECK_INF=True,
         )
 
@@ -331,6 +341,7 @@ def _fwd_dense_kernel(
                 IS_MASK=False,
                 MASK_CAUSAL=False,
                 MASK_LOCAL=False,
+                MASK_SINK=False,
                 CHECK_INF=False,
             )
 
@@ -364,6 +375,7 @@ def _fwd_dense_kernel(
                     IS_MASK=True,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
                     CHECK_INF=True,
                 )
 
@@ -399,6 +411,7 @@ def _fwd_dense_kernel(
                     IS_MASK=False,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=False,
+                    MASK_SINK=False,
                     CHECK_INF=False,
                 )
 
@@ -431,6 +444,35 @@ def _fwd_dense_kernel(
                     IS_MASK=True,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
+                    CHECK_INF=True,
+                )
+
+        if block_sched.n_block_sink_max > block_sched.n_block_sink_min:
+            k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_sink_max - 1)
+            for n_block in tl.range(
+                block_sched.n_block_sink_max - 1,
+                block_sched.n_block_sink_min - 1,
+                -1,
+            ):
+                k_tile, acc_o, row_max, row_sum = _fwd_inner_dense_kernel(
+                    config=config,
+                    ptrs_sched=ptrs_sched,
+                    mask_sched=mask_sched,
+                    softmax_sched=softmax_sched,
+                    q_tile=q_tile,
+                    k_tile=k_tile,
+                    k_ptrs=k_ptrs,
+                    v_ptrs=v_ptrs,
+                    acc_o=acc_o,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    n_block=n_block,
+                    n_block_min=block_sched.n_block_sink_min,
+                    IS_MASK=True,
+                    MASK_CAUSAL=False,
+                    MASK_LOCAL=True,
+                    MASK_SINK=True,
                     CHECK_INF=True,
                 )
 
@@ -500,7 +542,7 @@ def _flash_dense_attn_forward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(
@@ -727,7 +769,7 @@ def _flash_dense_attn_varlen_forward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(

--- a/flash_sparse_attn/ops/triton/flash_dense_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_fwd.py
@@ -553,6 +553,11 @@ def _flash_dense_attn_forward(
             num_SMs=num_SMs,
             TILE_M=TILE_M,
             TILE_N=TILE_N,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_N
+            )
+            if is_local
+            else None,
         )
         if is_split_kv
         else 1
@@ -775,6 +780,11 @@ def _flash_dense_attn_varlen_forward(
             num_SMs=num_SMs,
             TILE_M=TILE_M,
             TILE_N=TILE_N,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_N
+            )
+            if is_local
+            else None,
         )
         if is_split_kv
         else 1

--- a/flash_sparse_attn/ops/triton/flash_fwd_combine.py
+++ b/flash_sparse_attn/ops/triton/flash_fwd_combine.py
@@ -136,8 +136,8 @@ def _fwd_combine_kernel(
 
         # Compute normalized exponentials
         new_e_max = tl.maximum(lse_s, e_max)
-        old_scale = tl.exp2(e_max - new_e_max)
-        exp_logic = tl.exp2(lse_s - new_e_max)
+        old_scale = tl.where(e_max == float("-inf"), 0.0, tl.exp2(e_max - new_e_max))
+        exp_logic = tl.where(lse_s == float("-inf"), 0.0, tl.exp2(lse_s - new_e_max))
 
         # Load partial outputs
         o_s = tl.sum(out_part_desc.load([s, m_block * TILE_M, 0]), axis=0)

--- a/flash_sparse_attn/ops/triton/flash_gated_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_bwd.py
@@ -730,6 +730,11 @@ def _flash_gated_attn_backward(
             num_SMs=num_SMs,
             TILE_M=TILE_N,
             TILE_N=TILE_M,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_M
+            )
+            if is_local
+            else None,
         )
         if is_split_qo
         else 1
@@ -1043,6 +1048,11 @@ def _flash_gated_attn_varlen_backward(
             num_SMs=num_SMs,
             TILE_M=TILE_N,
             TILE_N=TILE_M,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_M
+            )
+            if is_local
+            else None,
         )
         if is_split_qo
         else 1

--- a/flash_sparse_attn/ops/triton/flash_gated_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_bwd.py
@@ -256,7 +256,7 @@ def _bwd_gated_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right = grid_idx.load_window_sizes(
+    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -274,6 +274,7 @@ def _bwd_gated_kernel(
         batch_idx=grid_idx.batch_idx,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
+        window_size_dist=window_size_dist,
         head_dim=head_dim,
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
@@ -673,7 +674,7 @@ def _flash_gated_attn_backward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(
@@ -986,7 +987,7 @@ def _flash_gated_attn_varlen_backward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(

--- a/flash_sparse_attn/ops/triton/flash_gated_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_bwd.py
@@ -614,6 +614,7 @@ def _bwd_gated_kernel(
                     MASK_SINK=False,
                 )
 
+        # Process m_blocks with local sink masking
         if block_sched.m_block_sink_max > block_sched.m_block_sink_min:
             for m_block in tl.range(
                 block_sched.m_block_sink_min,

--- a/flash_sparse_attn/ops/triton/flash_gated_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_bwd.py
@@ -53,6 +53,7 @@ def _bwd_inner_gated_kernel(
     IS_MASK: tl.constexpr,
     MASK_CAUSAL: tl.constexpr,
     MASK_LOCAL: tl.constexpr,
+    MASK_SINK: tl.constexpr,
 ):
     skip_gate = False
     skip_softmax = False
@@ -104,6 +105,7 @@ def _bwd_inner_gated_kernel(
                 iter_block=m_block,
                 MASK_CAUSAL=MASK_CAUSAL,
                 MASK_LOCAL=MASK_LOCAL,
+                MASK_SINK=MASK_SINK,
             )
 
         # Load LSE
@@ -256,7 +258,12 @@ def _bwd_gated_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
+    (
+        window_size_sink,
+        window_size_left,
+        window_size_right,
+        window_size_dist,
+    ) = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -272,6 +279,7 @@ def _bwd_gated_kernel(
         value_scale=value_scale,
         n_block=grid_idx.n_block,
         batch_idx=grid_idx.batch_idx,
+        window_size_sink=window_size_sink,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
         window_size_dist=window_size_dist,
@@ -444,6 +452,7 @@ def _bwd_gated_kernel(
                 IS_MASK=True,
                 MASK_CAUSAL=IS_CAUSAL,
                 MASK_LOCAL=True if IS_LOCAL else False,
+                MASK_SINK=False,
             )
 
     # Process m_blocks without masking
@@ -481,6 +490,7 @@ def _bwd_gated_kernel(
                 IS_MASK=False,
                 MASK_CAUSAL=False,
                 MASK_LOCAL=False,
+                MASK_SINK=False,
             )
 
     if IS_LOCAL:
@@ -520,6 +530,7 @@ def _bwd_gated_kernel(
                     IS_MASK=True,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
                 )
 
         # Process m_blocks without masking
@@ -561,6 +572,7 @@ def _bwd_gated_kernel(
                     IS_MASK=False,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=False,
+                    MASK_SINK=False,
                 )
 
         # Process m_blocks with local left masking
@@ -599,6 +611,45 @@ def _bwd_gated_kernel(
                     IS_MASK=True,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
+                )
+
+        if block_sched.m_block_sink_max > block_sched.m_block_sink_min:
+            for m_block in tl.range(
+                block_sched.m_block_sink_min,
+                block_sched.m_block_sink_max,
+            ):
+                (
+                    acc_dk,
+                    acc_dv,
+                    acc_dd,
+                    gate_max,
+                ) = _bwd_inner_gated_kernel(
+                    config=config,
+                    ptrs_sched=ptrs_sched,
+                    mask_sched=mask_sched,
+                    softmax_sched=softmax_sched,
+                    acc_dk=acc_dk,
+                    acc_dv=acc_dv,
+                    acc_dd=acc_dd,
+                    k_tile=k_tile,
+                    v_tile=v_tile,
+                    d_tile=d_tile,
+                    q_ptrs=q_ptrs,
+                    a_ptrs=a_ptrs,
+                    do_ptrs=do_ptrs,
+                    dq_accum_ptrs=dq_accum_ptrs,
+                    da_ptrs=da_ptrs,
+                    lse_ptrs=lse_ptrs,
+                    dpsum_ptrs=dpsum_ptrs,
+                    d_max=d_max,
+                    d_min=d_min,
+                    gate_max=gate_max,
+                    m_block=m_block,
+                    IS_MASK=True,
+                    MASK_CAUSAL=False,
+                    MASK_LOCAL=True,
+                    MASK_SINK=True,
                 )
 
     # Store value gradients
@@ -674,7 +725,7 @@ def _flash_gated_attn_backward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(
@@ -992,7 +1043,7 @@ def _flash_gated_attn_varlen_backward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(

--- a/flash_sparse_attn/ops/triton/flash_gated_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_dec.py
@@ -790,6 +790,9 @@ def _flash_gated_attn_decode(
         num_SMs=num_SMs,
         TILE_M=TILE_M,
         TILE_N=TILE_N,
+        max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+        if is_local
+        else None,
     )
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype
@@ -1006,6 +1009,9 @@ def _flash_gated_attn_varlen_decode(
         num_SMs=num_SMs,
         TILE_M=TILE_M,
         TILE_N=TILE_N,
+        max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+        if is_local
+        else None,
     )
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype

--- a/flash_sparse_attn/ops/triton/flash_gated_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_dec.py
@@ -47,6 +47,7 @@ def _dec_inner_gated_kernel(
     n_block_min,
     IS_MASK: tl.constexpr,
     MASK_LOCAL: tl.constexpr,
+    MASK_SINK: tl.constexpr,
     CHECK_INF: tl.constexpr,
 ):
     # Load next delta tile
@@ -73,6 +74,7 @@ def _dec_inner_gated_kernel(
                 acc_s=acc_s,
                 iter_block=n_block,
                 MASK_LOCAL=MASK_LOCAL,
+                MASK_SINK=MASK_SINK,
             )
 
         # Apply online softmax
@@ -200,7 +202,12 @@ def _dec_gated_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
+    (
+        window_size_sink,
+        window_size_left,
+        window_size_right,
+        window_size_dist,
+    ) = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -215,6 +222,7 @@ def _dec_gated_kernel(
         key_scale=key_scale,
         value_scale=value_scale,
         batch_idx=grid_idx.batch_idx,
+        window_size_sink=window_size_sink,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
         window_size_dist=window_size_dist,
@@ -382,7 +390,8 @@ def _dec_gated_kernel(
             n_block=n_block,
             n_block_min=block_sched.n_block_max_no_mask,
             IS_MASK=True,
-            MASK_LOCAL=False,
+            MASK_LOCAL=True if IS_LOCAL else False,
+            MASK_SINK=False,
             CHECK_INF=True,
         )
 
@@ -448,6 +457,7 @@ def _dec_gated_kernel(
                 n_block_min=block_sched.n_block_min,
                 IS_MASK=False,
                 MASK_LOCAL=False,
+                MASK_SINK=False,
                 CHECK_INF=False,
             )
 
@@ -520,6 +530,7 @@ def _dec_gated_kernel(
                     n_block_min=block_sched.n_block_window_max_no_mask,
                     IS_MASK=True,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
                     CHECK_INF=True,
                 )
 
@@ -594,6 +605,7 @@ def _dec_gated_kernel(
                     n_block_min=block_sched.n_block_window_min_no_mask,
                     IS_MASK=False,
                     MASK_LOCAL=False,
+                    MASK_SINK=False,
                     CHECK_INF=False,
                 )
 
@@ -665,6 +677,74 @@ def _dec_gated_kernel(
                     n_block_min=block_sched.n_block_window_min,
                     IS_MASK=True,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
+                    CHECK_INF=True,
+                )
+
+        if block_sched.n_block_sink_max > block_sched.n_block_sink_min:
+            # Load key tile
+            k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_sink_max - 1)
+
+            # Load delta tile
+            d_tile = ptrs_sched.load_d(config, d_ptrs, block_sched.n_block_sink_max - 1)
+            d_max = tl.max(d_tile)
+            d_min = tl.min(d_tile)
+
+            # Check if any gates are active for current tile
+            gate_max, skip_gate_curr = softmax_sched.online_gate(
+                a_max=a_max,
+                a_min=a_min,
+                d_max=d_max,
+                d_min=d_min,
+                gate_max=gate_max,
+                gate_threshold_log2=config.gate_threshold_log2,
+            )
+
+            # Compute attention gates
+            acc_s = a_tile[:, None] * d_tile[None, :]
+            if IS_LOGSIGMOID_GATE:
+                acc_s = softmax_sched.log_sigmoid(
+                    acc_s=acc_s,
+                )
+
+            # Compute attention scores
+            acc_s += tl.dot(q_tile, k_tile.T)
+
+            for n_block in tl.range(
+                block_sched.n_block_sink_max - 1,
+                block_sched.n_block_sink_min - 1,
+                -1,
+            ):
+                (
+                    skip_gate_curr,
+                    acc_s,
+                    acc_o,
+                    gate_max,
+                    row_max,
+                    row_sum,
+                ) = _dec_inner_gated_kernel(
+                    config=config,
+                    ptrs_sched=ptrs_sched,
+                    mask_sched=mask_sched,
+                    softmax_sched=softmax_sched,
+                    skip_gate_curr=skip_gate_curr,
+                    acc_s=acc_s,
+                    acc_o=acc_o,
+                    q_tile=q_tile,
+                    a_tile=a_tile,
+                    k_ptrs=k_ptrs,
+                    v_ptrs=v_ptrs,
+                    d_ptrs=d_ptrs,
+                    a_max=a_max,
+                    a_min=a_min,
+                    gate_max=gate_max,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    n_block=n_block,
+                    n_block_min=block_sched.n_block_sink_min,
+                    IS_MASK=True,
+                    MASK_LOCAL=True,
+                    MASK_SINK=True,
                     CHECK_INF=True,
                 )
 
@@ -741,7 +821,7 @@ def _flash_gated_attn_decode(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(
@@ -873,7 +953,7 @@ def _flash_gated_attn_decode(
         None,
         None,
         num_splits,
-        seqlen_q=qhead_per_kvhead,
+        seqlen_q=1,
         seqlen_k=seqlen_k,
         head_dim=head_dim,
         SEQLEN_Q_CACHE=0,
@@ -960,7 +1040,7 @@ def _flash_gated_attn_varlen_decode(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(
@@ -1092,7 +1172,7 @@ def _flash_gated_attn_varlen_decode(
         None,
         seqused_k,
         num_splits,
-        seqlen_q=qhead_per_kvhead,
+        seqlen_q=1,
         seqlen_k=seqlen_k,
         head_dim=head_dim,
         SEQLEN_Q_CACHE=0,

--- a/flash_sparse_attn/ops/triton/flash_gated_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_dec.py
@@ -681,6 +681,7 @@ def _dec_gated_kernel(
                     CHECK_INF=True,
                 )
 
+        # Process n_blocks with local sink masking
         if block_sched.n_block_sink_max > block_sched.n_block_sink_min:
             # Load key tile
             k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_sink_max - 1)

--- a/flash_sparse_attn/ops/triton/flash_gated_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_dec.py
@@ -200,7 +200,7 @@ def _dec_gated_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right = grid_idx.load_window_sizes(
+    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -217,6 +217,7 @@ def _dec_gated_kernel(
         batch_idx=grid_idx.batch_idx,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
+        window_size_dist=window_size_dist,
         head_dim=head_dim,
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
@@ -740,7 +741,7 @@ def _flash_gated_attn_decode(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(
@@ -956,7 +957,7 @@ def _flash_gated_attn_varlen_decode(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(

--- a/flash_sparse_attn/ops/triton/flash_gated_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_fwd.py
@@ -865,6 +865,11 @@ def _flash_gated_attn_forward(
             num_SMs=num_SMs,
             TILE_M=TILE_M,
             TILE_N=TILE_N,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_N
+            )
+            if is_local
+            else None,
         )
         if is_split_kv
         else 1
@@ -1113,6 +1118,11 @@ def _flash_gated_attn_varlen_forward(
             num_SMs=num_SMs,
             TILE_M=TILE_M,
             TILE_N=TILE_N,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_N
+            )
+            if is_local
+            else None,
         )
         if is_split_kv
         else 1

--- a/flash_sparse_attn/ops/triton/flash_gated_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_fwd.py
@@ -314,7 +314,7 @@ def _fwd_gated_kernel(
 
     # Early exit if no n_blocks to process
     if block_sched.is_empty():
-        ptrs_sched.store_empty(config, out_ptrs, lse_ptrs)
+        ptrs_sched.store_empty(config, out_ptrs, lse_ptrs, IS_SPLIT_KV=IS_SPLIT_KV)
         return
 
     q_ptrs = ptrs_sched.make_q_ptrs(config)

--- a/flash_sparse_attn/ops/triton/flash_gated_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_fwd.py
@@ -210,7 +210,7 @@ def _fwd_gated_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right = grid_idx.load_window_sizes(
+    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -228,6 +228,7 @@ def _fwd_gated_kernel(
         batch_idx=grid_idx.batch_idx,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
+        window_size_dist=window_size_dist,
         head_dim=head_dim,
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
@@ -809,7 +810,7 @@ def _flash_gated_attn_forward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(
@@ -1057,7 +1058,7 @@ def _flash_gated_attn_varlen_forward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(

--- a/flash_sparse_attn/ops/triton/flash_gated_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_fwd.py
@@ -735,6 +735,7 @@ def _fwd_gated_kernel(
                     CHECK_INF=True,
                 )
 
+        # Process n_blocks with local sink masking
         if block_sched.n_block_sink_max > block_sched.n_block_sink_min:
             # Load key tile
             k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_sink_max - 1)

--- a/flash_sparse_attn/ops/triton/flash_gated_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_fwd.py
@@ -48,26 +48,11 @@ def _fwd_inner_gated_kernel(
     IS_MASK: tl.constexpr,
     MASK_CAUSAL: tl.constexpr,
     MASK_LOCAL: tl.constexpr,
+    MASK_SINK: tl.constexpr,
     CHECK_INF: tl.constexpr,
 ):
-    # Load next delta tile
-    d_tile = ptrs_sched.load_d(config, d_ptrs, n_block - 1)
-    d_max = tl.max(d_tile)
-    d_min = tl.min(d_tile)
-
     skip_gate_next = True
     if not skip_gate_curr:
-        if n_block > n_block_min:
-            # Check if any gates are active for next tile
-            gate_max, skip_gate_next = softmax_sched.online_gate(
-                a_max=a_max,
-                a_min=a_min,
-                d_max=d_max,
-                d_min=d_min,
-                gate_max=gate_max,
-                gate_threshold_log2=config.gate_threshold_log2,
-            )
-
         if IS_MASK:
             # Apply mask
             acc_s = mask_sched.apply_mask(
@@ -75,6 +60,7 @@ def _fwd_inner_gated_kernel(
                 iter_block=n_block,
                 MASK_CAUSAL=MASK_CAUSAL,
                 MASK_LOCAL=MASK_LOCAL,
+                MASK_SINK=MASK_SINK,
             )
 
         # Apply online sparse softmax
@@ -100,31 +86,36 @@ def _fwd_inner_gated_kernel(
 
             # Update output accumulator
             acc_o += tl.dot(p.to(v_tile.dtype), v_tile)
-    else:
-        if n_block > n_block_min:
-            # Check if any gates are active for next tile
-            gate_max, skip_gate_next = softmax_sched.online_gate(
-                a_max=a_max,
-                a_min=a_min,
-                d_max=d_max,
-                d_min=d_min,
-                gate_max=gate_max,
-                gate_threshold_log2=config.gate_threshold_log2,
-            )
 
-    if not skip_gate_next:
-        # Compute attention gates for next tile
-        acc_s = a_tile[:, None] * d_tile[None, :]
-        if config.IS_LOGSIGMOID_GATE:
-            acc_s = softmax_sched.log_sigmoid(
-                acc_s=acc_s,
-            )
+    if n_block > n_block_min:
+        # Load next delta tile
+        d_tile = ptrs_sched.load_d(config, d_ptrs, n_block - 1)
+        d_max = tl.max(d_tile)
+        d_min = tl.min(d_tile)
 
-        # Load next key tile
-        k_tile = ptrs_sched.load_k(config, k_ptrs, n_block - 1)
+        # Check if any gates are active for next tile
+        gate_max, skip_gate_next = softmax_sched.online_gate(
+            a_max=a_max,
+            a_min=a_min,
+            d_max=d_max,
+            d_min=d_min,
+            gate_max=gate_max,
+            gate_threshold_log2=config.gate_threshold_log2,
+        )
 
-        # Compute attention scores for next tile
-        acc_s += tl.dot(q_tile, k_tile.T)
+        if not skip_gate_next:
+            # Compute attention gates for next tile
+            acc_s = a_tile[:, None] * d_tile[None, :]
+            if config.IS_LOGSIGMOID_GATE:
+                acc_s = softmax_sched.log_sigmoid(
+                    acc_s=acc_s,
+                )
+
+            # Load next key tile
+            k_tile = ptrs_sched.load_k(config, k_ptrs, n_block - 1)
+
+            # Compute attention scores for next tile
+            acc_s += tl.dot(q_tile, k_tile.T)
 
     return (
         skip_gate_next,
@@ -210,7 +201,12 @@ def _fwd_gated_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
+    (
+        window_size_sink,
+        window_size_left,
+        window_size_right,
+        window_size_dist,
+    ) = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -226,6 +222,7 @@ def _fwd_gated_kernel(
         value_scale=value_scale,
         m_block=grid_idx.m_block,
         batch_idx=grid_idx.batch_idx,
+        window_size_sink=window_size_sink,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
         window_size_dist=window_size_dist,
@@ -404,6 +401,7 @@ def _fwd_gated_kernel(
                 IS_MASK=True,
                 MASK_CAUSAL=IS_CAUSAL,
                 MASK_LOCAL=True if IS_LOCAL else False,
+                MASK_SINK=False,
                 CHECK_INF=True,
             )
     else:
@@ -443,6 +441,7 @@ def _fwd_gated_kernel(
             IS_MASK=True,
             MASK_CAUSAL=False,
             MASK_LOCAL=False,
+            MASK_SINK=False,
             CHECK_INF=True,
         )
 
@@ -509,6 +508,7 @@ def _fwd_gated_kernel(
                 IS_MASK=False,
                 MASK_CAUSAL=False,
                 MASK_LOCAL=False,
+                MASK_SINK=False,
                 CHECK_INF=False,
             )
 
@@ -582,6 +582,7 @@ def _fwd_gated_kernel(
                     IS_MASK=True,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
                     CHECK_INF=True,
                 )
 
@@ -657,6 +658,7 @@ def _fwd_gated_kernel(
                     IS_MASK=False,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=False,
+                    MASK_SINK=False,
                     CHECK_INF=False,
                 )
 
@@ -729,6 +731,75 @@ def _fwd_gated_kernel(
                     IS_MASK=True,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
+                    CHECK_INF=True,
+                )
+
+        if block_sched.n_block_sink_max > block_sched.n_block_sink_min:
+            # Load key tile
+            k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_sink_max - 1)
+
+            # Load delta tile
+            d_tile = ptrs_sched.load_d(config, d_ptrs, block_sched.n_block_sink_max - 1)
+            d_max = tl.max(d_tile)
+            d_min = tl.min(d_tile)
+
+            # Check if any gates are active for current tile
+            gate_max, skip_gate_curr = softmax_sched.online_gate(
+                a_max=a_max,
+                a_min=a_min,
+                d_max=d_max,
+                d_min=d_min,
+                gate_max=gate_max,
+                gate_threshold_log2=config.gate_threshold_log2,
+            )
+
+            # Compute attention gates
+            acc_s = a_tile[:, None] * d_tile[None, :]
+            if IS_LOGSIGMOID_GATE:
+                acc_s = softmax_sched.log_sigmoid(
+                    acc_s=acc_s,
+                )
+
+            # Compute attention scores
+            acc_s += tl.dot(q_tile, k_tile.T)
+
+            for n_block in tl.range(
+                block_sched.n_block_sink_max - 1,
+                block_sched.n_block_sink_min - 1,
+                -1,
+            ):
+                (
+                    skip_gate_curr,
+                    acc_s,
+                    acc_o,
+                    gate_max,
+                    row_max,
+                    row_sum,
+                ) = _fwd_inner_gated_kernel(
+                    config=config,
+                    ptrs_sched=ptrs_sched,
+                    mask_sched=mask_sched,
+                    softmax_sched=softmax_sched,
+                    skip_gate_curr=skip_gate_curr,
+                    acc_s=acc_s,
+                    acc_o=acc_o,
+                    q_tile=q_tile,
+                    a_tile=a_tile,
+                    k_ptrs=k_ptrs,
+                    v_ptrs=v_ptrs,
+                    d_ptrs=d_ptrs,
+                    a_max=a_max,
+                    a_min=a_min,
+                    gate_max=gate_max,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    n_block=n_block,
+                    n_block_min=block_sched.n_block_sink_min,
+                    IS_MASK=True,
+                    MASK_CAUSAL=False,
+                    MASK_LOCAL=True,
+                    MASK_SINK=True,
                     CHECK_INF=True,
                 )
 
@@ -810,7 +881,7 @@ def _flash_gated_attn_forward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(
@@ -1063,7 +1134,7 @@ def _flash_gated_attn_varlen_forward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(

--- a/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
@@ -180,7 +180,7 @@ def _bwd_sparse_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right = grid_idx.load_window_sizes(
+    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -197,6 +197,7 @@ def _bwd_sparse_kernel(
         batch_idx=grid_idx.batch_idx,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
+        window_size_dist=window_size_dist,
         head_dim=head_dim,
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
@@ -487,7 +488,7 @@ def _flash_sparse_attn_backward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(
@@ -756,7 +757,7 @@ def _flash_sparse_attn_varlen_backward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(

--- a/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
@@ -542,6 +542,11 @@ def _flash_sparse_attn_backward(
             num_SMs=num_SMs,
             TILE_M=TILE_N,
             TILE_N=TILE_M,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_M
+            )
+            if is_local
+            else None,
         )
         if is_split_qo
         else 1
@@ -811,6 +816,11 @@ def _flash_sparse_attn_varlen_backward(
             num_SMs=num_SMs,
             TILE_M=TILE_N,
             TILE_N=TILE_M,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_M
+            )
+            if is_local
+            else None,
         )
         if is_split_qo
         else 1

--- a/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
@@ -442,6 +442,7 @@ def _bwd_sparse_kernel(
                     MASK_SINK=False,
                 )
 
+        # Process m_blocks with local sink masking
         if block_sched.m_block_sink_max > block_sched.m_block_sink_min:
             for m_block in tl.range(
                 block_sched.m_block_sink_min,

--- a/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
@@ -44,6 +44,7 @@ def _bwd_inner_sparse_kernel(
     IS_MASK: tl.constexpr,
     MASK_CAUSAL: tl.constexpr,
     MASK_LOCAL: tl.constexpr,
+    MASK_SINK: tl.constexpr,
 ):
     # Load query tile
     q_tile = ptrs_sched.load_q(config, q_ptrs, m_block)
@@ -58,6 +59,7 @@ def _bwd_inner_sparse_kernel(
             iter_block=m_block,
             MASK_CAUSAL=MASK_CAUSAL,
             MASK_LOCAL=MASK_LOCAL,
+            MASK_SINK=MASK_SINK,
         )
 
     # Load LSE
@@ -180,7 +182,12 @@ def _bwd_sparse_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
+    (
+        window_size_sink,
+        window_size_left,
+        window_size_right,
+        window_size_dist,
+    ) = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -195,6 +202,7 @@ def _bwd_sparse_kernel(
         value_scale=value_scale,
         n_block=grid_idx.n_block,
         batch_idx=grid_idx.batch_idx,
+        window_size_sink=window_size_sink,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
         window_size_dist=window_size_dist,
@@ -324,6 +332,7 @@ def _bwd_sparse_kernel(
                 IS_MASK=True,
                 MASK_CAUSAL=IS_CAUSAL,
                 MASK_LOCAL=True if IS_LOCAL else False,
+                MASK_SINK=False,
             )
 
     # Process m_blocks without masking
@@ -348,6 +357,7 @@ def _bwd_sparse_kernel(
                 IS_MASK=False,
                 MASK_CAUSAL=False,
                 MASK_LOCAL=False,
+                MASK_SINK=False,
             )
 
     if IS_LOCAL:
@@ -374,6 +384,7 @@ def _bwd_sparse_kernel(
                     IS_MASK=True,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
                 )
 
         # Process m_blocks without masking
@@ -402,6 +413,7 @@ def _bwd_sparse_kernel(
                     IS_MASK=False,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=False,
+                    MASK_SINK=False,
                 )
 
         # Process m_blocks with local left masking
@@ -427,6 +439,32 @@ def _bwd_sparse_kernel(
                     IS_MASK=True,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
+                )
+
+        if block_sched.m_block_sink_max > block_sched.m_block_sink_min:
+            for m_block in tl.range(
+                block_sched.m_block_sink_min,
+                block_sched.m_block_sink_max,
+            ):
+                acc_dk, acc_dv = _bwd_inner_sparse_kernel(
+                    config=config,
+                    ptrs_sched=ptrs_sched,
+                    mask_sched=mask_sched,
+                    acc_dk=acc_dk,
+                    acc_dv=acc_dv,
+                    k_tile=k_tile,
+                    v_tile=v_tile,
+                    q_ptrs=q_ptrs,
+                    do_ptrs=do_ptrs,
+                    dq_accum_ptrs=dq_accum_ptrs,
+                    lse_ptrs=lse_ptrs,
+                    dpsum_ptrs=dpsum_ptrs,
+                    m_block=m_block,
+                    IS_MASK=True,
+                    MASK_CAUSAL=False,
+                    MASK_LOCAL=True,
+                    MASK_SINK=True,
                 )
 
     # Store value gradients
@@ -488,7 +526,7 @@ def _flash_sparse_attn_backward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(
@@ -762,7 +800,7 @@ def _flash_sparse_attn_varlen_backward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(

--- a/flash_sparse_attn/ops/triton/flash_sparse_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_dec.py
@@ -41,6 +41,7 @@ def _dec_inner_sparse_kernel(
     n_block_min,
     IS_MASK: tl.constexpr,
     MASK_LOCAL: tl.constexpr,
+    MASK_SINK: tl.constexpr,
     CHECK_INF: tl.constexpr,
 ):
     # Compute attention scores
@@ -57,6 +58,7 @@ def _dec_inner_sparse_kernel(
             acc_s=acc_s,
             iter_block=n_block,
             MASK_LOCAL=MASK_LOCAL,
+            MASK_SINK=MASK_SINK,
         )
 
     # Apply online sparse softmax
@@ -141,7 +143,12 @@ def _dec_sparse_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
+    (
+        window_size_sink,
+        window_size_left,
+        window_size_right,
+        window_size_dist,
+    ) = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -155,6 +162,7 @@ def _dec_sparse_kernel(
         key_scale=key_scale,
         value_scale=value_scale,
         batch_idx=grid_idx.batch_idx,
+        window_size_sink=window_size_sink,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
         window_size_dist=window_size_dist,
@@ -265,7 +273,8 @@ def _dec_sparse_kernel(
             n_block=n_block,
             n_block_min=block_sched.n_block_max_no_mask,
             IS_MASK=True,
-            MASK_LOCAL=False,
+            MASK_LOCAL=True if IS_LOCAL else False,
+            MASK_SINK=False,
             CHECK_INF=True,
         )
 
@@ -293,6 +302,7 @@ def _dec_sparse_kernel(
                 n_block_min=block_sched.n_block_min,
                 IS_MASK=False,
                 MASK_LOCAL=False,
+                MASK_SINK=False,
                 CHECK_INF=False,
             )
 
@@ -325,6 +335,7 @@ def _dec_sparse_kernel(
                     n_block_min=block_sched.n_block_window_max_no_mask,
                     IS_MASK=True,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
                     CHECK_INF=True,
                 )
 
@@ -359,6 +370,7 @@ def _dec_sparse_kernel(
                     n_block_min=block_sched.n_block_window_min_no_mask,
                     IS_MASK=False,
                     MASK_LOCAL=False,
+                    MASK_SINK=False,
                     CHECK_INF=False,
                 )
 
@@ -390,6 +402,34 @@ def _dec_sparse_kernel(
                     n_block_min=block_sched.n_block_window_min,
                     IS_MASK=True,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
+                    CHECK_INF=True,
+                )
+
+        if block_sched.n_block_sink_max > block_sched.n_block_sink_min:
+            k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_sink_max - 1)
+            for n_block in tl.range(
+                block_sched.n_block_sink_max - 1,
+                block_sched.n_block_sink_min - 1,
+                -1,
+            ):
+                k_tile, acc_o, row_max, row_sum = _dec_inner_sparse_kernel(
+                    config=config,
+                    ptrs_sched=ptrs_sched,
+                    mask_sched=mask_sched,
+                    softmax_sched=softmax_sched,
+                    q_tile=q_tile,
+                    k_tile=k_tile,
+                    k_ptrs=k_ptrs,
+                    v_ptrs=v_ptrs,
+                    acc_o=acc_o,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    n_block=n_block,
+                    n_block_min=block_sched.n_block_sink_min,
+                    IS_MASK=True,
+                    MASK_LOCAL=True,
+                    MASK_SINK=True,
                     CHECK_INF=True,
                 )
 
@@ -459,7 +499,7 @@ def _flash_sparse_attn_decode(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(
@@ -582,7 +622,7 @@ def _flash_sparse_attn_decode(
         None,
         None,
         num_splits,
-        seqlen_q=qhead_per_kvhead,
+        seqlen_q=1,
         seqlen_k=seqlen_k,
         head_dim=head_dim,
         SEQLEN_Q_CACHE=0,
@@ -661,7 +701,7 @@ def _flash_sparse_attn_varlen_decode(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(
@@ -784,7 +824,7 @@ def _flash_sparse_attn_varlen_decode(
         None,
         seqused_k,
         num_splits,
-        seqlen_q=qhead_per_kvhead,
+        seqlen_q=1,
         seqlen_k=seqlen_k,
         head_dim=head_dim,
         SEQLEN_Q_CACHE=0,

--- a/flash_sparse_attn/ops/triton/flash_sparse_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_dec.py
@@ -141,7 +141,7 @@ def _dec_sparse_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right = grid_idx.load_window_sizes(
+    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -157,6 +157,7 @@ def _dec_sparse_kernel(
         batch_idx=grid_idx.batch_idx,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
+        window_size_dist=window_size_dist,
         head_dim=head_dim,
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
@@ -458,7 +459,7 @@ def _flash_sparse_attn_decode(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(
@@ -657,7 +658,7 @@ def _flash_sparse_attn_varlen_decode(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(

--- a/flash_sparse_attn/ops/triton/flash_sparse_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_dec.py
@@ -406,8 +406,11 @@ def _dec_sparse_kernel(
                     CHECK_INF=True,
                 )
 
+        # Process n_blocks with local sink masking
         if block_sched.n_block_sink_max > block_sched.n_block_sink_min:
+            # Load key tile
             k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_sink_max - 1)
+
             for n_block in tl.range(
                 block_sched.n_block_sink_max - 1,
                 block_sched.n_block_sink_min - 1,

--- a/flash_sparse_attn/ops/triton/flash_sparse_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_dec.py
@@ -506,6 +506,9 @@ def _flash_sparse_attn_decode(
         num_SMs=num_SMs,
         TILE_M=TILE_M,
         TILE_N=TILE_N,
+        max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+        if is_local
+        else None,
     )
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype
@@ -705,6 +708,9 @@ def _flash_sparse_attn_varlen_decode(
         num_SMs=num_SMs,
         TILE_M=TILE_M,
         TILE_N=TILE_N,
+        max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+        if is_local
+        else None,
     )
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype

--- a/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
@@ -452,8 +452,11 @@ def _fwd_sparse_kernel(
                     CHECK_INF=True,
                 )
 
+        # Process n_blocks with local sink masking
         if block_sched.n_block_sink_max > block_sched.n_block_sink_min:
+            # Load key tile
             k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_sink_max - 1)
+
             for n_block in tl.range(
                 block_sched.n_block_sink_max - 1,
                 block_sched.n_block_sink_min - 1,

--- a/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
@@ -240,7 +240,7 @@ def _fwd_sparse_kernel(
 
     # Early exit if no n_blocks to process
     if block_sched.is_empty():
-        ptrs_sched.store_empty(config, out_ptrs, lse_ptrs)
+        ptrs_sched.store_empty(config, out_ptrs, lse_ptrs, IS_SPLIT_KV=IS_SPLIT_KV)
         return
 
     q_ptrs = ptrs_sched.make_q_ptrs(config)

--- a/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
@@ -149,7 +149,7 @@ def _fwd_sparse_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right = grid_idx.load_window_sizes(
+    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -166,6 +166,7 @@ def _fwd_sparse_kernel(
         batch_idx=grid_idx.batch_idx,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
+        window_size_dist=window_size_dist,
         head_dim=head_dim,
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
@@ -507,7 +508,7 @@ def _flash_sparse_attn_forward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(
@@ -734,7 +735,7 @@ def _flash_sparse_attn_varlen_forward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 2), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(

--- a/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
@@ -561,6 +561,11 @@ def _flash_sparse_attn_forward(
             num_SMs=num_SMs,
             TILE_M=TILE_M,
             TILE_N=TILE_N,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_N
+            )
+            if is_local
+            else None,
         )
         if is_split_kv
         else 1
@@ -788,6 +793,11 @@ def _flash_sparse_attn_varlen_forward(
             num_SMs=num_SMs,
             TILE_M=TILE_M,
             TILE_N=TILE_N,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_N
+            )
+            if is_local
+            else None,
         )
         if is_split_kv
         else 1

--- a/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
@@ -42,6 +42,7 @@ def _fwd_inner_sparse_kernel(
     IS_MASK: tl.constexpr,
     MASK_CAUSAL: tl.constexpr,
     MASK_LOCAL: tl.constexpr,
+    MASK_SINK: tl.constexpr,
     CHECK_INF: tl.constexpr,
 ):
     # Compute attention scores
@@ -59,6 +60,7 @@ def _fwd_inner_sparse_kernel(
             iter_block=n_block,
             MASK_CAUSAL=MASK_CAUSAL,
             MASK_LOCAL=MASK_LOCAL,
+            MASK_SINK=MASK_SINK,
         )
 
     # Apply online sparse softmax
@@ -149,7 +151,12 @@ def _fwd_sparse_kernel(
     )
 
     # Load window sizes
-    window_size_left, window_size_right, window_size_dist = grid_idx.load_window_sizes(
+    (
+        window_size_sink,
+        window_size_left,
+        window_size_right,
+        window_size_dist,
+    ) = grid_idx.load_window_sizes(
         window_sizes=window_sizes,
         stride_wh=stride_wh,
         IS_LOCAL=IS_LOCAL,
@@ -164,6 +171,7 @@ def _fwd_sparse_kernel(
         value_scale=value_scale,
         m_block=grid_idx.m_block,
         batch_idx=grid_idx.batch_idx,
+        window_size_sink=window_size_sink,
         window_size_left=window_size_left,
         window_size_right=window_size_right,
         window_size_dist=window_size_dist,
@@ -281,6 +289,7 @@ def _fwd_sparse_kernel(
                 IS_MASK=True,
                 MASK_CAUSAL=IS_CAUSAL,
                 MASK_LOCAL=True if IS_LOCAL else False,
+                MASK_SINK=False,
                 CHECK_INF=True,
             )
     else:
@@ -307,6 +316,7 @@ def _fwd_sparse_kernel(
             IS_MASK=True,
             MASK_CAUSAL=False,
             MASK_LOCAL=False,
+            MASK_SINK=False,
             CHECK_INF=True,
         )
 
@@ -335,6 +345,7 @@ def _fwd_sparse_kernel(
                 IS_MASK=False,
                 MASK_CAUSAL=False,
                 MASK_LOCAL=False,
+                MASK_SINK=False,
                 CHECK_INF=False,
             )
 
@@ -368,6 +379,7 @@ def _fwd_sparse_kernel(
                     IS_MASK=True,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
                     CHECK_INF=True,
                 )
 
@@ -403,6 +415,7 @@ def _fwd_sparse_kernel(
                     IS_MASK=False,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=False,
+                    MASK_SINK=False,
                     CHECK_INF=False,
                 )
 
@@ -435,6 +448,35 @@ def _fwd_sparse_kernel(
                     IS_MASK=True,
                     MASK_CAUSAL=False,
                     MASK_LOCAL=True,
+                    MASK_SINK=False,
+                    CHECK_INF=True,
+                )
+
+        if block_sched.n_block_sink_max > block_sched.n_block_sink_min:
+            k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_sink_max - 1)
+            for n_block in tl.range(
+                block_sched.n_block_sink_max - 1,
+                block_sched.n_block_sink_min - 1,
+                -1,
+            ):
+                k_tile, acc_o, row_max, row_sum = _fwd_inner_sparse_kernel(
+                    config=config,
+                    ptrs_sched=ptrs_sched,
+                    mask_sched=mask_sched,
+                    softmax_sched=softmax_sched,
+                    q_tile=q_tile,
+                    k_tile=k_tile,
+                    k_ptrs=k_ptrs,
+                    v_ptrs=v_ptrs,
+                    acc_o=acc_o,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    n_block=n_block,
+                    n_block_min=block_sched.n_block_sink_min,
+                    IS_MASK=True,
+                    MASK_CAUSAL=False,
+                    MASK_LOCAL=True,
+                    MASK_SINK=True,
                     CHECK_INF=True,
                 )
 
@@ -508,7 +550,7 @@ def _flash_sparse_attn_forward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(
@@ -740,7 +782,7 @@ def _flash_sparse_attn_varlen_forward(
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
     elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 3), dtype=torch.int32, device=device)
+        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(

--- a/flash_sparse_attn/ops/triton/interface.py
+++ b/flash_sparse_attn/ops/triton/interface.py
@@ -932,7 +932,7 @@ def flash_dense_attn_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided or will be computed from the input tensors.
     :param is_split_kv: Whether to enable split-KV for forward occupancy.
@@ -996,7 +996,7 @@ def flash_dense_attn_with_kvcache_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
@@ -1080,7 +1080,7 @@ def flash_dense_attn_varlen_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided or will be computed from the input tensors.
     :param is_split_kv: Whether to enable split-KV for forward occupancy.
@@ -1157,7 +1157,7 @@ def flash_dense_attn_varlen_with_kvcache_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param seqused_k: Optional tensor indicating the actual sequence lengths for keys/values.
@@ -1236,7 +1236,7 @@ def flash_sparse_attn_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to head_dim / seqlen_k.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided or will be computed from the input tensors.
@@ -1304,7 +1304,7 @@ def flash_sparse_attn_with_kvcache_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
@@ -1390,7 +1390,7 @@ def flash_sparse_attn_varlen_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to head_dim / max_seqlen_k.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided or will be computed from the input tensors.
@@ -1471,7 +1471,7 @@ def flash_sparse_attn_varlen_with_kvcache_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param seqused_k: Optional tensor indicating the actual sequence lengths for keys/values.
@@ -1558,7 +1558,7 @@ def flash_gated_attn_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param softmax_threshold: Optional threshold for the sparse softmax.
     :param gate_threshold: Optional threshold for the sparsity gate.
     :param is_logsigmoid_gate: Whether to use a log-sigmoid function for the sparsity gate. If False, uses a linear function.
@@ -1642,7 +1642,7 @@ def flash_gated_attn_with_kvcache_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
@@ -1742,7 +1742,7 @@ def flash_gated_attn_varlen_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param softmax_threshold: Optional threshold for the sparse softmax.
     :param gate_threshold: Optional threshold for the sparsity gate.
     :param is_logsigmoid_gate: Whether to use a log-sigmoid function for the sparsity gate. If False, uses a linear function.
@@ -1839,7 +1839,7 @@ def flash_gated_attn_varlen_with_kvcache_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param seqused_k: Optional tensor indicating the actual sequence lengths for keys/values.

--- a/flash_sparse_attn/ops/triton/interface.py
+++ b/flash_sparse_attn/ops/triton/interface.py
@@ -932,7 +932,7 @@ def flash_dense_attn_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 2] with dtype int32. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided or will be computed from the input tensors.
     :param is_split_kv: Whether to enable split-KV for forward occupancy.
@@ -996,7 +996,7 @@ def flash_dense_attn_with_kvcache_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 2] with dtype int32. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
@@ -1080,7 +1080,7 @@ def flash_dense_attn_varlen_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 2] with dtype int32. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided or will be computed from the input tensors.
     :param is_split_kv: Whether to enable split-KV for forward occupancy.
@@ -1157,7 +1157,7 @@ def flash_dense_attn_varlen_with_kvcache_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 2] with dtype int32. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param seqused_k: Optional tensor indicating the actual sequence lengths for keys/values.
@@ -1236,7 +1236,7 @@ def flash_sparse_attn_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 2] with dtype int32. If provided, is_local is automatically set to True.
+    :param window_sizes: :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
     :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to head_dim / seqlen_k.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided or will be computed from the input tensors.
@@ -1304,7 +1304,7 @@ def flash_sparse_attn_with_kvcache_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 2] with dtype int32. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
@@ -1390,7 +1390,7 @@ def flash_sparse_attn_varlen_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 2] with dtype int32. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
     :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to head_dim / max_seqlen_k.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided or will be computed from the input tensors.
@@ -1471,7 +1471,7 @@ def flash_sparse_attn_varlen_with_kvcache_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 2] with dtype int32. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param seqused_k: Optional tensor indicating the actual sequence lengths for keys/values.
@@ -1558,7 +1558,7 @@ def flash_gated_attn_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 2] with dtype int32. If provided, is_local is automatically set to True.
+    :param window_sizes: :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
     :param softmax_threshold: Optional threshold for the sparse softmax.
     :param gate_threshold: Optional threshold for the sparsity gate.
     :param is_logsigmoid_gate: Whether to use a log-sigmoid function for the sparsity gate. If False, uses a linear function.
@@ -1642,7 +1642,7 @@ def flash_gated_attn_with_kvcache_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 2] with dtype int32. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
@@ -1742,7 +1742,7 @@ def flash_gated_attn_varlen_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 2] with dtype int32. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
     :param softmax_threshold: Optional threshold for the sparse softmax.
     :param gate_threshold: Optional threshold for the sparsity gate.
     :param is_logsigmoid_gate: Whether to use a log-sigmoid function for the sparsity gate. If False, uses a linear function.
@@ -1839,7 +1839,7 @@ def flash_gated_attn_varlen_with_kvcache_func(
     :param query_scale: Optional per-tensor scale for query dequantization.
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
-    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 2] with dtype int32. If provided, is_local is automatically set to True.
+    :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 3] with dtype int32, with columns [window_dist, window_right, window_left]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param seqused_k: Optional tensor indicating the actual sequence lengths for keys/values.

--- a/flash_sparse_attn/ops/triton/mask.py
+++ b/flash_sparse_attn/ops/triton/mask.py
@@ -11,6 +11,7 @@ def apply_mask(
     seqlen_k,
     window_size_left,
     window_size_right,
+    window_size_dist,
     MASK_SEQLEN: tl.constexpr,
     MASK_CAUSAL: tl.constexpr,
     MASK_LOCAL: tl.constexpr,
@@ -27,8 +28,9 @@ def apply_mask(
     :param n_block: Current block index along the N dimension.
     :param seqlen_q: The sequence length of the query.
     :param seqlen_k: The sequence length of the key.
-    :param window_size_left: Left window size for local masking.
-    :param window_size_right: Right window size for local masking.
+    :param window_size_left: Distant local band token count.
+    :param window_size_right: Gap token count after the near-diagonal window before the distant band.
+    :param window_size_dist: Near-diagonal local token count.
     :param MASK_SEQLEN: Boolean flag indicating if seqlen masking should be applied.
     :param MASK_CAUSAL: Boolean flag indicating if causal masking should be applied.
     :param MASK_LOCAL: Boolean flag indicating if local masking should be applied.
@@ -67,8 +69,11 @@ def apply_mask(
 
         if MASK_CAUSAL and MASK_LOCAL:
             acc_s = tl.where(
-                (dist >= 0)
-                | ((dist >= window_size_right) & (dist <= window_size_left)),
+                ((dist >= 0) & (dist < window_size_dist))
+                | (
+                    (dist >= window_size_dist + window_size_right)
+                    & (dist < window_size_dist + window_size_right + window_size_left)
+                ),
                 acc_s,
                 float("-inf"),
             )
@@ -80,7 +85,11 @@ def apply_mask(
             )
         else:
             acc_s = tl.where(
-                (dist >= window_size_right) & (dist <= window_size_left),
+                ((dist >= 0) & (dist < window_size_dist))
+                | (
+                    (dist >= window_size_dist + window_size_right)
+                    & (dist < window_size_dist + window_size_right + window_size_left)
+                ),
                 acc_s,
                 float("-inf"),
             )

--- a/flash_sparse_attn/ops/triton/mask.py
+++ b/flash_sparse_attn/ops/triton/mask.py
@@ -9,12 +9,14 @@ def apply_mask(
     n_block,
     seqlen_q,
     seqlen_k,
+    window_size_sink,
     window_size_left,
     window_size_right,
     window_size_dist,
     MASK_SEQLEN: tl.constexpr,
     MASK_CAUSAL: tl.constexpr,
     MASK_LOCAL: tl.constexpr,
+    MASK_SINK: tl.constexpr,
     TILE_M: tl.constexpr,
     TILE_N: tl.constexpr,
     QHEAD_PER_KVHEAD_PACKGQA: tl.constexpr,
@@ -28,12 +30,14 @@ def apply_mask(
     :param n_block: Current block index along the N dimension.
     :param seqlen_q: The sequence length of the query.
     :param seqlen_k: The sequence length of the key.
+    :param window_size_sink: Prefix sink token count.
     :param window_size_left: Distant local band token count.
     :param window_size_right: Gap token count after the near-diagonal window before the distant band.
     :param window_size_dist: Near-diagonal local token count.
     :param MASK_SEQLEN: Boolean flag indicating if seqlen masking should be applied.
     :param MASK_CAUSAL: Boolean flag indicating if causal masking should be applied.
     :param MASK_LOCAL: Boolean flag indicating if local masking should be applied.
+    :param MASK_SINK: Boolean flag indicating if sink masking should be applied.
     :param TILE_M: Tile size along the M dimension.
     :param TILE_N: Tile size along the N dimension.
     :param QHEAD_PER_KVHEAD_PACKGQA: Ratio of query heads to key/value heads for packed GQA.
@@ -63,17 +67,22 @@ def apply_mask(
             float("-inf"),
         )
 
-    if MASK_CAUSAL or MASK_LOCAL:
+    if MASK_CAUSAL or MASK_LOCAL or MASK_SINK:
         causal_offset = seqlen_k - seqlen_q
         dist = q_idx + causal_offset - k_idx
 
-        if MASK_CAUSAL and MASK_LOCAL:
-            acc_s = tl.where(
-                ((dist >= 0) & (dist < window_size_dist))
-                | (
+        if MASK_LOCAL or MASK_SINK:
+            allowed = (dist >= 0) & (dist < 0)
+            if MASK_LOCAL:
+                allowed = allowed | ((dist >= 0) & (dist < window_size_dist))
+                allowed = allowed | (
                     (dist >= window_size_dist + window_size_right)
                     & (dist < window_size_dist + window_size_right + window_size_left)
-                ),
+                )
+            if MASK_SINK:
+                allowed = allowed | ((k_idx < window_size_sink) & (dist >= 0))
+            acc_s = tl.where(
+                allowed,
                 acc_s,
                 float("-inf"),
             )

--- a/flash_sparse_attn/ops/triton/scheduler.py
+++ b/flash_sparse_attn/ops/triton/scheduler.py
@@ -52,10 +52,12 @@ class AttnFwdGridIndex:
         if IS_LOCAL:
             window_size_left = tl.load(window_sizes + self.head_kv_idx * stride_wh)
             window_size_right = tl.load(window_sizes + self.head_kv_idx * stride_wh + 1)
+            window_size_dist = tl.load(window_sizes + self.head_kv_idx * stride_wh + 2)
         else:
             window_size_left = 0
             window_size_right = 0
-        return window_size_left, window_size_right
+            window_size_dist = 0
+        return window_size_left, window_size_right, window_size_dist
 
 
 @aggregate
@@ -98,10 +100,12 @@ class AttnBwdGridIndex:
         if IS_LOCAL:
             window_size_left = tl.load(window_sizes + self.head_kv_idx * stride_wh)
             window_size_right = tl.load(window_sizes + self.head_kv_idx * stride_wh + 1)
+            window_size_dist = tl.load(window_sizes + self.head_kv_idx * stride_wh + 2)
         else:
             window_size_left = 0
             window_size_right = 0
-        return window_size_left, window_size_right
+            window_size_dist = 0
+        return window_size_left, window_size_right, window_size_dist
 
 
 @aggregate
@@ -135,10 +139,12 @@ class AttnDecGridIndex:
         if IS_LOCAL:
             window_size_left = tl.load(window_sizes + self.head_kv_idx * stride_wh)
             window_size_right = tl.load(window_sizes + self.head_kv_idx * stride_wh + 1)
+            window_size_dist = tl.load(window_sizes + self.head_kv_idx * stride_wh + 2)
         else:
             window_size_left = 0
             window_size_right = 0
-        return window_size_left, window_size_right
+            window_size_dist = 0
+        return window_size_left, window_size_right, window_size_dist
 
 
 @aggregate
@@ -156,6 +162,7 @@ class AttnFwdConfig:
     padded_offset_k: tl.tensor
     window_size_left: tl.tensor
     window_size_right: tl.tensor
+    window_size_dist: tl.tensor
     head_dim: tl.tensor
     PACK_GQA: tl.constexpr
     QHEAD_PER_KVHEAD_PACKGQA: tl.constexpr
@@ -180,6 +187,7 @@ class AttnFwdConfig:
         padded_offset_k,
         window_size_left,
         window_size_right,
+        window_size_dist,
         head_dim,
         PACK_GQA,
         QHEAD_PER_KVHEAD_PACKGQA,
@@ -201,6 +209,7 @@ class AttnFwdConfig:
         self.padded_offset_k = padded_offset_k
         self.window_size_left = window_size_left
         self.window_size_right = window_size_right
+        self.window_size_dist = window_size_dist
         self.head_dim = head_dim
         self.PACK_GQA = tl.constexpr(PACK_GQA)
         self.QHEAD_PER_KVHEAD_PACKGQA = tl.constexpr(QHEAD_PER_KVHEAD_PACKGQA)
@@ -222,6 +231,7 @@ class AttnFwdConfig:
         batch_idx=0,
         window_size_left=0,
         window_size_right=0,
+        window_size_dist=0,
         head_dim=0,
         cu_seqlens_q=None,
         cu_seqlens_k=None,
@@ -306,6 +316,7 @@ class AttnFwdConfig:
             padded_offset_k,
             window_size_left,
             window_size_right,
+            window_size_dist,
             head_dim,
             PACK_GQA,
             QHEAD_PER_KVHEAD_PACKGQA,
@@ -341,6 +352,7 @@ class AttnBwdConfig:
     padded_offset_k: tl.tensor
     window_size_left: tl.tensor
     window_size_right: tl.tensor
+    window_size_dist: tl.tensor
     head_dim: tl.tensor
     QHEAD_PER_KVHEAD: tl.constexpr
     TILE_M: tl.constexpr
@@ -368,6 +380,7 @@ class AttnBwdConfig:
         padded_offset_k,
         window_size_left,
         window_size_right,
+        window_size_dist,
         head_dim,
         QHEAD_PER_KVHEAD,
         TILE_M,
@@ -392,6 +405,7 @@ class AttnBwdConfig:
         self.padded_offset_k = padded_offset_k
         self.window_size_left = window_size_left
         self.window_size_right = window_size_right
+        self.window_size_dist = window_size_dist
         self.head_dim = head_dim
         self.QHEAD_PER_KVHEAD = tl.constexpr(QHEAD_PER_KVHEAD)
         self.TILE_M = tl.constexpr(TILE_M)
@@ -414,6 +428,7 @@ class AttnBwdConfig:
         batch_idx=0,
         window_size_left=0,
         window_size_right=0,
+        window_size_dist=0,
         head_dim=0,
         cu_seqlens_q=None,
         cu_seqlens_k=None,
@@ -482,6 +497,7 @@ class AttnBwdConfig:
             padded_offset_k,
             window_size_left,
             window_size_right,
+            window_size_dist,
             head_dim,
             QHEAD_PER_KVHEAD,
             TILE_M,
@@ -539,6 +555,7 @@ class AttnDecConfig:
     padded_offset_k: tl.tensor
     window_size_left: tl.tensor
     window_size_right: tl.tensor
+    window_size_dist: tl.tensor
     head_dim: tl.tensor
     QHEAD_PER_KVHEAD_PACKGQA: tl.constexpr
     TILE_M: tl.constexpr
@@ -562,6 +579,7 @@ class AttnDecConfig:
         padded_offset_k,
         window_size_left,
         window_size_right,
+        window_size_dist,
         head_dim,
         QHEAD_PER_KVHEAD_PACKGQA,
         TILE_M,
@@ -582,6 +600,7 @@ class AttnDecConfig:
         self.padded_offset_k = padded_offset_k
         self.window_size_left = window_size_left
         self.window_size_right = window_size_right
+        self.window_size_dist = window_size_dist
         self.head_dim = head_dim
         self.QHEAD_PER_KVHEAD_PACKGQA = tl.constexpr(QHEAD_PER_KVHEAD_PACKGQA)
         self.TILE_M = tl.constexpr(TILE_M)
@@ -601,6 +620,7 @@ class AttnDecConfig:
         batch_idx=0,
         window_size_left=0,
         window_size_right=0,
+        window_size_dist=0,
         head_dim=0,
         cu_seqlens_q=None,
         cu_seqlens_k=None,
@@ -682,6 +702,7 @@ class AttnDecConfig:
             padded_offset_k,
             window_size_left,
             window_size_right,
+            window_size_dist,
             head_dim,
             QHEAD_PER_KVHEAD_PACKGQA,
             TILE_M,
@@ -744,6 +765,7 @@ class AttnFwdBlockScheduler:
                 num_splits=num_splits,
                 window_size_left=config.window_size_left,
                 window_size_right=config.window_size_right,
+                window_size_dist=config.window_size_dist,
                 TILE_N=config.TILE_N,
                 TILE_M=config.TILE_M,
                 IS_CAUSAL=IS_CAUSAL,
@@ -758,9 +780,10 @@ class AttnFwdBlockScheduler:
             m_block=config.m_block,
             n_block_min=n_block_min,
             window_size_right=0,
+            window_size_dist=config.window_size_dist - 1,
             TILE_N=config.TILE_N,
             TILE_M=config.TILE_M,
-            IS_LOCAL=False,
+            IS_LOCAL=IS_LOCAL,
             QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
         )
 
@@ -778,6 +801,7 @@ class AttnFwdBlockScheduler:
                 m_block=config.m_block,
                 n_block_min=n_block_window_min,
                 window_size_right=config.window_size_right,
+                window_size_dist=config.window_size_dist,
                 TILE_N=config.TILE_N,
                 TILE_M=config.TILE_M,
                 IS_LOCAL=True,
@@ -789,6 +813,8 @@ class AttnFwdBlockScheduler:
                 m_block=config.m_block,
                 n_block_min=n_block_window_min,
                 window_size_left=config.window_size_left,
+                window_size_right=config.window_size_right,
+                window_size_dist=config.window_size_dist,
                 TILE_N=config.TILE_N,
                 TILE_M=config.TILE_M,
                 IS_LOCAL=True,
@@ -876,6 +902,7 @@ class AttnBwdBlockScheduler:
                 num_splits=num_splits,
                 window_size_left=config.window_size_left,
                 window_size_right=config.window_size_right,
+                window_size_dist=config.window_size_dist,
                 TILE_N=config.TILE_N,
                 TILE_M=config.TILE_M,
                 IS_CAUSAL=IS_CAUSAL,
@@ -889,10 +916,11 @@ class AttnBwdBlockScheduler:
             n_block=config.n_block,
             m_block_min=m_block_min,
             window_size_right=0,
+            window_size_dist=config.window_size_dist - 1,
             TILE_N=config.TILE_N,
             TILE_M=config.TILE_M,
             IS_CAUSAL=IS_CAUSAL or IS_LOCAL,
-            IS_LOCAL=False,
+            IS_LOCAL=IS_LOCAL,
         )
 
         # Clamp to split's range so the no-mask loop stays within bounds
@@ -909,6 +937,7 @@ class AttnBwdBlockScheduler:
                 n_block=config.n_block,
                 m_block_min=m_block_window_min,
                 window_size_right=config.window_size_right,
+                window_size_dist=config.window_size_dist,
                 TILE_N=config.TILE_N,
                 TILE_M=config.TILE_M,
                 IS_CAUSAL=False,
@@ -923,6 +952,8 @@ class AttnBwdBlockScheduler:
                 n_block=config.n_block,
                 m_block_max=m_block_window_max,
                 window_size_left=config.window_size_left,
+                window_size_right=config.window_size_right,
+                window_size_dist=config.window_size_dist,
                 TILE_N=config.TILE_N,
                 TILE_M=config.TILE_M,
                 IS_LOCAL=True,
@@ -996,6 +1027,7 @@ class AttnDecBlockScheduler:
                 num_splits=num_splits,
                 window_size_left=config.window_size_left,
                 window_size_right=config.window_size_right,
+                window_size_dist=config.window_size_dist,
                 TILE_N=config.TILE_N,
                 TILE_M=config.TILE_M,
                 IS_CAUSAL=False,
@@ -1010,9 +1042,10 @@ class AttnDecBlockScheduler:
             m_block=0,
             n_block_min=n_block_min,
             window_size_right=0,
+            window_size_dist=config.window_size_dist - 1,
             TILE_N=config.TILE_N,
             TILE_M=config.TILE_M,
-            IS_LOCAL=False,
+            IS_LOCAL=IS_LOCAL,
             QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
         )
 
@@ -1029,6 +1062,7 @@ class AttnDecBlockScheduler:
                 m_block=0,
                 n_block_min=n_block_window_min,
                 window_size_right=config.window_size_right,
+                window_size_dist=config.window_size_dist,
                 TILE_N=config.TILE_N,
                 TILE_M=config.TILE_M,
                 IS_LOCAL=True,
@@ -1040,6 +1074,8 @@ class AttnDecBlockScheduler:
                 m_block=0,
                 n_block_min=n_block_window_min,
                 window_size_left=config.window_size_left,
+                window_size_right=config.window_size_right,
+                window_size_dist=config.window_size_dist,
                 TILE_N=config.TILE_N,
                 TILE_M=config.TILE_M,
                 IS_LOCAL=True,
@@ -2239,6 +2275,7 @@ class AttnMaskScheduler:
     actual_seqlen_k: tl.tensor
     window_size_left: tl.tensor
     window_size_right: tl.tensor
+    window_size_dist: tl.tensor
     TILE_M: tl.constexpr
     TILE_N: tl.constexpr
     QHEAD_PER_KVHEAD_PACKGQA: tl.constexpr
@@ -2252,6 +2289,7 @@ class AttnMaskScheduler:
         actual_seqlen_k,
         window_size_left,
         window_size_right,
+        window_size_dist,
         TILE_M,
         TILE_N,
         QHEAD_PER_KVHEAD_PACKGQA,
@@ -2262,6 +2300,7 @@ class AttnMaskScheduler:
         self.actual_seqlen_k = actual_seqlen_k
         self.window_size_left = window_size_left
         self.window_size_right = window_size_right
+        self.window_size_dist = window_size_dist
         self.TILE_M = tl.constexpr(TILE_M)
         self.TILE_N = tl.constexpr(TILE_N)
         self.QHEAD_PER_KVHEAD_PACKGQA = tl.constexpr(QHEAD_PER_KVHEAD_PACKGQA)
@@ -2280,6 +2319,7 @@ class AttnMaskScheduler:
                 config.actual_seqlen_k,
                 config.window_size_left,
                 config.window_size_right,
+                config.window_size_dist,
                 config.TILE_M,
                 config.TILE_N,
                 config.QHEAD_PER_KVHEAD_PACKGQA,
@@ -2292,6 +2332,7 @@ class AttnMaskScheduler:
                 config.actual_seqlen_k,
                 config.window_size_left,
                 config.window_size_right,
+                config.window_size_dist,
                 config.TILE_M,
                 config.TILE_N,
                 1,
@@ -2320,6 +2361,7 @@ class AttnMaskScheduler:
             seqlen_k=self.actual_seqlen_k,
             window_size_left=self.window_size_left,
             window_size_right=self.window_size_right,
+            window_size_dist=self.window_size_dist,
             MASK_SEQLEN=True,
             MASK_CAUSAL=MASK_CAUSAL,
             MASK_LOCAL=MASK_LOCAL,

--- a/flash_sparse_attn/ops/triton/scheduler.py
+++ b/flash_sparse_attn/ops/triton/scheduler.py
@@ -50,14 +50,16 @@ class AttnFwdGridIndex:
     @triton.jit
     def load_window_sizes(self, window_sizes, stride_wh, IS_LOCAL: tl.constexpr):
         if IS_LOCAL:
-            window_size_dist = tl.load(window_sizes + self.head_kv_idx * stride_wh)
-            window_size_right = tl.load(window_sizes + self.head_kv_idx * stride_wh + 1)
-            window_size_left = tl.load(window_sizes + self.head_kv_idx * stride_wh + 2)
+            window_size_sink = tl.load(window_sizes + self.head_kv_idx * stride_wh)
+            window_size_left = tl.load(window_sizes + self.head_kv_idx * stride_wh + 1)
+            window_size_right = tl.load(window_sizes + self.head_kv_idx * stride_wh + 2)
+            window_size_dist = tl.load(window_sizes + self.head_kv_idx * stride_wh + 3)
         else:
+            window_size_sink = 0
             window_size_left = 0
             window_size_right = 0
             window_size_dist = 0
-        return window_size_left, window_size_right, window_size_dist
+        return window_size_sink, window_size_left, window_size_right, window_size_dist
 
 
 @aggregate
@@ -98,14 +100,16 @@ class AttnBwdGridIndex:
     @triton.jit
     def load_window_sizes(self, window_sizes, stride_wh, IS_LOCAL: tl.constexpr):
         if IS_LOCAL:
-            window_size_dist = tl.load(window_sizes + self.head_kv_idx * stride_wh)
-            window_size_right = tl.load(window_sizes + self.head_kv_idx * stride_wh + 1)
-            window_size_left = tl.load(window_sizes + self.head_kv_idx * stride_wh + 2)
+            window_size_sink = tl.load(window_sizes + self.head_kv_idx * stride_wh)
+            window_size_left = tl.load(window_sizes + self.head_kv_idx * stride_wh + 1)
+            window_size_right = tl.load(window_sizes + self.head_kv_idx * stride_wh + 2)
+            window_size_dist = tl.load(window_sizes + self.head_kv_idx * stride_wh + 3)
         else:
+            window_size_sink = 0
             window_size_left = 0
             window_size_right = 0
             window_size_dist = 0
-        return window_size_left, window_size_right, window_size_dist
+        return window_size_sink, window_size_left, window_size_right, window_size_dist
 
 
 @aggregate
@@ -137,14 +141,16 @@ class AttnDecGridIndex:
     @triton.jit
     def load_window_sizes(self, window_sizes, stride_wh, IS_LOCAL: tl.constexpr):
         if IS_LOCAL:
-            window_size_dist = tl.load(window_sizes + self.head_kv_idx * stride_wh)
-            window_size_right = tl.load(window_sizes + self.head_kv_idx * stride_wh + 1)
-            window_size_left = tl.load(window_sizes + self.head_kv_idx * stride_wh + 2)
+            window_size_sink = tl.load(window_sizes + self.head_kv_idx * stride_wh)
+            window_size_left = tl.load(window_sizes + self.head_kv_idx * stride_wh + 1)
+            window_size_right = tl.load(window_sizes + self.head_kv_idx * stride_wh + 2)
+            window_size_dist = tl.load(window_sizes + self.head_kv_idx * stride_wh + 3)
         else:
+            window_size_sink = 0
             window_size_left = 0
             window_size_right = 0
             window_size_dist = 0
-        return window_size_left, window_size_right, window_size_dist
+        return window_size_sink, window_size_left, window_size_right, window_size_dist
 
 
 @aggregate
@@ -160,6 +166,7 @@ class AttnFwdConfig:
     offset_k: tl.tensor
     padded_offset_q: tl.tensor
     padded_offset_k: tl.tensor
+    window_size_sink: tl.tensor
     window_size_left: tl.tensor
     window_size_right: tl.tensor
     window_size_dist: tl.tensor
@@ -185,6 +192,7 @@ class AttnFwdConfig:
         offset_k,
         padded_offset_q,
         padded_offset_k,
+        window_size_sink,
         window_size_left,
         window_size_right,
         window_size_dist,
@@ -207,6 +215,7 @@ class AttnFwdConfig:
         self.offset_k = offset_k
         self.padded_offset_q = padded_offset_q
         self.padded_offset_k = padded_offset_k
+        self.window_size_sink = window_size_sink
         self.window_size_left = window_size_left
         self.window_size_right = window_size_right
         self.window_size_dist = window_size_dist
@@ -229,6 +238,7 @@ class AttnFwdConfig:
         value_scale=None,
         m_block=0,
         batch_idx=0,
+        window_size_sink=0,
         window_size_left=0,
         window_size_right=0,
         window_size_dist=0,
@@ -314,6 +324,7 @@ class AttnFwdConfig:
             offset_k,
             padded_offset_q,
             padded_offset_k,
+            window_size_sink,
             window_size_left,
             window_size_right,
             window_size_dist,
@@ -350,6 +361,7 @@ class AttnBwdConfig:
     offset_k: tl.tensor
     padded_offset_q: tl.tensor
     padded_offset_k: tl.tensor
+    window_size_sink: tl.tensor
     window_size_left: tl.tensor
     window_size_right: tl.tensor
     window_size_dist: tl.tensor
@@ -378,6 +390,7 @@ class AttnBwdConfig:
         offset_k,
         padded_offset_q,
         padded_offset_k,
+        window_size_sink,
         window_size_left,
         window_size_right,
         window_size_dist,
@@ -403,6 +416,7 @@ class AttnBwdConfig:
         self.offset_k = offset_k
         self.padded_offset_q = padded_offset_q
         self.padded_offset_k = padded_offset_k
+        self.window_size_sink = window_size_sink
         self.window_size_left = window_size_left
         self.window_size_right = window_size_right
         self.window_size_dist = window_size_dist
@@ -426,6 +440,7 @@ class AttnBwdConfig:
         value_scale=None,
         n_block=0,
         batch_idx=0,
+        window_size_sink=0,
         window_size_left=0,
         window_size_right=0,
         window_size_dist=0,
@@ -495,6 +510,7 @@ class AttnBwdConfig:
             offset_k,
             padded_offset_q,
             padded_offset_k,
+            window_size_sink,
             window_size_left,
             window_size_right,
             window_size_dist,
@@ -553,6 +569,7 @@ class AttnDecConfig:
     offset_k: tl.tensor
     padded_offset_q: tl.tensor
     padded_offset_k: tl.tensor
+    window_size_sink: tl.tensor
     window_size_left: tl.tensor
     window_size_right: tl.tensor
     window_size_dist: tl.tensor
@@ -577,6 +594,7 @@ class AttnDecConfig:
         offset_k,
         padded_offset_q,
         padded_offset_k,
+        window_size_sink,
         window_size_left,
         window_size_right,
         window_size_dist,
@@ -598,6 +616,7 @@ class AttnDecConfig:
         self.offset_k = offset_k
         self.padded_offset_q = padded_offset_q
         self.padded_offset_k = padded_offset_k
+        self.window_size_sink = window_size_sink
         self.window_size_left = window_size_left
         self.window_size_right = window_size_right
         self.window_size_dist = window_size_dist
@@ -618,6 +637,7 @@ class AttnDecConfig:
         key_scale=None,
         value_scale=None,
         batch_idx=0,
+        window_size_sink=0,
         window_size_left=0,
         window_size_right=0,
         window_size_dist=0,
@@ -700,6 +720,7 @@ class AttnDecConfig:
             offset_k,
             padded_offset_q,
             padded_offset_k,
+            window_size_sink,
             window_size_left,
             window_size_right,
             window_size_dist,
@@ -721,6 +742,8 @@ class AttnFwdBlockScheduler:
     n_block_window_max: tl.tensor
     n_block_window_min_no_mask: tl.tensor
     n_block_window_max_no_mask: tl.tensor
+    n_block_sink_min: tl.tensor
+    n_block_sink_max: tl.tensor
 
     @constexpr_function
     def __init__(
@@ -732,6 +755,8 @@ class AttnFwdBlockScheduler:
         n_block_window_max,
         n_block_window_min_no_mask,
         n_block_window_max_no_mask,
+        n_block_sink_min,
+        n_block_sink_max,
     ):
         self.n_block_min = n_block_min
         self.n_block_max = n_block_max
@@ -740,11 +765,15 @@ class AttnFwdBlockScheduler:
         self.n_block_window_max = n_block_window_max
         self.n_block_window_min_no_mask = n_block_window_min_no_mask
         self.n_block_window_max_no_mask = n_block_window_max_no_mask
+        self.n_block_sink_min = n_block_sink_min
+        self.n_block_sink_max = n_block_sink_max
 
     @triton.jit
     def is_empty(self):
-        return (self.n_block_max <= self.n_block_min) & (
-            self.n_block_window_max <= self.n_block_window_min
+        return (
+            (self.n_block_max <= self.n_block_min)
+            & (self.n_block_window_max <= self.n_block_window_min)
+            & (self.n_block_sink_max <= self.n_block_sink_min)
         )
 
     @staticmethod
@@ -758,23 +787,29 @@ class AttnFwdBlockScheduler:
         IS_SPLIT_KV: tl.constexpr,
     ):
         # Compute causal n_block range for this m_block
-        n_block_min, n_block_max, n_block_window_min, n_block_window_max = (
-            block_info.get_n_block_min_max(
-                seqlen_q=config.actual_seqlen_q,
-                seqlen_k=config.actual_seqlen_k,
-                m_block=config.m_block,
-                split_idx=split_idx,
-                num_splits=num_splits,
-                window_size_left=config.window_size_left,
-                window_size_right=config.window_size_right,
-                window_size_dist=config.window_size_dist,
-                TILE_N=config.TILE_N,
-                TILE_M=config.TILE_M,
-                IS_CAUSAL=IS_CAUSAL,
-                IS_LOCAL=IS_LOCAL,
-                IS_SPLIT_KV=IS_SPLIT_KV,
-                QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
-            )
+        (
+            n_block_min,
+            n_block_max,
+            n_block_window_min,
+            n_block_window_max,
+            n_block_sink_min,
+            n_block_sink_max,
+        ) = block_info.get_n_block_min_max(
+            seqlen_q=config.actual_seqlen_q,
+            seqlen_k=config.actual_seqlen_k,
+            m_block=config.m_block,
+            split_idx=split_idx,
+            num_splits=num_splits,
+            window_size_sink=config.window_size_sink,
+            window_size_left=config.window_size_left,
+            window_size_right=config.window_size_right,
+            window_size_dist=config.window_size_dist,
+            TILE_N=config.TILE_N,
+            TILE_M=config.TILE_M,
+            IS_CAUSAL=IS_CAUSAL,
+            IS_LOCAL=IS_LOCAL,
+            IS_SPLIT_KV=IS_SPLIT_KV,
+            QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
         )
         n_block_max_no_mask = block_info.get_n_block_min_causal_local_mask(
             seqlen_q=config.actual_seqlen_q,
@@ -859,6 +894,8 @@ class AttnFwdBlockScheduler:
             n_block_window_max,
             n_block_window_min_no_mask,
             n_block_window_max_no_mask,
+            n_block_sink_min,
+            n_block_sink_max,
         )
 
 
@@ -871,6 +908,8 @@ class AttnBwdBlockScheduler:
     m_block_window_max: tl.tensor
     m_block_window_min_no_mask: tl.tensor
     m_block_window_max_no_mask: tl.tensor
+    m_block_sink_min: tl.tensor
+    m_block_sink_max: tl.tensor
 
     @constexpr_function
     def __init__(
@@ -882,6 +921,8 @@ class AttnBwdBlockScheduler:
         m_block_window_max,
         m_block_window_min_no_mask,
         m_block_window_max_no_mask,
+        m_block_sink_min,
+        m_block_sink_max,
     ):
         self.m_block_min = m_block_min
         self.m_block_max = m_block_max
@@ -890,10 +931,16 @@ class AttnBwdBlockScheduler:
         self.m_block_window_max = m_block_window_max
         self.m_block_window_min_no_mask = m_block_window_min_no_mask
         self.m_block_window_max_no_mask = m_block_window_max_no_mask
+        self.m_block_sink_min = m_block_sink_min
+        self.m_block_sink_max = m_block_sink_max
 
     @triton.jit
     def is_empty(self):
-        return self.m_block_max <= self.m_block_min
+        return (
+            (self.m_block_max <= self.m_block_min)
+            & (self.m_block_window_max <= self.m_block_window_min)
+            & (self.m_block_sink_max <= self.m_block_sink_min)
+        )
 
     @staticmethod
     @triton.jit
@@ -906,22 +953,28 @@ class AttnBwdBlockScheduler:
         IS_SPLIT_QO: tl.constexpr,
     ):
         # Compute causal m_block range for this n_block
-        m_block_min, m_block_max, m_block_window_min, m_block_window_max = (
-            block_info.get_m_block_min_max(
-                seqlen_q=config.actual_seqlen_q,
-                seqlen_k=config.actual_seqlen_k,
-                n_block=config.n_block,
-                split_idx=split_idx,
-                num_splits=num_splits,
-                window_size_left=config.window_size_left,
-                window_size_right=config.window_size_right,
-                window_size_dist=config.window_size_dist,
-                TILE_N=config.TILE_N,
-                TILE_M=config.TILE_M,
-                IS_CAUSAL=IS_CAUSAL,
-                IS_LOCAL=IS_LOCAL,
-                IS_SPLIT_QO=IS_SPLIT_QO,
-            )
+        (
+            m_block_min,
+            m_block_max,
+            m_block_window_min,
+            m_block_window_max,
+            m_block_sink_min,
+            m_block_sink_max,
+        ) = block_info.get_m_block_min_max(
+            seqlen_q=config.actual_seqlen_q,
+            seqlen_k=config.actual_seqlen_k,
+            n_block=config.n_block,
+            split_idx=split_idx,
+            num_splits=num_splits,
+            window_size_sink=config.window_size_sink,
+            window_size_left=config.window_size_left,
+            window_size_right=config.window_size_right,
+            window_size_dist=config.window_size_dist,
+            TILE_N=config.TILE_N,
+            TILE_M=config.TILE_M,
+            IS_CAUSAL=IS_CAUSAL,
+            IS_LOCAL=IS_LOCAL,
+            IS_SPLIT_QO=IS_SPLIT_QO,
         )
         m_block_min_no_mask = block_info.get_m_block_min_causal_local_mask(
             seqlen_q=config.actual_seqlen_q,
@@ -974,9 +1027,19 @@ class AttnBwdBlockScheduler:
             m_block_window_max_no_mask = tl.maximum(
                 m_block_window_max_no_mask, m_block_window_min_no_mask
             )
+            m_block_window_min_no_mask = tl.maximum(
+                tl.minimum(m_block_window_min_no_mask, m_block_window_max),
+                m_block_window_min,
+            )
+            m_block_window_max_no_mask = tl.maximum(
+                tl.minimum(m_block_window_max_no_mask, m_block_window_max),
+                m_block_window_min_no_mask,
+            )
         else:
             m_block_window_min_no_mask = 0
             m_block_window_max_no_mask = 0
+            m_block_sink_min = 0
+            m_block_sink_max = 0
 
         return AttnBwdBlockScheduler(
             m_block_min,
@@ -986,6 +1049,8 @@ class AttnBwdBlockScheduler:
             m_block_window_max,
             m_block_window_min_no_mask,
             m_block_window_max_no_mask,
+            m_block_sink_min,
+            m_block_sink_max,
         )
 
 
@@ -998,6 +1063,8 @@ class AttnDecBlockScheduler:
     n_block_window_max: tl.tensor
     n_block_window_min_no_mask: tl.tensor
     n_block_window_max_no_mask: tl.tensor
+    n_block_sink_min: tl.tensor
+    n_block_sink_max: tl.tensor
 
     @constexpr_function
     def __init__(
@@ -1009,6 +1076,8 @@ class AttnDecBlockScheduler:
         n_block_window_max,
         n_block_window_min_no_mask,
         n_block_window_max_no_mask,
+        n_block_sink_min,
+        n_block_sink_max,
     ):
         self.n_block_min = n_block_min
         self.n_block_max = n_block_max
@@ -1017,11 +1086,15 @@ class AttnDecBlockScheduler:
         self.n_block_window_max = n_block_window_max
         self.n_block_window_min_no_mask = n_block_window_min_no_mask
         self.n_block_window_max_no_mask = n_block_window_max_no_mask
+        self.n_block_sink_min = n_block_sink_min
+        self.n_block_sink_max = n_block_sink_max
 
     @triton.jit
     def is_empty(self):
-        return (self.n_block_max <= self.n_block_min) & (
-            self.n_block_window_max <= self.n_block_window_min
+        return (
+            (self.n_block_max <= self.n_block_min)
+            & (self.n_block_window_max <= self.n_block_window_min)
+            & (self.n_block_sink_max <= self.n_block_sink_min)
         )
 
     @staticmethod
@@ -1033,23 +1106,29 @@ class AttnDecBlockScheduler:
         IS_LOCAL: tl.constexpr,
     ):
         # Compute non-causal n_block range for this m_block
-        n_block_min, n_block_max, n_block_window_min, n_block_window_max = (
-            block_info.get_n_block_min_max(
-                seqlen_q=1,
-                seqlen_k=config.actual_seqlen_k,
-                m_block=0,
-                split_idx=split_idx,
-                num_splits=num_splits,
-                window_size_left=config.window_size_left,
-                window_size_right=config.window_size_right,
-                window_size_dist=config.window_size_dist,
-                TILE_N=config.TILE_N,
-                TILE_M=config.TILE_M,
-                IS_CAUSAL=False,
-                IS_LOCAL=IS_LOCAL,
-                IS_SPLIT_KV=True,
-                QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
-            )
+        (
+            n_block_min,
+            n_block_max,
+            n_block_window_min,
+            n_block_window_max,
+            n_block_sink_min,
+            n_block_sink_max,
+        ) = block_info.get_n_block_min_max(
+            seqlen_q=1,
+            seqlen_k=config.actual_seqlen_k,
+            m_block=0,
+            split_idx=split_idx,
+            num_splits=num_splits,
+            window_size_sink=config.window_size_sink,
+            window_size_left=config.window_size_left,
+            window_size_right=config.window_size_right,
+            window_size_dist=config.window_size_dist,
+            TILE_N=config.TILE_N,
+            TILE_M=config.TILE_M,
+            IS_CAUSAL=False,
+            IS_LOCAL=IS_LOCAL,
+            IS_SPLIT_KV=True,
+            QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
         )
         n_block_max_no_mask = block_info.get_n_block_min_causal_local_mask(
             seqlen_q=1,
@@ -1128,6 +1207,8 @@ class AttnDecBlockScheduler:
             n_block_window_max,
             n_block_window_min_no_mask,
             n_block_window_max_no_mask,
+            n_block_sink_min,
+            n_block_sink_max,
         )
 
 
@@ -2201,7 +2282,7 @@ class AttnDecPointerScheduler:
     def make_q_ptrs(self, config: AttnDecConfig):
         return tl.make_tensor_descriptor(
             self.q_base,
-            shape=[config.actual_seqlen_q, config.head_dim],
+            shape=[config.QHEAD_PER_KVHEAD_PACKGQA, config.head_dim],
             strides=[self.stride_qh, 1],
             block_shape=[config.TILE_M, config.TILE_K],
         )
@@ -2228,7 +2309,7 @@ class AttnDecPointerScheduler:
     def make_a_ptrs(self, config: AttnDecConfig):
         return tl.make_tensor_descriptor(
             self.a_base,
-            shape=[config.actual_seqlen_q],
+            shape=[config.QHEAD_PER_KVHEAD_PACKGQA],
             strides=[1],
             block_shape=[config.TILE_M],
         )
@@ -2246,7 +2327,7 @@ class AttnDecPointerScheduler:
     def make_out_ptrs(self, config: AttnDecConfig):
         return tl.make_tensor_descriptor(
             self.out_base,
-            shape=[config.actual_seqlen_q, config.head_dim],
+            shape=[config.QHEAD_PER_KVHEAD_PACKGQA, config.head_dim],
             strides=[self.stride_oh, 1],
             block_shape=[config.TILE_M, config.TILE_K],
         )
@@ -2255,7 +2336,7 @@ class AttnDecPointerScheduler:
     def make_lse_ptrs(self, config: AttnDecConfig):
         return tl.make_tensor_descriptor(
             self.lse_base,
-            shape=[config.actual_seqlen_q],
+            shape=[config.QHEAD_PER_KVHEAD_PACKGQA],
             strides=[1],
             block_shape=[config.TILE_M],
         )
@@ -2301,6 +2382,7 @@ class AttnMaskScheduler:
     fixed_block: tl.tensor
     actual_seqlen_q: tl.tensor
     actual_seqlen_k: tl.tensor
+    window_size_sink: tl.tensor
     window_size_left: tl.tensor
     window_size_right: tl.tensor
     window_size_dist: tl.tensor
@@ -2315,6 +2397,7 @@ class AttnMaskScheduler:
         fixed_block,
         actual_seqlen_q,
         actual_seqlen_k,
+        window_size_sink,
         window_size_left,
         window_size_right,
         window_size_dist,
@@ -2326,6 +2409,7 @@ class AttnMaskScheduler:
         self.fixed_block = fixed_block
         self.actual_seqlen_q = actual_seqlen_q
         self.actual_seqlen_k = actual_seqlen_k
+        self.window_size_sink = window_size_sink
         self.window_size_left = window_size_left
         self.window_size_right = window_size_right
         self.window_size_dist = window_size_dist
@@ -2345,6 +2429,7 @@ class AttnMaskScheduler:
                 config.m_block,
                 config.actual_seqlen_q,
                 config.actual_seqlen_k,
+                config.window_size_sink,
                 config.window_size_left,
                 config.window_size_right,
                 config.window_size_dist,
@@ -2358,6 +2443,7 @@ class AttnMaskScheduler:
                 config.n_block,
                 config.actual_seqlen_q,
                 config.actual_seqlen_k,
+                config.window_size_sink,
                 config.window_size_left,
                 config.window_size_right,
                 config.window_size_dist,
@@ -2374,6 +2460,7 @@ class AttnMaskScheduler:
         iter_block,
         MASK_CAUSAL: tl.constexpr = False,
         MASK_LOCAL: tl.constexpr = False,
+        MASK_SINK: tl.constexpr = False,
     ):
         if not self.SWAP_AB:
             m_block = self.fixed_block
@@ -2387,12 +2474,14 @@ class AttnMaskScheduler:
             n_block=n_block,
             seqlen_q=self.actual_seqlen_q,
             seqlen_k=self.actual_seqlen_k,
+            window_size_sink=self.window_size_sink,
             window_size_left=self.window_size_left,
             window_size_right=self.window_size_right,
             window_size_dist=self.window_size_dist,
             MASK_SEQLEN=True,
             MASK_CAUSAL=MASK_CAUSAL,
             MASK_LOCAL=MASK_LOCAL,
+            MASK_SINK=MASK_SINK,
             TILE_M=self.TILE_M,
             TILE_N=self.TILE_N,
             QHEAD_PER_KVHEAD_PACKGQA=self.QHEAD_PER_KVHEAD_PACKGQA,

--- a/flash_sparse_attn/ops/triton/scheduler.py
+++ b/flash_sparse_attn/ops/triton/scheduler.py
@@ -780,10 +780,10 @@ class AttnFwdBlockScheduler:
             m_block=config.m_block,
             n_block_min=n_block_min,
             window_size_right=0,
-            window_size_dist=config.window_size_dist - 1,
+            window_size_dist=0,
             TILE_N=config.TILE_N,
             TILE_M=config.TILE_M,
-            IS_LOCAL=IS_LOCAL,
+            IS_LOCAL=False,
             QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
         )
 
@@ -916,11 +916,11 @@ class AttnBwdBlockScheduler:
             n_block=config.n_block,
             m_block_min=m_block_min,
             window_size_right=0,
-            window_size_dist=config.window_size_dist - 1,
+            window_size_dist=0,
             TILE_N=config.TILE_N,
             TILE_M=config.TILE_M,
             IS_CAUSAL=IS_CAUSAL or IS_LOCAL,
-            IS_LOCAL=IS_LOCAL,
+            IS_LOCAL=False,
         )
 
         # Clamp to split's range so the no-mask loop stays within bounds
@@ -1042,10 +1042,10 @@ class AttnDecBlockScheduler:
             m_block=0,
             n_block_min=n_block_min,
             window_size_right=0,
-            window_size_dist=config.window_size_dist - 1,
+            window_size_dist=0,
             TILE_N=config.TILE_N,
             TILE_M=config.TILE_M,
-            IS_LOCAL=IS_LOCAL,
+            IS_LOCAL=False,
             QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
         )
 

--- a/flash_sparse_attn/ops/triton/scheduler.py
+++ b/flash_sparse_attn/ops/triton/scheduler.py
@@ -50,9 +50,9 @@ class AttnFwdGridIndex:
     @triton.jit
     def load_window_sizes(self, window_sizes, stride_wh, IS_LOCAL: tl.constexpr):
         if IS_LOCAL:
-            window_size_left = tl.load(window_sizes + self.head_kv_idx * stride_wh)
+            window_size_dist = tl.load(window_sizes + self.head_kv_idx * stride_wh)
             window_size_right = tl.load(window_sizes + self.head_kv_idx * stride_wh + 1)
-            window_size_dist = tl.load(window_sizes + self.head_kv_idx * stride_wh + 2)
+            window_size_left = tl.load(window_sizes + self.head_kv_idx * stride_wh + 2)
         else:
             window_size_left = 0
             window_size_right = 0
@@ -98,9 +98,9 @@ class AttnBwdGridIndex:
     @triton.jit
     def load_window_sizes(self, window_sizes, stride_wh, IS_LOCAL: tl.constexpr):
         if IS_LOCAL:
-            window_size_left = tl.load(window_sizes + self.head_kv_idx * stride_wh)
+            window_size_dist = tl.load(window_sizes + self.head_kv_idx * stride_wh)
             window_size_right = tl.load(window_sizes + self.head_kv_idx * stride_wh + 1)
-            window_size_dist = tl.load(window_sizes + self.head_kv_idx * stride_wh + 2)
+            window_size_left = tl.load(window_sizes + self.head_kv_idx * stride_wh + 2)
         else:
             window_size_left = 0
             window_size_right = 0
@@ -137,9 +137,9 @@ class AttnDecGridIndex:
     @triton.jit
     def load_window_sizes(self, window_sizes, stride_wh, IS_LOCAL: tl.constexpr):
         if IS_LOCAL:
-            window_size_left = tl.load(window_sizes + self.head_kv_idx * stride_wh)
+            window_size_dist = tl.load(window_sizes + self.head_kv_idx * stride_wh)
             window_size_right = tl.load(window_sizes + self.head_kv_idx * stride_wh + 1)
-            window_size_dist = tl.load(window_sizes + self.head_kv_idx * stride_wh + 2)
+            window_size_left = tl.load(window_sizes + self.head_kv_idx * stride_wh + 2)
         else:
             window_size_left = 0
             window_size_right = 0
@@ -743,7 +743,9 @@ class AttnFwdBlockScheduler:
 
     @triton.jit
     def is_empty(self):
-        return self.n_block_max <= self.n_block_min
+        return (self.n_block_max <= self.n_block_min) & (
+            self.n_block_window_max <= self.n_block_window_min
+        )
 
     @staticmethod
     @triton.jit
@@ -792,8 +794,17 @@ class AttnFwdBlockScheduler:
             n_block_max_no_mask = tl.minimum(n_block_max_no_mask, n_block_max)
 
         if IS_LOCAL:
+            if IS_SPLIT_KV:
+                n_block_max_no_mask = tl.where(
+                    split_idx >= num_splits - 1,
+                    n_block_min,
+                    n_block_max_no_mask,
+                )
+            else:
+                n_block_max_no_mask = n_block_min
             # Compute local n_block range for this m_block
-            n_block_window_min = tl.maximum(n_block_window_min, n_block_min)
+            if IS_SPLIT_KV:
+                n_block_window_min = tl.maximum(n_block_window_min, n_block_min)
             n_block_window_max = tl.minimum(n_block_window_max, n_block_max_no_mask)
             n_block_window_max_no_mask = block_info.get_n_block_min_causal_local_mask(
                 seqlen_q=config.actual_seqlen_q,
@@ -835,6 +846,8 @@ class AttnFwdBlockScheduler:
                     n_block_window_min,
                 )
         else:
+            n_block_window_min = 0
+            n_block_window_max = 0
             n_block_window_min_no_mask = 0
             n_block_window_max_no_mask = 0
 
@@ -928,9 +941,9 @@ class AttnBwdBlockScheduler:
             m_block_min_no_mask = tl.minimum(m_block_min_no_mask, m_block_max)
 
         if IS_LOCAL:
+            m_block_min_no_mask = m_block_max
             # Compute local m_block range for this n_block
             m_block_window_min = tl.maximum(m_block_window_min, m_block_min_no_mask)
-            m_block_window_max = tl.minimum(m_block_window_max, m_block_max)
             m_block_window_min_no_mask = block_info.get_m_block_min_causal_local_mask(
                 seqlen_q=config.actual_seqlen_q,
                 seqlen_k=config.actual_seqlen_k,
@@ -1007,7 +1020,9 @@ class AttnDecBlockScheduler:
 
     @triton.jit
     def is_empty(self):
-        return self.n_block_max <= self.n_block_min
+        return (self.n_block_max <= self.n_block_min) & (
+            self.n_block_window_max <= self.n_block_window_min
+        )
 
     @staticmethod
     @triton.jit
@@ -1053,6 +1068,11 @@ class AttnDecBlockScheduler:
         n_block_max_no_mask = tl.minimum(n_block_max_no_mask, n_block_max)
 
         if IS_LOCAL:
+            n_block_max_no_mask = tl.where(
+                split_idx >= num_splits - 1,
+                n_block_min,
+                n_block_max_no_mask,
+            )
             # Compute local n_block range for this m_block
             n_block_window_min = tl.maximum(n_block_window_min, n_block_min)
             n_block_window_max = tl.minimum(n_block_window_max, n_block_max_no_mask)
@@ -1095,6 +1115,8 @@ class AttnDecBlockScheduler:
                 n_block_window_min,
             )
         else:
+            n_block_window_min = 0
+            n_block_window_max = 0
             n_block_window_min_no_mask = 0
             n_block_window_max_no_mask = 0
 
@@ -1502,11 +1524,17 @@ class AttnFwdPointerScheduler:
             lse_ptrs.store([config.m_block * config.TILE_M], lse_tile)
 
     @triton.jit
-    def store_empty(self, config: AttnFwdConfig, out_ptrs, lse_ptrs):
+    def store_empty(
+        self,
+        config: AttnFwdConfig,
+        out_ptrs,
+        lse_ptrs,
+        IS_SPLIT_KV: tl.constexpr = False,
+    ):
         lse_tile = tl.full((config.TILE_M,), float("-inf"), dtype=tl.float32)
         self.store_lse(config, lse_ptrs, lse_tile)
         o_tile = tl.zeros((config.TILE_M, config.TILE_K), dtype=tl.float32)
-        self.store_out(config, out_ptrs, o_tile)
+        self.store_out(config, out_ptrs, o_tile, IS_SPLIT_KV=IS_SPLIT_KV)
 
 
 @aggregate

--- a/flash_sparse_attn/ops/triton/utils.py
+++ b/flash_sparse_attn/ops/triton/utils.py
@@ -80,27 +80,34 @@ def window_sizes_heuristic(
     num_heads_kv: int,
     device: torch.device,
     equal_bandwidth: bool = True,
+    window_dist: int = 256,
 ) -> torch.Tensor:
     """
-    Compute window sizes that partition the causal triangle into bands.
+    Compute token count window sizes that partition non-diagonal causal distances into bands.
 
     :param seqlen_k: Sequence length of keys.
     :param num_heads_kv: Number of KV heads.
     :param device: Target device.
     :param equal_bandwidth: If True, use equal-bandwidth partitioning for balanced decode load. If False, use equal-area partitioning for balanced forward and backward load.
+    :param window_dist: Near-diagonal token count shared by all KV heads.
 
-    :return: int32 tensor with shape [num_heads_kv, 2], columns are [left, right].
+    :return: int32 tensor with shape [num_heads_kv, 3], columns are [left, right, window_dist]. left is the distant band token count, right is the token count gap after the near-diagonal window before the distant band, and window_dist is the near-diagonal token count.
     """
+    window_dist = min(max(window_dist, 0), seqlen_k)
     head_kv_idx = torch.arange(num_heads_kv + 1, dtype=torch.float32)
+    distance_span = max(seqlen_k - window_dist, 0)
     if equal_bandwidth:
-        breakpoints = (seqlen_k * head_kv_idx / num_heads_kv).to(torch.int32)
+        breakpoints = (distance_span * head_kv_idx / num_heads_kv).to(torch.int32)
     else:
         breakpoints = (
-            seqlen_k * (1.0 - torch.sqrt(1.0 - head_kv_idx / num_heads_kv))
+            distance_span * (1.0 - torch.sqrt(1.0 - head_kv_idx / num_heads_kv))
         ).to(torch.int32)
-    window_size_left = torch.clamp(breakpoints[1:] - 1, min=0)
+    window_size_left = breakpoints[1:] - breakpoints[:-1]
     window_size_right = breakpoints[:-1]
-    return torch.stack([window_size_left, window_size_right], dim=1).to(device)
+    window_size_dist = torch.full_like(window_size_left, window_dist)
+    return torch.stack(
+        [window_size_left, window_size_right, window_size_dist], dim=1
+    ).to(device)
 
 
 def alloc_fn(size: int, alignment: int, stream):

--- a/flash_sparse_attn/ops/triton/utils.py
+++ b/flash_sparse_attn/ops/triton/utils.py
@@ -44,37 +44,6 @@ def ensure_contiguous(fn):
 
 
 @functools.lru_cache(maxsize=4096)
-def num_splits_heuristic(
-    seqlen_q: int,
-    seqlen_k: int,
-    num_SMs: int,
-    TILE_M: int,
-    TILE_N: int,
-) -> int:
-    """
-    Determine the number of KV splits for FlashDecoding.
-
-    Splits only when there are enough KV blocks to benefit from parallelism,
-    and targets full SM occupancy by over-subscribing the M-block count.
-
-    :param seqlen_q: Sequence length of queries.
-    :param seqlen_k: Sequence length of keys.
-    :param num_SMs: Number of streaming multiprocessors on the device.
-    :param TILE_M: Tile size for M dimension.
-    :param TILE_N: Tile size for N dimension.
-
-    :return: Number of splits.
-    """
-    total_mblocks = triton.cdiv(seqlen_q, TILE_M)
-    num_n_blocks = triton.cdiv(seqlen_k, TILE_N)
-    max_splits = 1 << (max(num_SMs, 1).bit_length() - 1)
-    if num_n_blocks <= 4:
-        # 1 means no splitting
-        return 1
-    return max(1, min(num_SMs // max(total_mblocks, 1), max_splits, num_n_blocks))
-
-
-@functools.lru_cache(maxsize=4096)
 def window_sizes_heuristic(
     seqlen_k: int,
     num_heads_kv: int,
@@ -108,6 +77,64 @@ def window_sizes_heuristic(
     return torch.stack(
         [window_size_dist, window_size_right, window_size_left], dim=1
     ).to(device)
+
+
+def max_split_blocks_from_window_sizes(window_sizes: torch.Tensor, TILE_N: int) -> int:
+    """
+    Estimate useful split-axis blocks for local two-band attention.
+
+    Split-KV partitions the distant band across splits while the final split keeps
+    the near-diagonal band, so the useful split count is bounded by distant-band
+    blocks plus one near-diagonal split.
+
+    :param window_sizes: Int32 tensor with shape [num_heads_kv, 3], columns are [window_dist, right, left]
+    :param TILE_N: Tile size for N dimension.
+
+    :return: Useful split-axis blocks.
+    """
+    if window_sizes is None or window_sizes.numel() == 0:
+        return 1
+    window_dist = int(torch.clamp(window_sizes[:, 0], min=0).max().item())
+    window_left = int(torch.clamp(window_sizes[:, 2], min=0).max().item())
+    distant_blocks = triton.cdiv(window_left, TILE_N)
+    near_blocks = 1 if window_dist > 0 else 0
+    return max(1, distant_blocks + near_blocks)
+
+
+@functools.lru_cache(maxsize=4096)
+def num_splits_heuristic(
+    seqlen_q: int,
+    seqlen_k: int,
+    num_SMs: int,
+    TILE_M: int,
+    TILE_N: int,
+    max_split_blocks: int | None = None,
+) -> int:
+    """
+    Determine the number of KV splits for FlashDecoding.
+
+    Splits only when there are enough KV blocks to benefit from parallelism,
+    and targets full SM occupancy by over-subscribing the M-block count.
+
+    :param seqlen_q: Sequence length of queries.
+    :param seqlen_k: Sequence length of keys.
+    :param num_SMs: Number of streaming multiprocessors on the device.
+    :param TILE_M: Tile size for M dimension.
+    :param TILE_N: Tile size for N dimension.
+    :param max_split_blocks: Optional cap on useful split-axis blocks. Local two-band attention should pass this to avoid assigning splits to empty gap regions.
+
+    :return: Number of splits.
+    """
+    total_mblocks = triton.cdiv(seqlen_q, TILE_M)
+    num_n_blocks = triton.cdiv(seqlen_k, TILE_N)
+    effective_n_blocks = num_n_blocks
+    if max_split_blocks is not None:
+        effective_n_blocks = min(num_n_blocks, max(max_split_blocks, 1))
+    max_splits = 1 << (max(num_SMs, 1).bit_length() - 1)
+    if effective_n_blocks <= 4:
+        # 1 means no splitting
+        return 1
+    return max(1, min(num_SMs // max(total_mblocks, 1), max_splits, effective_n_blocks))
 
 
 def alloc_fn(size: int, alignment: int, stream):

--- a/flash_sparse_attn/ops/triton/utils.py
+++ b/flash_sparse_attn/ops/triton/utils.py
@@ -49,7 +49,8 @@ def window_sizes_heuristic(
     num_heads_kv: int,
     device: torch.device,
     equal_bandwidth: bool = True,
-    window_dist: int = 256,
+    window_dist: int = 1024,
+    window_sink: int = 64,
 ) -> torch.Tensor:
     """
     Compute token count window sizes that partition non-diagonal causal distances into bands.
@@ -59,12 +60,14 @@ def window_sizes_heuristic(
     :param device: Target device.
     :param equal_bandwidth: If True, use equal-bandwidth partitioning for balanced decode load. If False, use equal-area partitioning for balanced forward and backward load.
     :param window_dist: Near-diagonal token count shared by all KV heads.
+    :param window_sink: Sink token count shared by all KV heads.
 
-    :return: int32 tensor with shape [num_heads_kv, 3], columns are [window_dist, right, left]. window_dist is the near-diagonal token count, right is the token count gap after the near-diagonal window before the distant band, and left is the distant band token count.
+    :return: int32 tensor with shape [num_heads_kv, 4], columns are [window_sink, window_left, window_right, window_dist]. window_sink is the prefix sink token count, window_left is the distant local band token count, window_right is the token count gap after the near-diagonal window before the distant band, and window_dist is the near-diagonal token count.
     """
     window_dist = min(max(window_dist, 0), seqlen_k)
+    window_sink = min(max(window_sink, 0), seqlen_k)
     head_kv_idx = torch.arange(num_heads_kv + 1, dtype=torch.float32)
-    distance_span = max(seqlen_k - window_dist, 0)
+    distance_span = max(seqlen_k - window_sink - window_dist, 0)
     if equal_bandwidth:
         breakpoints = (distance_span * head_kv_idx / num_heads_kv).to(torch.int32)
     else:
@@ -74,31 +77,45 @@ def window_sizes_heuristic(
     window_size_left = breakpoints[1:] - breakpoints[:-1]
     window_size_right = breakpoints[:-1]
     window_size_dist = torch.full_like(window_size_left, window_dist)
+    window_size_sink = torch.full_like(window_size_left, window_sink)
     return torch.stack(
-        [window_size_dist, window_size_right, window_size_left], dim=1
+        [window_size_sink, window_size_left, window_size_right, window_size_dist], dim=1
     ).to(device)
 
 
-def max_split_blocks_from_window_sizes(window_sizes: torch.Tensor, TILE_N: int) -> int:
+def max_split_blocks_from_window_sizes(
+    window_sizes: torch.Tensor, TILE_N: int
+) -> int | None:
     """
-    Estimate useful split-axis blocks for local two-band attention.
+    Estimate useful split-axis blocks for local attention.
 
-    Split-KV partitions the distant band across splits while the final split keeps
-    the near-diagonal band, so the useful split count is bounded by distant-band
-    blocks plus one near-diagonal split.
+    The exact useful split count depends on the max values stored in window_sizes.
 
-    :param window_sizes: Int32 tensor with shape [num_heads_kv, 3], columns are [window_dist, right, left]
+    :param window_sizes: Int32 tensor with shape [num_heads_kv, 4], columns are [sink, left, right, dist]
     :param TILE_N: Tile size for N dimension.
 
-    :return: Useful split-axis blocks.
+    :return: Useful split-axis blocks, or None when CUDA Graph capture needs a static launch-grid bound.
     """
     if window_sizes is None or window_sizes.numel() == 0:
         return 1
-    window_dist = int(torch.clamp(window_sizes[:, 0], min=0).max().item())
-    window_left = int(torch.clamp(window_sizes[:, 2], min=0).max().item())
-    distant_blocks = triton.cdiv(window_left, TILE_N)
-    near_blocks = 1 if window_dist > 0 else 0
-    return max(1, distant_blocks + near_blocks)
+    if (
+        window_sizes.is_cuda
+        and torch.cuda.is_available()
+        and torch.cuda.is_current_stream_capturing()
+    ):
+        return None
+    window_sizes = torch.clamp(window_sizes, min=0)
+    window_sink = torch.max(window_sizes[:, 0])
+    window_left = torch.max(window_sizes[:, 1])
+    window_dist = torch.max(window_sizes[:, 3])
+    distant_blocks = torch.div(window_left + TILE_N - 1, TILE_N, rounding_mode="floor")
+    near_blocks = (window_dist > 0).to(window_left.dtype)
+    sink_blocks = torch.div(window_sink + TILE_N - 1, TILE_N, rounding_mode="floor")
+    split_blocks = torch.maximum(
+        distant_blocks + near_blocks + sink_blocks,
+        torch.ones((), dtype=window_left.dtype, device=window_sizes.device),
+    )
+    return int(split_blocks)
 
 
 @functools.lru_cache(maxsize=4096)

--- a/flash_sparse_attn/ops/triton/utils.py
+++ b/flash_sparse_attn/ops/triton/utils.py
@@ -91,7 +91,7 @@ def window_sizes_heuristic(
     :param equal_bandwidth: If True, use equal-bandwidth partitioning for balanced decode load. If False, use equal-area partitioning for balanced forward and backward load.
     :param window_dist: Near-diagonal token count shared by all KV heads.
 
-    :return: int32 tensor with shape [num_heads_kv, 3], columns are [left, right, window_dist]. left is the distant band token count, right is the token count gap after the near-diagonal window before the distant band, and window_dist is the near-diagonal token count.
+    :return: int32 tensor with shape [num_heads_kv, 3], columns are [window_dist, right, left]. window_dist is the near-diagonal token count, right is the token count gap after the near-diagonal window before the distant band, and left is the distant band token count.
     """
     window_dist = min(max(window_dist, 0), seqlen_k)
     head_kv_idx = torch.arange(num_heads_kv + 1, dtype=torch.float32)
@@ -106,7 +106,7 @@ def window_sizes_heuristic(
     window_size_right = breakpoints[:-1]
     window_size_dist = torch.full_like(window_size_left, window_dist)
     return torch.stack(
-        [window_size_left, window_size_right, window_size_dist], dim=1
+        [window_size_dist, window_size_right, window_size_left], dim=1
     ).to(device)
 
 

--- a/tests/benchmark_backward.py
+++ b/tests/benchmark_backward.py
@@ -107,7 +107,7 @@ def benchmark_triton_sparse_backward(
     k = k.requires_grad_(True)
     v = v.requires_grad_(True)
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = 16.0
+    softmax_threshold = 1.0
 
     out = flash_sparse_attn_func(
         q,
@@ -144,7 +144,7 @@ def benchmark_triton_sparse_backward_quant(
     k = k.requires_grad_(True)
     v = v.requires_grad_(True)
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = 16.0
+    softmax_threshold = 1.0
 
     out = flash_sparse_attn_func(
         q,
@@ -188,8 +188,8 @@ def benchmark_triton_gated_backward(
         cfg.batch_size, cfg.seqlen_k, cfg.num_kv_heads, device=device, dtype=dtype
     ).requires_grad_(True)
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = 16.0
-    gate_threshold = 16.0
+    softmax_threshold = 1.0
+    gate_threshold = 1.0
 
     out = flash_gated_attn_func(
         q,
@@ -239,8 +239,8 @@ def benchmark_triton_gated_backward_quant(
         cfg.batch_size, cfg.seqlen_k, cfg.num_kv_heads, device=device, dtype=dtype
     ).requires_grad_(True)
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = 16.0
-    gate_threshold = 16.0
+    softmax_threshold = 1.0
+    gate_threshold = 1.0
 
     out = flash_gated_attn_func(
         q,

--- a/tests/benchmark_decode.py
+++ b/tests/benchmark_decode.py
@@ -191,7 +191,7 @@ def benchmark_triton_sparse_decode(
     q = q.squeeze(1)
     out, lse = allocate_decode_outputs(q)
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = 16.0
+    softmax_threshold = 1.0
 
     def fn():
         return flash_sparse_attn_with_kvcache_func(
@@ -229,7 +229,7 @@ def benchmark_triton_sparse_decode_quant(
 
     out, lse = allocate_decode_outputs(q_quant, is_quant=True)
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = 16.0
+    softmax_threshold = 1.0
 
     def fn():
         return flash_sparse_attn_with_kvcache_func(
@@ -271,8 +271,8 @@ def benchmark_triton_gated_decode(
     )
     out, lse = allocate_decode_outputs(q)
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = 16.0
-    gate_threshold = 16.0
+    softmax_threshold = 1.0
+    gate_threshold = 1.0
 
     def fn():
         return flash_gated_attn_with_kvcache_func(
@@ -324,8 +324,8 @@ def benchmark_triton_gated_decode_quant(
     )
     out, lse = allocate_decode_outputs(q_quant, is_quant=True)
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = 16.0
-    gate_threshold = 16.0
+    softmax_threshold = 1.0
+    gate_threshold = 1.0
 
     def fn():
         return flash_gated_attn_with_kvcache_func(

--- a/tests/benchmark_forward.py
+++ b/tests/benchmark_forward.py
@@ -95,7 +95,7 @@ def benchmark_triton_sparse_forward(
         input_source="random",
     )
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = 16.0
+    softmax_threshold = 1.0
 
     def fn():
         flash_sparse_attn_func(
@@ -128,7 +128,7 @@ def benchmark_triton_sparse_forward_quant(
     v_quant, v_scale = quant.quantize_fp8(v)
 
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = 16.0
+    softmax_threshold = 1.0
 
     def fn():
         flash_sparse_attn_func(
@@ -166,8 +166,8 @@ def benchmark_triton_gated_forward(
         cfg.batch_size, cfg.seqlen_k, cfg.num_kv_heads, device=device, dtype=dtype
     )
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = 16.0
-    gate_threshold = 16.0
+    softmax_threshold = 1.0
+    gate_threshold = 1.0
 
     def fn():
         flash_gated_attn_func(
@@ -215,8 +215,8 @@ def benchmark_triton_gated_forward_quant(
         dtype=torch.bfloat16,
     )
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = 16.0
-    gate_threshold = 16.0
+    softmax_threshold = 1.0
+    gate_threshold = 1.0
 
     def fn():
         flash_gated_attn_func(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -446,10 +446,10 @@ def _reference_scores(
         dist = q_idx + causal_offset - k_idx
 
         for h in range(num_kv_heads):
-            wd = int(ws[h, 0].item())
-            wr = int(ws[h, 1].item())
-            wl = int(ws[h, 2].item())
-            sink = int(ws[h, 3].item())
+            sink = int(ws[h, 0].item())
+            wl = int(ws[h, 1].item())
+            wr = int(ws[h, 2].item())
+            wd = int(ws[h, 3].item())
             window_mask = (dist >= wd + wr) & (dist < wd + wr + wl)
             dist_mask = (dist >= 0) & (dist < wd)
             sink_mask = (k_idx < sink) & (dist >= 0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -446,9 +446,9 @@ def _reference_scores(
         dist = q_idx + causal_offset - k_idx
 
         for h in range(num_kv_heads):
-            wl = int(ws[h, 0].item())
+            wd = int(ws[h, 0].item())
             wr = int(ws[h, 1].item())
-            wd = int(ws[h, 2].item())
+            wl = int(ws[h, 2].item())
             window_mask = (dist >= wd + wr) & (dist < wd + wr + wl)
             dist_mask = (dist >= 0) & (dist < wd)
             allowed = dist_mask | window_mask

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Literal, Optional, Sequence
 
 import torch
 
-from flash_sparse_attn.ops.triton import launch_template
 from flash_sparse_attn.ops.triton.interface import (
     flash_dense_attn_func,
     flash_dense_attn_varlen_func,
@@ -446,55 +445,13 @@ def _reference_scores(
         causal_offset = seqlen_k - seqlen_q
         dist = q_idx + causal_offset - k_idx
 
-        tile_k = max(1 << (max(q.shape[-1], 16) - 1).bit_length(), 16)
-        if seqlen_q > 1:
-            launch_config = launch_template.load_launch_config(
-                device=q.device,
-                kernel_name=f"fwd_{kind}",
-                seqlen_q=seqlen_q,
-                seqlen_k=seqlen_k,
-                tile_k=tile_k,
-                is_local=is_local,
-                qhead_per_kvhead=qpk,
-                is_causal=is_causal,
-            )
-            if launch_config is not None:
-                tile_m, tile_n, _, _, _ = launch_config
-            else:
-                tile_m = tile_n = 64
-            m_block = q_idx // tile_m
-            n_blk = k_idx // tile_n
-            n_block_max_no_mask = (m_block * tile_m + causal_offset) // tile_n
-            n_block_max_diag = (
-                (m_block + 1) * tile_m + causal_offset + tile_n - 1
-            ) // tile_n
-            is_diagonal = (n_blk >= n_block_max_no_mask) & (n_blk < n_block_max_diag)
-            causal_mask = dist >= 0
-        else:
-            kernel_name = f"dec_{kind}"
-            launch_config = launch_template.load_launch_config(
-                device=q.device,
-                kernel_name=kernel_name,
-                seqlen_q=1,
-                seqlen_k=seqlen_k,
-                tile_k=tile_k,
-                is_local=is_local,
-                qhead_per_kvhead=qpk,
-            )
-            if launch_config is not None:
-                _, tile_n, _, _, _ = launch_config
-            else:
-                tile_n = 128
-            last_block_start = (seqlen_k - 1) // tile_n * tile_n
-            is_diagonal = k_idx >= last_block_start
-
         for h in range(num_kv_heads):
-            wl, wr = int(ws[h, 0].item()), int(ws[h, 1].item())
-            window_mask = (dist >= wr) & (dist <= wl)
-            if seqlen_q > 1:
-                allowed = (is_diagonal & causal_mask) | window_mask
-            else:
-                allowed = is_diagonal | window_mask
+            wl = int(ws[h, 0].item())
+            wr = int(ws[h, 1].item())
+            wd = int(ws[h, 2].item())
+            window_mask = (dist >= wd + wr) & (dist < wd + wr + wl)
+            dist_mask = (dist >= 0) & (dist < wd)
+            allowed = dist_mask | window_mask
             scores[:, h * qpk : (h + 1) * qpk] = scores[
                 :, h * qpk : (h + 1) * qpk
             ].masked_fill(~allowed, float("-inf"))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,24 +32,24 @@ CORRECTNESS_DTYPE = torch.bfloat16
 KernelType = Literal["dense", "sparse", "gated"]
 
 _DEFAULT_RTOL = {
-    "dense": 8e-2,
-    "sparse": 2.0e-1,
-    "gated": 2.0e-1,
+    "dense": 1.6e-2,
+    "sparse": 1.6e-2,
+    "gated": 1.6e-2,
 }
 _DEFAULT_ATOL = {
-    "dense": 8e-2,
-    "sparse": 2.0e-1,
-    "gated": 2.0e-1,
+    "dense": 1.0e-5,
+    "sparse": 1.0e-5,
+    "gated": 1.0e-5,
 }
 _DEFAULT_BWD_RTOL = {
-    "dense": 1.0e-1,
-    "sparse": 2.0e-1,
-    "gated": 2.0e-1,
+    "dense": 1.6e-2,
+    "sparse": 1.6e-2,
+    "gated": 1.6e-2,
 }
 _DEFAULT_BWD_ATOL = {
-    "dense": 1.0e-1,
-    "sparse": 2.0e-1,
-    "gated": 2.0e-1,
+    "dense": 1.0e-5,
+    "sparse": 1.0e-5,
+    "gated": 1.0e-5,
 }
 
 
@@ -449,9 +449,11 @@ def _reference_scores(
             wd = int(ws[h, 0].item())
             wr = int(ws[h, 1].item())
             wl = int(ws[h, 2].item())
+            sink = int(ws[h, 3].item())
             window_mask = (dist >= wd + wr) & (dist < wd + wr + wl)
             dist_mask = (dist >= 0) & (dist < wd)
-            allowed = dist_mask | window_mask
+            sink_mask = (k_idx < sink) & (dist >= 0)
+            allowed = sink_mask | dist_mask | window_mask
             scores[:, h * qpk : (h + 1) * qpk] = scores[
                 :, h * qpk : (h + 1) * qpk
             ].masked_fill(~allowed, float("-inf"))
@@ -728,7 +730,7 @@ def _run_forward_base(
     pack_gqa: bool = False,
 ):
     softmax_scale = q.shape[-1] ** -0.5
-    threshold = q.shape[-1] / k.shape[1]
+    threshold = -128.0
     if kind == "dense":
         out = flash_dense_attn_func(
             q,
@@ -878,7 +880,7 @@ def _run_forward_varlen(
     pack_gqa: bool = False,
 ):
     softmax_scale = q.shape[-1] ** -0.5
-    threshold = q.shape[-1] / max_seqlen_k
+    threshold = -128.0
     if kind == "dense":
         out = flash_dense_attn_varlen_func(
             q,
@@ -1068,7 +1070,7 @@ def run_decode_base_case(
         else None
     )
     softmax_scale = head_dim**-0.5
-    threshold = head_dim / seqlen_k
+    threshold = -128.0
 
     if is_quant_dtype:
         q_quant, q_scale = _quantize_per_tensor_quant(q)
@@ -1324,7 +1326,7 @@ def run_decode_varlen_case(
 
     cu_seqlens_k = make_cu_seqlens(lens_k, device)
     softmax_scale = head_dim**-0.5
-    threshold = head_dim / max(lens_k)
+    threshold = -128.0
 
     if is_quant_dtype:
         q_quant, q_scale = _quantize_per_tensor_quant(q)
@@ -1532,7 +1534,7 @@ def run_backward_base_case(
 ) -> None:
     device = torch.device("cuda")
     softmax_scale = head_dim**-0.5
-    threshold = head_dim / seqlen_k
+    threshold = -128.0
 
     q = torch.randn(
         batch_size, seqlen_q, num_heads_q, head_dim, device=device, dtype=dtype
@@ -1676,7 +1678,7 @@ def run_backward_varlen_case(
     device = torch.device("cuda")
     max_seqlen_k = max(lens_k)
     softmax_scale = head_dim**-0.5
-    threshold = head_dim / max_seqlen_k
+    threshold = -128.0
 
     q = torch.cat(
         [


### PR DESCRIPTION
## Summary

- standardize flexible local window layout as `[window_sink, window_left, window_right, window_dist]`
- move sink/window block-bound math into `block_info.py` and route it through scheduler classes
- add masked sink loops for dense, sparse, and gated fwd/bwd/decode paths
- update mask handling, split heuristics, docs, assertions, benchmarks, and reference tests for the new four-field window model
- keep split cap calculation CUDA Graph friendly by avoiding GPU scalar synchronization during graph capture

Fixes #324

## Testing

- `python -m py_compile flash_sparse_attn/ops/triton/block_info.py flash_sparse_attn/ops/triton/mask.py flash_sparse_attn/ops/triton/scheduler.py flash_sparse_attn/ops/triton/utils.py flash_sparse_attn/ops/triton/assert_inputs.py flash_sparse_attn/ops/triton/interface.py flash_sparse_attn/ops/triton/flash_dense_fwd.py flash_sparse_attn/ops/triton/flash_dense_bwd.py flash_sparse_attn/ops/triton/flash_dense_dec.py flash_sparse_attn/ops/triton/flash_sparse_fwd.py flash_sparse_attn/ops/triton/flash_sparse_bwd.py flash_sparse_attn/ops/triton/flash_sparse_dec.py flash_sparse_attn/ops/triton/flash_gated_fwd.py flash_sparse_attn/ops/triton/flash_gated_bwd.py flash_sparse_attn/ops/triton/flash_gated_dec.py tests/test_utils.py`
- `python -m ruff check flash_sparse_attn/ops/triton/utils.py`
- server-side dense forward/backward correctness checks passed during development
