### PR TITLE
Add Triton decode top-k gather KV

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Flash-Sparse-Attention is a high-performance trainable sparse attention implemen
 - Split-KV for workload balancing in forward and decode workloads
 - Split-QO for workload balancing in backward workloads
 - Fused Quant for low-precision computation on hardware without native FP8 support
+- Top-k gather KV-cache decode
 
 ## Features We Aim to Support
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -31,6 +31,7 @@ Flash-Sparse-Attention 是一个高性能的可训练稀疏注意力实现, 将 
 - Split-KV 适用于前向和解码的工作负载均衡
 - Split-QO 适用于反向的工作负载均衡
 - Fused Quant 支持非FP8原生支持的硬件使用低精度计算
+- Top-k gather KV-cache 解码
 
 ## 我们想要支持的功能
 

--- a/flash_sparse_attn/ops/triton/block_info.py
+++ b/flash_sparse_attn/ops/triton/block_info.py
@@ -275,3 +275,34 @@ def get_m_block_max_before_local_mask(
         m_idx = n_idx_min + seqlen_q - seqlen_k
         m_idx_left = m_idx + window_size_dist + window_size_right + window_size_left
         return tl.minimum(m_block_max, m_idx_left // TILE_M)
+
+
+@triton.jit
+def get_topk_n_block_min_max(
+    topk_seqlen_k,
+    split_idx,
+    num_splits,
+    TILE_N: tl.constexpr,
+):
+    total_n_blocks = tl.cdiv(topk_seqlen_k, TILE_N)
+    base = total_n_blocks // num_splits
+    extra = total_n_blocks % num_splits
+    n_block_min = tl.where(
+        split_idx < extra,
+        split_idx * (base + 1),
+        extra * (base + 1) + (split_idx - extra) * base,
+    )
+    n_block_count = tl.where(split_idx < extra, base + 1, base)
+    n_block_max = tl.minimum(n_block_min + n_block_count, total_n_blocks)
+    n_block_window_min = 0
+    n_block_window_max = 0
+    n_block_sink_min = 0
+    n_block_sink_max = 0
+    return (
+        n_block_min,
+        n_block_max,
+        n_block_window_min,
+        n_block_window_max,
+        n_block_sink_min,
+        n_block_sink_max,
+    )

--- a/flash_sparse_attn/ops/triton/flash_dense_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_dec.py
@@ -32,6 +32,7 @@ def _dec_inner_dense_kernel(
     softmax_sched: SoftmaxScheduler,
     q_tile,
     k_tile,
+    topk_indices,
     k_ptrs,
     v_ptrs,
     acc_o,
@@ -43,14 +44,34 @@ def _dec_inner_dense_kernel(
     MASK_LOCAL: tl.constexpr,
     MASK_SINK: tl.constexpr,
     CHECK_INF: tl.constexpr,
+    HAS_GATHER_KV: tl.constexpr,
 ):
     # Compute attention scores
     acc_s = tl.dot(q_tile, k_tile.T)
 
     # Prefetch next key tile
+    next_topk_indices = topk_indices
     if n_block > n_block_min:
+        if HAS_GATHER_KV:
+            # Load next topk indices
+            next_topk_indices = ptrs_sched.load_topk_indices(config, n_block - 1)
+
         # Load next key tile
-        k_tile = ptrs_sched.load_k(config, k_ptrs, n_block - 1)
+        k_tile = ptrs_sched.load_k(
+            config,
+            k_ptrs,
+            n_block - 1,
+            next_topk_indices,
+            HAS_GATHER_KV=HAS_GATHER_KV,
+        )
+
+    if HAS_GATHER_KV:
+        # Apply mask to attention scores
+        acc_s = ptrs_sched.apply_gather_mask(
+            config,
+            acc_s,
+            topk_indices,
+        )
 
     if IS_MASK:
         # Apply mask to attention scores
@@ -70,7 +91,9 @@ def _dec_inner_dense_kernel(
     )
 
     # Load value tile
-    v_tile = ptrs_sched.load_v(config, v_ptrs, n_block)
+    v_tile = ptrs_sched.load_v(
+        config, v_ptrs, n_block, topk_indices, HAS_GATHER_KV=HAS_GATHER_KV
+    )
 
     # Rescale output accumulator
     acc_o = softmax_sched.rescale_o(
@@ -81,7 +104,7 @@ def _dec_inner_dense_kernel(
     # Update output accumulator
     acc_o += tl.dot(p.to(v_tile.dtype), v_tile)
 
-    return k_tile, acc_o, row_max, row_sum
+    return k_tile, next_topk_indices, acc_o, row_max, row_sum
 
 
 @triton.jit(repr=kernel_repr.dec_dense_repr)
@@ -96,6 +119,7 @@ def _dec_dense_kernel(
     key_scale,
     value_scale,
     window_sizes,
+    gather_kv_indices,
     stride_qb,
     stride_qh,
     stride_qm,
@@ -114,6 +138,8 @@ def _dec_dense_kernel(
     stride_lm,
     stride_ls,
     stride_wh,
+    stride_gb,
+    stride_gn,
     cu_seqlens_q,
     cu_seqlens_k,
     seqused_q,
@@ -128,7 +154,9 @@ def _dec_dense_kernel(
     TILE_M: tl.constexpr,
     TILE_N: tl.constexpr,
     TILE_K: tl.constexpr,
+    topk_seqlen_k: tl.constexpr,
     IS_LOCAL: tl.constexpr,
+    HAS_GATHER_KV: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
     HAS_CU_SEQLENS_K: tl.constexpr,
     HAS_SEQUSED_Q: tl.constexpr,
@@ -185,6 +213,7 @@ def _dec_dense_kernel(
         Q=Q,
         K=K,
         V=V,
+        GatherKVIndices=gather_kv_indices,
         Out=Out,
         Lse=Lse,
         batch_idx=grid_idx.batch_idx,
@@ -208,6 +237,9 @@ def _dec_dense_kernel(
         stride_lh=stride_lh,
         stride_lm=stride_lm,
         stride_ls=stride_ls,
+        stride_gb=stride_gb,
+        stride_gn=stride_gn,
+        HAS_GATHER_KV=HAS_GATHER_KV,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
     )
@@ -217,7 +249,9 @@ def _dec_dense_kernel(
         config=config,
         split_idx=grid_idx.split_idx,
         num_splits=num_splits,
+        topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=IS_LOCAL,
+        HAS_GATHER_KV=HAS_GATHER_KV,
     )
 
     # Create mask scheduler
@@ -244,23 +278,37 @@ def _dec_dense_kernel(
     row_sum = tl.zeros((TILE_M,), dtype=tl.float32)
     acc_o = tl.zeros((TILE_M, TILE_K), dtype=tl.float32)
 
+    # Initialize topk indices
+    topk_indices = tl.arange(0, TILE_N)
+
     # Load query tile
     q_tile = ptrs_sched.load_q(config, q_ptrs)
 
+    if HAS_GATHER_KV:
+        # Load topk indices
+        topk_indices = ptrs_sched.load_topk_indices(config, block_sched.n_block_max - 1)
+
     # Load key tile
-    k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_max - 1)
+    k_tile = ptrs_sched.load_k(
+        config,
+        k_ptrs,
+        block_sched.n_block_max - 1,
+        topk_indices,
+        HAS_GATHER_KV=HAS_GATHER_KV,
+    )
 
     # Process n_blocks with seqlen masking
     for n_block in tl.range(
         block_sched.n_block_max - 1, block_sched.n_block_max_no_mask - 1, -1
     ):
-        k_tile, acc_o, row_max, row_sum = _dec_inner_dense_kernel(
+        k_tile, topk_indices, acc_o, row_max, row_sum = _dec_inner_dense_kernel(
             config=config,
             ptrs_sched=ptrs_sched,
             mask_sched=mask_sched,
             softmax_sched=softmax_sched,
             q_tile=q_tile,
             k_tile=k_tile,
+            topk_indices=topk_indices,
             k_ptrs=k_ptrs,
             v_ptrs=v_ptrs,
             acc_o=acc_o,
@@ -272,23 +320,40 @@ def _dec_dense_kernel(
             MASK_LOCAL=True if IS_LOCAL else False,
             MASK_SINK=False,
             CHECK_INF=True,
+            HAS_GATHER_KV=HAS_GATHER_KV,
         )
 
     # Process n_blocks without masking
-    if not IS_LOCAL and block_sched.n_block_max_no_mask > block_sched.n_block_min:
+    if (
+        not IS_LOCAL or HAS_GATHER_KV
+    ) and block_sched.n_block_max_no_mask > block_sched.n_block_min:
+        if HAS_GATHER_KV:
+            # Load topk indices
+            topk_indices = ptrs_sched.load_topk_indices(
+                config,
+                block_sched.n_block_max_no_mask - 1,
+            )
+
         # Load key tile
-        k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_max_no_mask - 1)
+        k_tile = ptrs_sched.load_k(
+            config,
+            k_ptrs,
+            block_sched.n_block_max_no_mask - 1,
+            topk_indices,
+            HAS_GATHER_KV=HAS_GATHER_KV,
+        )
 
         for n_block in tl.range(
             block_sched.n_block_max_no_mask - 1, block_sched.n_block_min - 1, -1
         ):
-            k_tile, acc_o, row_max, row_sum = _dec_inner_dense_kernel(
+            k_tile, topk_indices, acc_o, row_max, row_sum = _dec_inner_dense_kernel(
                 config=config,
                 ptrs_sched=ptrs_sched,
                 mask_sched=mask_sched,
                 softmax_sched=softmax_sched,
                 q_tile=q_tile,
                 k_tile=k_tile,
+                topk_indices=topk_indices,
                 k_ptrs=k_ptrs,
                 v_ptrs=v_ptrs,
                 acc_o=acc_o,
@@ -299,10 +364,11 @@ def _dec_dense_kernel(
                 IS_MASK=False,
                 MASK_LOCAL=False,
                 MASK_SINK=False,
-                CHECK_INF=False,
+                CHECK_INF=True if HAS_GATHER_KV else False,
+                HAS_GATHER_KV=HAS_GATHER_KV,
             )
 
-    if IS_LOCAL:
+    if IS_LOCAL and not HAS_GATHER_KV:
         # Process n_blocks with local right masking
         if block_sched.n_block_window_max > block_sched.n_block_window_max_no_mask:
             # Load key tile
@@ -315,13 +381,14 @@ def _dec_dense_kernel(
                 block_sched.n_block_window_max_no_mask - 1,
                 -1,
             ):
-                k_tile, acc_o, row_max, row_sum = _dec_inner_dense_kernel(
+                k_tile, topk_indices, acc_o, row_max, row_sum = _dec_inner_dense_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
                     mask_sched=mask_sched,
                     softmax_sched=softmax_sched,
                     q_tile=q_tile,
                     k_tile=k_tile,
+                    topk_indices=topk_indices,
                     k_ptrs=k_ptrs,
                     v_ptrs=v_ptrs,
                     acc_o=acc_o,
@@ -333,6 +400,7 @@ def _dec_dense_kernel(
                     MASK_LOCAL=True,
                     MASK_SINK=False,
                     CHECK_INF=True,
+                    HAS_GATHER_KV=False,
                 )
 
         # Process n_blocks without masking
@@ -350,13 +418,14 @@ def _dec_dense_kernel(
                 block_sched.n_block_window_min_no_mask - 1,
                 -1,
             ):
-                k_tile, acc_o, row_max, row_sum = _dec_inner_dense_kernel(
+                k_tile, topk_indices, acc_o, row_max, row_sum = _dec_inner_dense_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
                     mask_sched=mask_sched,
                     softmax_sched=softmax_sched,
                     q_tile=q_tile,
                     k_tile=k_tile,
+                    topk_indices=topk_indices,
                     k_ptrs=k_ptrs,
                     v_ptrs=v_ptrs,
                     acc_o=acc_o,
@@ -368,6 +437,7 @@ def _dec_dense_kernel(
                     MASK_LOCAL=False,
                     MASK_SINK=False,
                     CHECK_INF=False,
+                    HAS_GATHER_KV=False,
                 )
 
         # Process n_blocks with local left masking
@@ -382,13 +452,14 @@ def _dec_dense_kernel(
                 block_sched.n_block_window_min - 1,
                 -1,
             ):
-                k_tile, acc_o, row_max, row_sum = _dec_inner_dense_kernel(
+                k_tile, topk_indices, acc_o, row_max, row_sum = _dec_inner_dense_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
                     mask_sched=mask_sched,
                     softmax_sched=softmax_sched,
                     q_tile=q_tile,
                     k_tile=k_tile,
+                    topk_indices=topk_indices,
                     k_ptrs=k_ptrs,
                     v_ptrs=v_ptrs,
                     acc_o=acc_o,
@@ -400,6 +471,7 @@ def _dec_dense_kernel(
                     MASK_LOCAL=True,
                     MASK_SINK=False,
                     CHECK_INF=True,
+                    HAS_GATHER_KV=False,
                 )
 
         # Process n_blocks with local sink masking
@@ -412,13 +484,14 @@ def _dec_dense_kernel(
                 block_sched.n_block_sink_min - 1,
                 -1,
             ):
-                k_tile, acc_o, row_max, row_sum = _dec_inner_dense_kernel(
+                k_tile, topk_indices, acc_o, row_max, row_sum = _dec_inner_dense_kernel(
                     config=config,
                     ptrs_sched=ptrs_sched,
                     mask_sched=mask_sched,
                     softmax_sched=softmax_sched,
                     q_tile=q_tile,
                     k_tile=k_tile,
+                    topk_indices=topk_indices,
                     k_ptrs=k_ptrs,
                     v_ptrs=v_ptrs,
                     acc_o=acc_o,
@@ -430,6 +503,7 @@ def _dec_dense_kernel(
                     MASK_LOCAL=True,
                     MASK_SINK=True,
                     CHECK_INF=True,
+                    HAS_GATHER_KV=False,
                 )
 
     # Finalize softmax
@@ -478,6 +552,7 @@ def _flash_dense_attn_decode(
     window_sizes: Optional[torch.Tensor] = None,
     is_local: bool = False,
     is_quant: bool = False,
+    gather_kv_indices: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = False,
@@ -487,6 +562,9 @@ def _flash_dense_attn_decode(
     num_SMs = cache_utils.get_device_num_sms(device)
     batch_size, num_heads_q, head_dim = query.shape
     _, seqlen_k, num_heads_kv, _ = key.shape
+    topk_seqlen_k = (
+        gather_kv_indices.shape[-1] if gather_kv_indices is not None else seqlen_k
+    )
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
@@ -520,7 +598,7 @@ def _flash_dense_attn_decode(
         device=device,
         kernel_name="dec_dense",
         seqlen_q=1,
-        seqlen_k=seqlen_k,
+        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
         tile_k=TILE_K,
         is_local=is_local,
         qhead_per_kvhead=qhead_per_kvhead,
@@ -537,7 +615,7 @@ def _flash_dense_attn_decode(
 
     num_splits = utils.num_splits_heuristic(
         seqlen_q=qhead_per_kvhead,
-        seqlen_k=seqlen_k,
+        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
         num_SMs=num_SMs,
         TILE_M=TILE_M,
         TILE_N=TILE_N,
@@ -593,6 +671,7 @@ def _flash_dense_attn_decode(
         key_scale,
         value_scale,
         window_sizes,
+        gather_kv_indices,
         query.stride(0),
         query.stride(-2),
         1,
@@ -611,6 +690,8 @@ def _flash_dense_attn_decode(
         1,
         lse_partial.stride(0),
         window_sizes.stride(0),
+        gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
+        gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
         None,
         None,
@@ -625,7 +706,9 @@ def _flash_dense_attn_decode(
         TILE_M=TILE_M,
         TILE_N=TILE_N,
         TILE_K=TILE_K,
+        topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
+        HAS_GATHER_KV=gather_kv_indices is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
         HAS_SEQUSED_Q=False,
@@ -642,7 +725,7 @@ def _flash_dense_attn_decode(
                 device=device,
                 kernel_name="dec_dense",
                 seqlen_q=1,
-                seqlen_k=seqlen_k,
+                seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
                 tile_k=TILE_K,
                 config=best,
                 is_local=is_local,
@@ -674,6 +757,7 @@ def _flash_dense_attn_varlen_decode(
     is_local: bool = False,
     is_quant: bool = False,
     seqused_k: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = False,
@@ -684,6 +768,9 @@ def _flash_dense_attn_varlen_decode(
     batch_size, num_heads_q, head_dim = query.shape
     _, num_heads_kv, _ = key.shape
     seqlen_k = max_seqlen_k
+    topk_seqlen_k = (
+        gather_kv_indices.shape[-1] if gather_kv_indices is not None else seqlen_k
+    )
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
@@ -717,7 +804,7 @@ def _flash_dense_attn_varlen_decode(
         device=device,
         kernel_name="dec_dense",
         seqlen_q=1,
-        seqlen_k=seqlen_k,
+        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
         tile_k=TILE_K,
         is_local=is_local,
         qhead_per_kvhead=qhead_per_kvhead,
@@ -734,7 +821,7 @@ def _flash_dense_attn_varlen_decode(
 
     num_splits = utils.num_splits_heuristic(
         seqlen_q=qhead_per_kvhead,
-        seqlen_k=seqlen_k,
+        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
         num_SMs=num_SMs,
         TILE_M=TILE_M,
         TILE_N=TILE_N,
@@ -790,6 +877,7 @@ def _flash_dense_attn_varlen_decode(
         key_scale,
         value_scale,
         window_sizes,
+        gather_kv_indices,
         query.stride(0),
         query.stride(-2),
         1,
@@ -808,6 +896,8 @@ def _flash_dense_attn_varlen_decode(
         1,
         lse_partial.stride(0),
         window_sizes.stride(0),
+        gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
+        gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
         cu_seqlens_k,
         None,
@@ -822,7 +912,9 @@ def _flash_dense_attn_varlen_decode(
         TILE_M=TILE_M,
         TILE_N=TILE_N,
         TILE_K=TILE_K,
+        topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
+        HAS_GATHER_KV=gather_kv_indices is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=True,
         HAS_SEQUSED_Q=False,
@@ -839,7 +931,7 @@ def _flash_dense_attn_varlen_decode(
                 device=device,
                 kernel_name="dec_dense",
                 seqlen_q=1,
-                seqlen_k=seqlen_k,
+                seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
                 tile_k=TILE_K,
                 config=best,
                 is_local=is_local,

--- a/flash_sparse_attn/ops/triton/flash_dense_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_dec.py
@@ -614,16 +614,19 @@ def _flash_dense_attn_decode(
         TILE_N = 128
         num_warps = num_stages = num_ctas = None
 
-    num_splits = utils.num_splits_heuristic(
-        seqlen_q=qhead_per_kvhead,
-        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
-        num_SMs=num_SMs,
-        TILE_M=TILE_M,
-        TILE_N=TILE_N,
-        max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
-        if is_local
-        else None,
-    )
+    if gather_kv_indices is not None:
+        num_splits = 1
+    else:
+        num_splits = utils.num_splits_heuristic(
+            seqlen_q=qhead_per_kvhead,
+            seqlen_k=seqlen_k,
+            num_SMs=num_SMs,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+            if is_local
+            else None,
+        )
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype
     out = (
@@ -820,16 +823,19 @@ def _flash_dense_attn_varlen_decode(
         TILE_N = 128
         num_warps = num_stages = num_ctas = None
 
-    num_splits = utils.num_splits_heuristic(
-        seqlen_q=qhead_per_kvhead,
-        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
-        num_SMs=num_SMs,
-        TILE_M=TILE_M,
-        TILE_N=TILE_N,
-        max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
-        if is_local
-        else None,
-    )
+    if gather_kv_indices is not None:
+        num_splits = 1
+    else:
+        num_splits = utils.num_splits_heuristic(
+            seqlen_q=qhead_per_kvhead,
+            seqlen_k=seqlen_k,
+            num_SMs=num_SMs,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+            if is_local
+            else None,
+        )
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype
     out = (

--- a/flash_sparse_attn/ops/triton/flash_dense_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_dec.py
@@ -623,7 +623,9 @@ def _flash_dense_attn_decode(
             num_SMs=num_SMs,
             TILE_M=TILE_M,
             TILE_N=TILE_N,
-            max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_N
+            )
             if is_local
             else None,
         )
@@ -832,7 +834,9 @@ def _flash_dense_attn_varlen_decode(
             num_SMs=num_SMs,
             TILE_M=TILE_M,
             TILE_N=TILE_N,
-            max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_N
+            )
             if is_local
             else None,
         )

--- a/flash_sparse_attn/ops/triton/flash_dense_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_dec.py
@@ -46,11 +46,12 @@ def _dec_inner_dense_kernel(
     CHECK_INF: tl.constexpr,
     HAS_GATHER_KV: tl.constexpr,
 ):
+    next_topk_indices = topk_indices
+
     # Compute attention scores
     acc_s = tl.dot(q_tile, k_tile.T)
 
     # Prefetch next key tile
-    next_topk_indices = topk_indices
     if n_block > n_block_min:
         if HAS_GATHER_KV:
             # Load next topk indices

--- a/flash_sparse_attn/ops/triton/flash_gated_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_dec.py
@@ -52,6 +52,7 @@ def _dec_inner_gated_kernel(
     CHECK_INF: tl.constexpr,
     HAS_GATHER_KV: tl.constexpr,
 ):
+    next_topk_indices = topk_indices
     skip_gate_next = True
     if not skip_gate_curr:
         if HAS_GATHER_KV:
@@ -98,7 +99,6 @@ def _dec_inner_gated_kernel(
             acc_o += tl.dot(p.to(v_tile.dtype), v_tile)
 
     if n_block > n_block_min:
-        next_topk_indices = topk_indices
         if HAS_GATHER_KV:
             # Load next topk indices
             next_topk_indices = ptrs_sched.load_topk_indices(config, n_block - 1)

--- a/flash_sparse_attn/ops/triton/flash_gated_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_dec.py
@@ -35,6 +35,7 @@ def _dec_inner_gated_kernel(
     acc_o,
     q_tile,
     a_tile,
+    topk_indices,
     k_ptrs,
     v_ptrs,
     d_ptrs,
@@ -49,23 +50,16 @@ def _dec_inner_gated_kernel(
     MASK_LOCAL: tl.constexpr,
     MASK_SINK: tl.constexpr,
     CHECK_INF: tl.constexpr,
+    HAS_GATHER_KV: tl.constexpr,
 ):
-    # Load next delta tile
-    d_tile = ptrs_sched.load_d(config, d_ptrs, n_block - 1)
-    d_max = tl.max(d_tile)
-    d_min = tl.min(d_tile)
-
     skip_gate_next = True
     if not skip_gate_curr:
-        if n_block > n_block_min:
-            # Check if any gates are active for next tile
-            gate_max, skip_gate_next = softmax_sched.online_gate(
-                a_max=a_max,
-                a_min=a_min,
-                d_max=d_max,
-                d_min=d_min,
-                gate_max=gate_max,
-                gate_threshold_log2=config.gate_threshold_log2,
+        if HAS_GATHER_KV:
+            # Apply mask to attention scores
+            acc_s = ptrs_sched.apply_gather_mask(
+                config,
+                acc_s,
+                topk_indices,
             )
 
         if IS_MASK:
@@ -90,7 +84,9 @@ def _dec_inner_gated_kernel(
 
         if not skip_softmax:
             # Load value tile
-            v_tile = ptrs_sched.load_v(config, v_ptrs, n_block)
+            v_tile = ptrs_sched.load_v(
+                config, v_ptrs, n_block, topk_indices, HAS_GATHER_KV=HAS_GATHER_KV
+            )
 
             # Rescale output accumulator
             acc_o = softmax_sched.rescale_o(
@@ -101,35 +97,57 @@ def _dec_inner_gated_kernel(
             # Update output accumulator
             acc_o += tl.dot(p.to(v_tile.dtype), v_tile)
 
-    else:
-        if n_block > n_block_min:
-            # Check if any gates are active for next tile
-            gate_max, skip_gate_next = softmax_sched.online_gate(
-                a_max=a_max,
-                a_min=a_min,
-                d_max=d_max,
-                d_min=d_min,
-                gate_max=gate_max,
-                gate_threshold_log2=config.gate_threshold_log2,
+    if n_block > n_block_min:
+        next_topk_indices = topk_indices
+        if HAS_GATHER_KV:
+            # Load next topk indices
+            next_topk_indices = ptrs_sched.load_topk_indices(config, n_block - 1)
+
+        # Load next delta tile
+        d_tile = ptrs_sched.load_d(
+            config,
+            d_ptrs,
+            n_block - 1,
+            next_topk_indices,
+            HAS_GATHER_KV=HAS_GATHER_KV,
+        )
+        d_max = tl.max(d_tile)
+        d_min = tl.min(d_tile)
+
+        # Check if any gates are active for next tile
+        gate_max, skip_gate_next = softmax_sched.online_gate(
+            a_max=a_max,
+            a_min=a_min,
+            d_max=d_max,
+            d_min=d_min,
+            gate_max=gate_max,
+            gate_threshold_log2=config.gate_threshold_log2,
+        )
+
+        if not skip_gate_next:
+            # Compute attention gates for next tile
+            acc_s = a_tile[:, None] * d_tile[None, :]
+            if config.IS_LOGSIGMOID_GATE:
+                acc_s = softmax_sched.log_sigmoid(
+                    acc_s=acc_s,
+                )
+
+            # Load next key tile
+            k_tile = ptrs_sched.load_k(
+                config,
+                k_ptrs,
+                n_block - 1,
+                next_topk_indices,
+                HAS_GATHER_KV=HAS_GATHER_KV,
             )
 
-    if not skip_gate_next:
-        # Compute attention gates for next tile
-        acc_s = a_tile[:, None] * d_tile[None, :]
-        if config.IS_LOGSIGMOID_GATE:
-            acc_s = softmax_sched.log_sigmoid(
-                acc_s=acc_s,
-            )
-
-        # Load next key tile
-        k_tile = ptrs_sched.load_k(config, k_ptrs, n_block - 1)
-
-        # Compute attention scores for next tile
-        acc_s += tl.dot(q_tile, k_tile.T)
+            # Compute attention scores for next tile
+            acc_s += tl.dot(q_tile, k_tile.T)
 
     return (
         skip_gate_next,
         acc_s,
+        next_topk_indices,
         acc_o,
         gate_max,
         row_max,
@@ -153,6 +171,7 @@ def _dec_gated_kernel(
     softmax_threshold,
     gate_threshold,
     window_sizes,
+    gather_kv_indices,
     stride_qb,
     stride_qh,
     stride_qm,
@@ -175,6 +194,8 @@ def _dec_gated_kernel(
     stride_lm,
     stride_ls,
     stride_wh,
+    stride_gb,
+    stride_gn,
     cu_seqlens_q,
     cu_seqlens_k,
     seqused_q,
@@ -189,7 +210,9 @@ def _dec_gated_kernel(
     TILE_M: tl.constexpr,
     TILE_N: tl.constexpr,
     TILE_K: tl.constexpr,
+    topk_seqlen_k: tl.constexpr,
     IS_LOCAL: tl.constexpr,
+    HAS_GATHER_KV: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
     HAS_CU_SEQLENS_K: tl.constexpr,
     HAS_SEQUSED_Q: tl.constexpr,
@@ -252,6 +275,7 @@ def _dec_gated_kernel(
         V=V,
         A=A,
         D=D,
+        GatherKVIndices=gather_kv_indices,
         Out=Out,
         Lse=Lse,
         batch_idx=grid_idx.batch_idx,
@@ -279,7 +303,10 @@ def _dec_gated_kernel(
         stride_lh=stride_lh,
         stride_lm=stride_lm,
         stride_ls=stride_ls,
+        stride_gb=stride_gb,
+        stride_gn=stride_gn,
         IS_GATED=True,
+        HAS_GATHER_KV=HAS_GATHER_KV,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
     )
@@ -289,7 +316,9 @@ def _dec_gated_kernel(
         config=config,
         split_idx=grid_idx.split_idx,
         num_splits=num_splits,
+        topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=IS_LOCAL,
+        HAS_GATHER_KV=HAS_GATHER_KV,
     )
 
     # Create mask scheduler
@@ -319,6 +348,9 @@ def _dec_gated_kernel(
     row_sum = tl.zeros((TILE_M,), dtype=tl.float32)
     acc_o = tl.zeros((TILE_M, TILE_K), dtype=tl.float32)
 
+    # Initialize topk indices
+    topk_indices = tl.arange(0, TILE_N)
+
     # Load query tile
     q_tile = ptrs_sched.load_q(config, q_ptrs)
 
@@ -327,8 +359,18 @@ def _dec_gated_kernel(
     a_max = tl.max(a_tile)
     a_min = tl.min(a_tile)
 
+    if HAS_GATHER_KV:
+        # Load topk indices
+        topk_indices = ptrs_sched.load_topk_indices(config, block_sched.n_block_max - 1)
+
     # Load delta tile
-    d_tile = ptrs_sched.load_d(config, d_ptrs, block_sched.n_block_max - 1)
+    d_tile = ptrs_sched.load_d(
+        config,
+        d_ptrs,
+        block_sched.n_block_max - 1,
+        topk_indices,
+        HAS_GATHER_KV=HAS_GATHER_KV,
+    )
     d_max = tl.max(d_tile)
     d_min = tl.min(d_tile)
 
@@ -353,7 +395,13 @@ def _dec_gated_kernel(
         )
 
     # Load key tile
-    k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_max - 1)
+    k_tile = ptrs_sched.load_k(
+        config,
+        k_ptrs,
+        block_sched.n_block_max - 1,
+        topk_indices,
+        HAS_GATHER_KV=HAS_GATHER_KV,
+    )
 
     # Compute attention scores for first tile
     acc_s += tl.dot(q_tile, k_tile.T)
@@ -365,6 +413,7 @@ def _dec_gated_kernel(
         (
             skip_gate_curr,
             acc_s,
+            topk_indices,
             acc_o,
             gate_max,
             row_max,
@@ -379,6 +428,7 @@ def _dec_gated_kernel(
             acc_o=acc_o,
             q_tile=q_tile,
             a_tile=a_tile,
+            topk_indices=topk_indices,
             k_ptrs=k_ptrs,
             v_ptrs=v_ptrs,
             d_ptrs=d_ptrs,
@@ -393,15 +443,37 @@ def _dec_gated_kernel(
             MASK_LOCAL=True if IS_LOCAL else False,
             MASK_SINK=False,
             CHECK_INF=True,
+            HAS_GATHER_KV=HAS_GATHER_KV,
         )
 
     # Process n_blocks without masking
-    if not IS_LOCAL and block_sched.n_block_max_no_mask > block_sched.n_block_min:
+    if (
+        not IS_LOCAL or HAS_GATHER_KV
+    ) and block_sched.n_block_max_no_mask > block_sched.n_block_min:
+        if HAS_GATHER_KV:
+            # Load topk indices
+            topk_indices = ptrs_sched.load_topk_indices(
+                config,
+                block_sched.n_block_max_no_mask - 1,
+            )
+
         # Load key tile
-        k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_max_no_mask - 1)
+        k_tile = ptrs_sched.load_k(
+            config,
+            k_ptrs,
+            block_sched.n_block_max_no_mask - 1,
+            topk_indices,
+            HAS_GATHER_KV=HAS_GATHER_KV,
+        )
 
         # Load delta tile
-        d_tile = ptrs_sched.load_d(config, d_ptrs, block_sched.n_block_max_no_mask - 1)
+        d_tile = ptrs_sched.load_d(
+            config,
+            d_ptrs,
+            block_sched.n_block_max_no_mask - 1,
+            topk_indices,
+            HAS_GATHER_KV=HAS_GATHER_KV,
+        )
         d_max = tl.max(d_tile)
         d_min = tl.min(d_tile)
 
@@ -431,6 +503,7 @@ def _dec_gated_kernel(
             (
                 skip_gate_curr,
                 acc_s,
+                topk_indices,
                 acc_o,
                 gate_max,
                 row_max,
@@ -445,6 +518,7 @@ def _dec_gated_kernel(
                 acc_o=acc_o,
                 q_tile=q_tile,
                 a_tile=a_tile,
+                topk_indices=topk_indices,
                 k_ptrs=k_ptrs,
                 v_ptrs=v_ptrs,
                 d_ptrs=d_ptrs,
@@ -458,10 +532,11 @@ def _dec_gated_kernel(
                 IS_MASK=False,
                 MASK_LOCAL=False,
                 MASK_SINK=False,
-                CHECK_INF=False,
+                CHECK_INF=True if HAS_GATHER_KV else False,
+                HAS_GATHER_KV=HAS_GATHER_KV,
             )
 
-    if IS_LOCAL:
+    if IS_LOCAL and not HAS_GATHER_KV:
         # Process n_blocks with local right masking
         if block_sched.n_block_window_max > block_sched.n_block_window_max_no_mask:
             # Load key tile
@@ -504,6 +579,7 @@ def _dec_gated_kernel(
                 (
                     skip_gate_curr,
                     acc_s,
+                    topk_indices,
                     acc_o,
                     gate_max,
                     row_max,
@@ -518,6 +594,7 @@ def _dec_gated_kernel(
                     acc_o=acc_o,
                     q_tile=q_tile,
                     a_tile=a_tile,
+                    topk_indices=topk_indices,
                     k_ptrs=k_ptrs,
                     v_ptrs=v_ptrs,
                     d_ptrs=d_ptrs,
@@ -532,6 +609,7 @@ def _dec_gated_kernel(
                     MASK_LOCAL=True,
                     MASK_SINK=False,
                     CHECK_INF=True,
+                    HAS_GATHER_KV=False,
                 )
 
         # Process n_blocks without masking
@@ -579,6 +657,7 @@ def _dec_gated_kernel(
                 (
                     skip_gate_curr,
                     acc_s,
+                    topk_indices,
                     acc_o,
                     gate_max,
                     row_max,
@@ -593,6 +672,7 @@ def _dec_gated_kernel(
                     acc_o=acc_o,
                     q_tile=q_tile,
                     a_tile=a_tile,
+                    topk_indices=topk_indices,
                     k_ptrs=k_ptrs,
                     v_ptrs=v_ptrs,
                     d_ptrs=d_ptrs,
@@ -607,6 +687,7 @@ def _dec_gated_kernel(
                     MASK_LOCAL=False,
                     MASK_SINK=False,
                     CHECK_INF=False,
+                    HAS_GATHER_KV=False,
                 )
 
         # Process n_blocks with local left masking
@@ -651,6 +732,7 @@ def _dec_gated_kernel(
                 (
                     skip_gate_curr,
                     acc_s,
+                    topk_indices,
                     acc_o,
                     gate_max,
                     row_max,
@@ -665,6 +747,7 @@ def _dec_gated_kernel(
                     acc_o=acc_o,
                     q_tile=q_tile,
                     a_tile=a_tile,
+                    topk_indices=topk_indices,
                     k_ptrs=k_ptrs,
                     v_ptrs=v_ptrs,
                     d_ptrs=d_ptrs,
@@ -679,6 +762,7 @@ def _dec_gated_kernel(
                     MASK_LOCAL=True,
                     MASK_SINK=False,
                     CHECK_INF=True,
+                    HAS_GATHER_KV=False,
                 )
 
         # Process n_blocks with local sink masking
@@ -719,6 +803,7 @@ def _dec_gated_kernel(
                 (
                     skip_gate_curr,
                     acc_s,
+                    topk_indices,
                     acc_o,
                     gate_max,
                     row_max,
@@ -733,6 +818,7 @@ def _dec_gated_kernel(
                     acc_o=acc_o,
                     q_tile=q_tile,
                     a_tile=a_tile,
+                    topk_indices=topk_indices,
                     k_ptrs=k_ptrs,
                     v_ptrs=v_ptrs,
                     d_ptrs=d_ptrs,
@@ -747,6 +833,7 @@ def _dec_gated_kernel(
                     MASK_LOCAL=True,
                     MASK_SINK=True,
                     CHECK_INF=True,
+                    HAS_GATHER_KV=False,
                 )
 
     # Finalize softmax
@@ -800,6 +887,7 @@ def _flash_gated_attn_decode(
     window_sizes: Optional[torch.Tensor] = None,
     is_local: bool = False,
     is_quant: bool = False,
+    gather_kv_indices: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = False,
@@ -809,6 +897,9 @@ def _flash_gated_attn_decode(
     num_SMs = cache_utils.get_device_num_sms(device)
     batch_size, num_heads_q, head_dim = query.shape
     _, seqlen_k, num_heads_kv, _ = key.shape
+    topk_seqlen_k = (
+        gather_kv_indices.shape[-1] if gather_kv_indices is not None else seqlen_k
+    )
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
@@ -850,7 +941,7 @@ def _flash_gated_attn_decode(
         device=device,
         kernel_name="dec_gated",
         seqlen_q=1,
-        seqlen_k=seqlen_k,
+        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
         tile_k=TILE_K,
         is_local=is_local,
         qhead_per_kvhead=qhead_per_kvhead,
@@ -867,7 +958,7 @@ def _flash_gated_attn_decode(
 
     num_splits = utils.num_splits_heuristic(
         seqlen_q=qhead_per_kvhead,
-        seqlen_k=seqlen_k,
+        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
         num_SMs=num_SMs,
         TILE_M=TILE_M,
         TILE_N=TILE_N,
@@ -927,6 +1018,7 @@ def _flash_gated_attn_decode(
         softmax_threshold,
         gate_threshold,
         window_sizes,
+        gather_kv_indices,
         query.stride(0),
         query.stride(-2),
         1,
@@ -949,6 +1041,8 @@ def _flash_gated_attn_decode(
         1,
         lse_partial.stride(0),
         window_sizes.stride(0),
+        gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
+        gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
         None,
         None,
@@ -963,7 +1057,9 @@ def _flash_gated_attn_decode(
         TILE_M=TILE_M,
         TILE_N=TILE_N,
         TILE_K=TILE_K,
+        topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
+        HAS_GATHER_KV=gather_kv_indices is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
         HAS_SEQUSED_Q=False,
@@ -981,7 +1077,7 @@ def _flash_gated_attn_decode(
                 device=device,
                 kernel_name="dec_gated",
                 seqlen_q=1,
-                seqlen_k=seqlen_k,
+                seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
                 tile_k=TILE_K,
                 config=best,
                 is_local=is_local,
@@ -1018,6 +1114,7 @@ def _flash_gated_attn_varlen_decode(
     is_local: bool = False,
     is_quant: bool = False,
     seqused_k: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = False,
@@ -1028,6 +1125,9 @@ def _flash_gated_attn_varlen_decode(
     batch_size, num_heads_q, head_dim = query.shape
     _, num_heads_kv, _ = key.shape
     seqlen_k = max_seqlen_k
+    topk_seqlen_k = (
+        gather_kv_indices.shape[-1] if gather_kv_indices is not None else seqlen_k
+    )
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
@@ -1069,7 +1169,7 @@ def _flash_gated_attn_varlen_decode(
         device=device,
         kernel_name="dec_gated",
         seqlen_q=1,
-        seqlen_k=seqlen_k,
+        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
         tile_k=TILE_K,
         is_local=is_local,
         qhead_per_kvhead=qhead_per_kvhead,
@@ -1086,7 +1186,7 @@ def _flash_gated_attn_varlen_decode(
 
     num_splits = utils.num_splits_heuristic(
         seqlen_q=qhead_per_kvhead,
-        seqlen_k=seqlen_k,
+        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
         num_SMs=num_SMs,
         TILE_M=TILE_M,
         TILE_N=TILE_N,
@@ -1146,6 +1246,7 @@ def _flash_gated_attn_varlen_decode(
         softmax_threshold,
         gate_threshold,
         window_sizes,
+        gather_kv_indices,
         query.stride(0),
         query.stride(-2),
         1,
@@ -1168,6 +1269,8 @@ def _flash_gated_attn_varlen_decode(
         1,
         lse_partial.stride(0),
         window_sizes.stride(0),
+        gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
+        gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
         cu_seqlens_k,
         None,
@@ -1182,7 +1285,9 @@ def _flash_gated_attn_varlen_decode(
         TILE_M=TILE_M,
         TILE_N=TILE_N,
         TILE_K=TILE_K,
+        topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
+        HAS_GATHER_KV=gather_kv_indices is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=True,
         HAS_SEQUSED_Q=False,
@@ -1200,7 +1305,7 @@ def _flash_gated_attn_varlen_decode(
                 device=device,
                 kernel_name="dec_gated",
                 seqlen_q=1,
-                seqlen_k=seqlen_k,
+                seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
                 tile_k=TILE_K,
                 config=best,
                 is_local=is_local,

--- a/flash_sparse_attn/ops/triton/flash_gated_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_dec.py
@@ -956,16 +956,19 @@ def _flash_gated_attn_decode(
         TILE_N = 128
         num_warps = num_stages = num_ctas = None
 
-    num_splits = utils.num_splits_heuristic(
-        seqlen_q=qhead_per_kvhead,
-        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
-        num_SMs=num_SMs,
-        TILE_M=TILE_M,
-        TILE_N=TILE_N,
-        max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
-        if is_local
-        else None,
-    )
+    if gather_kv_indices is not None:
+        num_splits = 1
+    else:
+        num_splits = utils.num_splits_heuristic(
+            seqlen_q=qhead_per_kvhead,
+            seqlen_k=seqlen_k,
+            num_SMs=num_SMs,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+            if is_local
+            else None,
+        )
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype
     out = (
@@ -1184,16 +1187,19 @@ def _flash_gated_attn_varlen_decode(
         TILE_N = 128
         num_warps = num_stages = num_ctas = None
 
-    num_splits = utils.num_splits_heuristic(
-        seqlen_q=qhead_per_kvhead,
-        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
-        num_SMs=num_SMs,
-        TILE_M=TILE_M,
-        TILE_N=TILE_N,
-        max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
-        if is_local
-        else None,
-    )
+    if gather_kv_indices is not None:
+        num_splits = 1
+    else:
+        num_splits = utils.num_splits_heuristic(
+            seqlen_q=qhead_per_kvhead,
+            seqlen_k=seqlen_k,
+            num_SMs=num_SMs,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+            if is_local
+            else None,
+        )
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype
     out = (

--- a/flash_sparse_attn/ops/triton/flash_gated_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_dec.py
@@ -965,7 +965,9 @@ def _flash_gated_attn_decode(
             num_SMs=num_SMs,
             TILE_M=TILE_M,
             TILE_N=TILE_N,
-            max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_N
+            )
             if is_local
             else None,
         )
@@ -1196,7 +1198,9 @@ def _flash_gated_attn_varlen_decode(
             num_SMs=num_SMs,
             TILE_M=TILE_M,
             TILE_N=TILE_N,
-            max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_N
+            )
             if is_local
             else None,
         )

--- a/flash_sparse_attn/ops/triton/flash_gated_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_fwd.py
@@ -54,7 +54,7 @@ def _fwd_inner_gated_kernel(
     skip_gate_next = True
     if not skip_gate_curr:
         if IS_MASK:
-            # Apply mask
+            # Apply mask to attention scores
             acc_s = mask_sched.apply_mask(
                 acc_s=acc_s,
                 iter_block=n_block,

--- a/flash_sparse_attn/ops/triton/flash_sparse_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_dec.py
@@ -639,7 +639,9 @@ def _flash_sparse_attn_decode(
             num_SMs=num_SMs,
             TILE_M=TILE_M,
             TILE_N=TILE_N,
-            max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_N
+            )
             if is_local
             else None,
         )
@@ -853,7 +855,9 @@ def _flash_sparse_attn_varlen_decode(
             num_SMs=num_SMs,
             TILE_M=TILE_M,
             TILE_N=TILE_N,
-            max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(
+                window_sizes, TILE_N
+            )
             if is_local
             else None,
         )

--- a/flash_sparse_attn/ops/triton/flash_sparse_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_dec.py
@@ -46,11 +46,12 @@ def _dec_inner_sparse_kernel(
     CHECK_INF: tl.constexpr,
     HAS_GATHER_KV: tl.constexpr,
 ):
+    next_topk_indices = topk_indices
+
     # Compute attention scores
     acc_s = tl.dot(q_tile, k_tile.T)
 
     # Prefetch next key tile
-    next_topk_indices = topk_indices
     if n_block > n_block_min:
         if HAS_GATHER_KV:
             # Load next topk indices

--- a/flash_sparse_attn/ops/triton/flash_sparse_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_dec.py
@@ -32,6 +32,7 @@ def _dec_inner_sparse_kernel(
     softmax_sched: SoftmaxScheduler,
     q_tile,
     k_tile,
+    topk_indices,
     k_ptrs,
     v_ptrs,
     acc_o,
@@ -43,14 +44,34 @@ def _dec_inner_sparse_kernel(
     MASK_LOCAL: tl.constexpr,
     MASK_SINK: tl.constexpr,
     CHECK_INF: tl.constexpr,
+    HAS_GATHER_KV: tl.constexpr,
 ):
     # Compute attention scores
     acc_s = tl.dot(q_tile, k_tile.T)
 
     # Prefetch next key tile
+    next_topk_indices = topk_indices
     if n_block > n_block_min:
+        if HAS_GATHER_KV:
+            # Load next topk indices
+            next_topk_indices = ptrs_sched.load_topk_indices(config, n_block - 1)
+
         # Load next key tile
-        k_tile = ptrs_sched.load_k(config, k_ptrs, n_block - 1)
+        k_tile = ptrs_sched.load_k(
+            config,
+            k_ptrs,
+            n_block - 1,
+            next_topk_indices,
+            HAS_GATHER_KV=HAS_GATHER_KV,
+        )
+
+    if HAS_GATHER_KV:
+        # Apply mask to attention scores
+        acc_s = ptrs_sched.apply_gather_mask(
+            config,
+            acc_s,
+            topk_indices,
+        )
 
     if IS_MASK:
         # Apply mask to attention scores
@@ -72,7 +93,9 @@ def _dec_inner_sparse_kernel(
 
     if not skip_softmax:
         # Load value tile
-        v_tile = ptrs_sched.load_v(config, v_ptrs, n_block)
+        v_tile = ptrs_sched.load_v(
+            config, v_ptrs, n_block, topk_indices, HAS_GATHER_KV=HAS_GATHER_KV
+        )
 
         # Rescale output accumulator
         acc_o = softmax_sched.rescale_o(
@@ -83,7 +106,7 @@ def _dec_inner_sparse_kernel(
         # Update output accumulator
         acc_o += tl.dot(p.to(v_tile.dtype), v_tile)
 
-    return k_tile, acc_o, row_max, row_sum
+    return k_tile, next_topk_indices, acc_o, row_max, row_sum
 
 
 @triton.jit(repr=kernel_repr.dec_sparse_repr)
@@ -99,6 +122,7 @@ def _dec_sparse_kernel(
     value_scale,
     softmax_threshold,
     window_sizes,
+    gather_kv_indices,
     stride_qb,
     stride_qh,
     stride_qm,
@@ -117,6 +141,8 @@ def _dec_sparse_kernel(
     stride_lm,
     stride_ls,
     stride_wh,
+    stride_gb,
+    stride_gn,
     cu_seqlens_q,
     cu_seqlens_k,
     seqused_q,
@@ -131,7 +157,9 @@ def _dec_sparse_kernel(
     TILE_M: tl.constexpr,
     TILE_N: tl.constexpr,
     TILE_K: tl.constexpr,
+    topk_seqlen_k: tl.constexpr,
     IS_LOCAL: tl.constexpr,
+    HAS_GATHER_KV: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
     HAS_CU_SEQLENS_K: tl.constexpr,
     HAS_SEQUSED_Q: tl.constexpr,
@@ -189,6 +217,7 @@ def _dec_sparse_kernel(
         Q=Q,
         K=K,
         V=V,
+        GatherKVIndices=gather_kv_indices,
         Out=Out,
         Lse=Lse,
         batch_idx=grid_idx.batch_idx,
@@ -212,6 +241,9 @@ def _dec_sparse_kernel(
         stride_lh=stride_lh,
         stride_lm=stride_lm,
         stride_ls=stride_ls,
+        stride_gb=stride_gb,
+        stride_gn=stride_gn,
+        HAS_GATHER_KV=HAS_GATHER_KV,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
     )
@@ -221,7 +253,9 @@ def _dec_sparse_kernel(
         config=config,
         split_idx=grid_idx.split_idx,
         num_splits=num_splits,
+        topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=IS_LOCAL,
+        HAS_GATHER_KV=HAS_GATHER_KV,
     )
 
     # Create mask scheduler
@@ -248,23 +282,37 @@ def _dec_sparse_kernel(
     row_sum = tl.zeros((TILE_M,), dtype=tl.float32)
     acc_o = tl.zeros((TILE_M, TILE_K), dtype=tl.float32)
 
+    # Initialize topk indices
+    topk_indices = tl.arange(0, TILE_N)
+
     # Load query tile
     q_tile = ptrs_sched.load_q(config, q_ptrs)
 
+    if HAS_GATHER_KV:
+        # Load topk indices
+        topk_indices = ptrs_sched.load_topk_indices(config, block_sched.n_block_max - 1)
+
     # Load key tile
-    k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_max - 1)
+    k_tile = ptrs_sched.load_k(
+        config,
+        k_ptrs,
+        block_sched.n_block_max - 1,
+        topk_indices,
+        HAS_GATHER_KV=HAS_GATHER_KV,
+    )
 
     # Process n_blocks with seqlen masking
     for n_block in tl.range(
         block_sched.n_block_max - 1, block_sched.n_block_max_no_mask - 1, -1
     ):
-        k_tile, acc_o, row_max, row_sum = _dec_inner_sparse_kernel(
+        k_tile, topk_indices, acc_o, row_max, row_sum = _dec_inner_sparse_kernel(
             config=config,
             ptrs_sched=ptrs_sched,
             mask_sched=mask_sched,
             softmax_sched=softmax_sched,
             q_tile=q_tile,
             k_tile=k_tile,
+            topk_indices=topk_indices,
             k_ptrs=k_ptrs,
             v_ptrs=v_ptrs,
             acc_o=acc_o,
@@ -276,23 +324,40 @@ def _dec_sparse_kernel(
             MASK_LOCAL=True if IS_LOCAL else False,
             MASK_SINK=False,
             CHECK_INF=True,
+            HAS_GATHER_KV=HAS_GATHER_KV,
         )
 
     # Process n_blocks without masking
-    if not IS_LOCAL and block_sched.n_block_max_no_mask > block_sched.n_block_min:
+    if (
+        not IS_LOCAL or HAS_GATHER_KV
+    ) and block_sched.n_block_max_no_mask > block_sched.n_block_min:
+        if HAS_GATHER_KV:
+            # Load topk indices
+            topk_indices = ptrs_sched.load_topk_indices(
+                config,
+                block_sched.n_block_max_no_mask - 1,
+            )
+
         # Load key tile
-        k_tile = ptrs_sched.load_k(config, k_ptrs, block_sched.n_block_max_no_mask - 1)
+        k_tile = ptrs_sched.load_k(
+            config,
+            k_ptrs,
+            block_sched.n_block_max_no_mask - 1,
+            topk_indices,
+            HAS_GATHER_KV=HAS_GATHER_KV,
+        )
 
         for n_block in tl.range(
             block_sched.n_block_max_no_mask - 1, block_sched.n_block_min - 1, -1
         ):
-            k_tile, acc_o, row_max, row_sum = _dec_inner_sparse_kernel(
+            k_tile, topk_indices, acc_o, row_max, row_sum = _dec_inner_sparse_kernel(
                 config=config,
                 ptrs_sched=ptrs_sched,
                 mask_sched=mask_sched,
                 softmax_sched=softmax_sched,
                 q_tile=q_tile,
                 k_tile=k_tile,
+                topk_indices=topk_indices,
                 k_ptrs=k_ptrs,
                 v_ptrs=v_ptrs,
                 acc_o=acc_o,
@@ -303,10 +368,11 @@ def _dec_sparse_kernel(
                 IS_MASK=False,
                 MASK_LOCAL=False,
                 MASK_SINK=False,
-                CHECK_INF=False,
+                CHECK_INF=True if HAS_GATHER_KV else False,
+                HAS_GATHER_KV=HAS_GATHER_KV,
             )
 
-    if IS_LOCAL:
+    if IS_LOCAL and not HAS_GATHER_KV:
         # Process n_blocks with local right masking
         if block_sched.n_block_window_max > block_sched.n_block_window_max_no_mask:
             # Load key tile
@@ -319,24 +385,28 @@ def _dec_sparse_kernel(
                 block_sched.n_block_window_max_no_mask - 1,
                 -1,
             ):
-                k_tile, acc_o, row_max, row_sum = _dec_inner_sparse_kernel(
-                    config=config,
-                    ptrs_sched=ptrs_sched,
-                    mask_sched=mask_sched,
-                    softmax_sched=softmax_sched,
-                    q_tile=q_tile,
-                    k_tile=k_tile,
-                    k_ptrs=k_ptrs,
-                    v_ptrs=v_ptrs,
-                    acc_o=acc_o,
-                    row_max=row_max,
-                    row_sum=row_sum,
-                    n_block=n_block,
-                    n_block_min=block_sched.n_block_window_max_no_mask,
-                    IS_MASK=True,
-                    MASK_LOCAL=True,
-                    MASK_SINK=False,
-                    CHECK_INF=True,
+                k_tile, topk_indices, acc_o, row_max, row_sum = (
+                    _dec_inner_sparse_kernel(
+                        config=config,
+                        ptrs_sched=ptrs_sched,
+                        mask_sched=mask_sched,
+                        softmax_sched=softmax_sched,
+                        q_tile=q_tile,
+                        k_tile=k_tile,
+                        topk_indices=topk_indices,
+                        k_ptrs=k_ptrs,
+                        v_ptrs=v_ptrs,
+                        acc_o=acc_o,
+                        row_max=row_max,
+                        row_sum=row_sum,
+                        n_block=n_block,
+                        n_block_min=block_sched.n_block_window_max_no_mask,
+                        IS_MASK=True,
+                        MASK_LOCAL=True,
+                        MASK_SINK=False,
+                        CHECK_INF=True,
+                        HAS_GATHER_KV=False,
+                    )
                 )
 
         # Process n_blocks without masking
@@ -354,24 +424,28 @@ def _dec_sparse_kernel(
                 block_sched.n_block_window_min_no_mask - 1,
                 -1,
             ):
-                k_tile, acc_o, row_max, row_sum = _dec_inner_sparse_kernel(
-                    config=config,
-                    ptrs_sched=ptrs_sched,
-                    mask_sched=mask_sched,
-                    softmax_sched=softmax_sched,
-                    q_tile=q_tile,
-                    k_tile=k_tile,
-                    k_ptrs=k_ptrs,
-                    v_ptrs=v_ptrs,
-                    acc_o=acc_o,
-                    row_max=row_max,
-                    row_sum=row_sum,
-                    n_block=n_block,
-                    n_block_min=block_sched.n_block_window_min_no_mask,
-                    IS_MASK=False,
-                    MASK_LOCAL=False,
-                    MASK_SINK=False,
-                    CHECK_INF=False,
+                k_tile, topk_indices, acc_o, row_max, row_sum = (
+                    _dec_inner_sparse_kernel(
+                        config=config,
+                        ptrs_sched=ptrs_sched,
+                        mask_sched=mask_sched,
+                        softmax_sched=softmax_sched,
+                        q_tile=q_tile,
+                        k_tile=k_tile,
+                        topk_indices=topk_indices,
+                        k_ptrs=k_ptrs,
+                        v_ptrs=v_ptrs,
+                        acc_o=acc_o,
+                        row_max=row_max,
+                        row_sum=row_sum,
+                        n_block=n_block,
+                        n_block_min=block_sched.n_block_window_min_no_mask,
+                        IS_MASK=False,
+                        MASK_LOCAL=False,
+                        MASK_SINK=False,
+                        CHECK_INF=False,
+                        HAS_GATHER_KV=False,
+                    )
                 )
 
         # Process n_blocks with local left masking
@@ -386,24 +460,28 @@ def _dec_sparse_kernel(
                 block_sched.n_block_window_min - 1,
                 -1,
             ):
-                k_tile, acc_o, row_max, row_sum = _dec_inner_sparse_kernel(
-                    config=config,
-                    ptrs_sched=ptrs_sched,
-                    mask_sched=mask_sched,
-                    softmax_sched=softmax_sched,
-                    q_tile=q_tile,
-                    k_tile=k_tile,
-                    k_ptrs=k_ptrs,
-                    v_ptrs=v_ptrs,
-                    acc_o=acc_o,
-                    row_max=row_max,
-                    row_sum=row_sum,
-                    n_block=n_block,
-                    n_block_min=block_sched.n_block_window_min,
-                    IS_MASK=True,
-                    MASK_LOCAL=True,
-                    MASK_SINK=False,
-                    CHECK_INF=True,
+                k_tile, topk_indices, acc_o, row_max, row_sum = (
+                    _dec_inner_sparse_kernel(
+                        config=config,
+                        ptrs_sched=ptrs_sched,
+                        mask_sched=mask_sched,
+                        softmax_sched=softmax_sched,
+                        q_tile=q_tile,
+                        k_tile=k_tile,
+                        topk_indices=topk_indices,
+                        k_ptrs=k_ptrs,
+                        v_ptrs=v_ptrs,
+                        acc_o=acc_o,
+                        row_max=row_max,
+                        row_sum=row_sum,
+                        n_block=n_block,
+                        n_block_min=block_sched.n_block_window_min,
+                        IS_MASK=True,
+                        MASK_LOCAL=True,
+                        MASK_SINK=False,
+                        CHECK_INF=True,
+                        HAS_GATHER_KV=False,
+                    )
                 )
 
         # Process n_blocks with local sink masking
@@ -416,24 +494,28 @@ def _dec_sparse_kernel(
                 block_sched.n_block_sink_min - 1,
                 -1,
             ):
-                k_tile, acc_o, row_max, row_sum = _dec_inner_sparse_kernel(
-                    config=config,
-                    ptrs_sched=ptrs_sched,
-                    mask_sched=mask_sched,
-                    softmax_sched=softmax_sched,
-                    q_tile=q_tile,
-                    k_tile=k_tile,
-                    k_ptrs=k_ptrs,
-                    v_ptrs=v_ptrs,
-                    acc_o=acc_o,
-                    row_max=row_max,
-                    row_sum=row_sum,
-                    n_block=n_block,
-                    n_block_min=block_sched.n_block_sink_min,
-                    IS_MASK=True,
-                    MASK_LOCAL=True,
-                    MASK_SINK=True,
-                    CHECK_INF=True,
+                k_tile, topk_indices, acc_o, row_max, row_sum = (
+                    _dec_inner_sparse_kernel(
+                        config=config,
+                        ptrs_sched=ptrs_sched,
+                        mask_sched=mask_sched,
+                        softmax_sched=softmax_sched,
+                        q_tile=q_tile,
+                        k_tile=k_tile,
+                        topk_indices=topk_indices,
+                        k_ptrs=k_ptrs,
+                        v_ptrs=v_ptrs,
+                        acc_o=acc_o,
+                        row_max=row_max,
+                        row_sum=row_sum,
+                        n_block=n_block,
+                        n_block_min=block_sched.n_block_sink_min,
+                        IS_MASK=True,
+                        MASK_LOCAL=True,
+                        MASK_SINK=True,
+                        CHECK_INF=True,
+                        HAS_GATHER_KV=False,
+                    )
                 )
 
     # Finalize softmax
@@ -483,6 +565,7 @@ def _flash_sparse_attn_decode(
     window_sizes: Optional[torch.Tensor] = None,
     is_local: bool = False,
     is_quant: bool = False,
+    gather_kv_indices: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = False,
@@ -492,6 +575,9 @@ def _flash_sparse_attn_decode(
     num_SMs = cache_utils.get_device_num_sms(device)
     batch_size, num_heads_q, head_dim = query.shape
     _, seqlen_k, num_heads_kv, _ = key.shape
+    topk_seqlen_k = (
+        gather_kv_indices.shape[-1] if gather_kv_indices is not None else seqlen_k
+    )
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
@@ -528,7 +614,7 @@ def _flash_sparse_attn_decode(
         device=device,
         kernel_name="dec_sparse",
         seqlen_q=1,
-        seqlen_k=seqlen_k,
+        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
         tile_k=TILE_K,
         is_local=is_local,
         qhead_per_kvhead=qhead_per_kvhead,
@@ -545,7 +631,7 @@ def _flash_sparse_attn_decode(
 
     num_splits = utils.num_splits_heuristic(
         seqlen_q=qhead_per_kvhead,
-        seqlen_k=seqlen_k,
+        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
         num_SMs=num_SMs,
         TILE_M=TILE_M,
         TILE_N=TILE_N,
@@ -602,6 +688,7 @@ def _flash_sparse_attn_decode(
         value_scale,
         softmax_threshold,
         window_sizes,
+        gather_kv_indices,
         query.stride(0),
         query.stride(-2),
         1,
@@ -620,6 +707,8 @@ def _flash_sparse_attn_decode(
         1,
         lse_partial.stride(0),
         window_sizes.stride(0),
+        gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
+        gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
         None,
         None,
@@ -634,7 +723,9 @@ def _flash_sparse_attn_decode(
         TILE_M=TILE_M,
         TILE_N=TILE_N,
         TILE_K=TILE_K,
+        topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
+        HAS_GATHER_KV=gather_kv_indices is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
         HAS_SEQUSED_Q=False,
@@ -651,7 +742,7 @@ def _flash_sparse_attn_decode(
                 device=device,
                 kernel_name="dec_sparse",
                 seqlen_q=1,
-                seqlen_k=seqlen_k,
+                seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
                 tile_k=TILE_K,
                 config=best,
                 is_local=is_local,
@@ -684,6 +775,7 @@ def _flash_sparse_attn_varlen_decode(
     is_local: bool = False,
     is_quant: bool = False,
     seqused_k: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = False,
@@ -694,6 +786,9 @@ def _flash_sparse_attn_varlen_decode(
     batch_size, num_heads_q, head_dim = query.shape
     _, num_heads_kv, _ = key.shape
     seqlen_k = max_seqlen_k
+    topk_seqlen_k = (
+        gather_kv_indices.shape[-1] if gather_kv_indices is not None else seqlen_k
+    )
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
@@ -730,7 +825,7 @@ def _flash_sparse_attn_varlen_decode(
         device=device,
         kernel_name="dec_sparse",
         seqlen_q=1,
-        seqlen_k=seqlen_k,
+        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
         tile_k=TILE_K,
         is_local=is_local,
         qhead_per_kvhead=qhead_per_kvhead,
@@ -747,7 +842,7 @@ def _flash_sparse_attn_varlen_decode(
 
     num_splits = utils.num_splits_heuristic(
         seqlen_q=qhead_per_kvhead,
-        seqlen_k=seqlen_k,
+        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
         num_SMs=num_SMs,
         TILE_M=TILE_M,
         TILE_N=TILE_N,
@@ -804,6 +899,7 @@ def _flash_sparse_attn_varlen_decode(
         value_scale,
         softmax_threshold,
         window_sizes,
+        gather_kv_indices,
         query.stride(0),
         query.stride(-2),
         1,
@@ -822,6 +918,8 @@ def _flash_sparse_attn_varlen_decode(
         1,
         lse_partial.stride(0),
         window_sizes.stride(0),
+        gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
+        gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
         cu_seqlens_k,
         None,
@@ -836,7 +934,9 @@ def _flash_sparse_attn_varlen_decode(
         TILE_M=TILE_M,
         TILE_N=TILE_N,
         TILE_K=TILE_K,
+        topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
+        HAS_GATHER_KV=gather_kv_indices is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=True,
         HAS_SEQUSED_Q=False,
@@ -853,7 +953,7 @@ def _flash_sparse_attn_varlen_decode(
                 device=device,
                 kernel_name="dec_sparse",
                 seqlen_q=1,
-                seqlen_k=seqlen_k,
+                seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
                 tile_k=TILE_K,
                 config=best,
                 is_local=is_local,

--- a/flash_sparse_attn/ops/triton/flash_sparse_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_dec.py
@@ -630,16 +630,19 @@ def _flash_sparse_attn_decode(
         TILE_N = 128
         num_warps = num_stages = num_ctas = None
 
-    num_splits = utils.num_splits_heuristic(
-        seqlen_q=qhead_per_kvhead,
-        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
-        num_SMs=num_SMs,
-        TILE_M=TILE_M,
-        TILE_N=TILE_N,
-        max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
-        if is_local
-        else None,
-    )
+    if gather_kv_indices is not None:
+        num_splits = 1
+    else:
+        num_splits = utils.num_splits_heuristic(
+            seqlen_q=qhead_per_kvhead,
+            seqlen_k=seqlen_k,
+            num_SMs=num_SMs,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+            if is_local
+            else None,
+        )
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype
     out = (
@@ -841,16 +844,19 @@ def _flash_sparse_attn_varlen_decode(
         TILE_N = 128
         num_warps = num_stages = num_ctas = None
 
-    num_splits = utils.num_splits_heuristic(
-        seqlen_q=qhead_per_kvhead,
-        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
-        num_SMs=num_SMs,
-        TILE_M=TILE_M,
-        TILE_N=TILE_N,
-        max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
-        if is_local
-        else None,
-    )
+    if gather_kv_indices is not None:
+        num_splits = 1
+    else:
+        num_splits = utils.num_splits_heuristic(
+            seqlen_q=qhead_per_kvhead,
+            seqlen_k=seqlen_k,
+            num_SMs=num_SMs,
+            TILE_M=TILE_M,
+            TILE_N=TILE_N,
+            max_split_blocks=utils.max_split_blocks_from_window_sizes(window_sizes, TILE_N)
+            if is_local
+            else None,
+        )
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype
     out = (

--- a/flash_sparse_attn/ops/triton/interface.py
+++ b/flash_sparse_attn/ops/triton/interface.py
@@ -980,6 +980,7 @@ def flash_dense_attn_with_kvcache_func(
     window_sizes: Optional[torch.Tensor] = None,
     is_local: bool = False,
     is_quant: bool = False,
+    gather_kv_indices: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = False,
@@ -1027,6 +1028,7 @@ def flash_dense_attn_with_kvcache_func(
         window_sizes=window_sizes,
         is_local=is_local,
         is_quant=is_quant,
+        gather_kv_indices=gather_kv_indices,
         out=out,
         lse=lse,
         is_autotune=is_autotune,
@@ -1139,6 +1141,7 @@ def flash_dense_attn_varlen_with_kvcache_func(
     is_local: bool = False,
     is_quant: bool = False,
     seqused_k: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = False,
@@ -1192,6 +1195,7 @@ def flash_dense_attn_varlen_with_kvcache_func(
         is_local=is_local,
         is_quant=is_quant,
         seqused_k=seqused_k,
+        gather_kv_indices=gather_kv_indices,
         out=out,
         lse=lse,
         is_autotune=is_autotune,
@@ -1287,6 +1291,7 @@ def flash_sparse_attn_with_kvcache_func(
     window_sizes: Optional[torch.Tensor] = None,
     is_local: bool = False,
     is_quant: bool = False,
+    gather_kv_indices: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = False,
@@ -1336,6 +1341,7 @@ def flash_sparse_attn_with_kvcache_func(
         window_sizes=window_sizes,
         is_local=is_local,
         is_quant=is_quant,
+        gather_kv_indices=gather_kv_indices,
         out=out,
         lse=lse,
         is_autotune=is_autotune,
@@ -1452,6 +1458,7 @@ def flash_sparse_attn_varlen_with_kvcache_func(
     is_local: bool = False,
     is_quant: bool = False,
     seqused_k: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = False,
@@ -1507,6 +1514,7 @@ def flash_sparse_attn_varlen_with_kvcache_func(
         is_local=is_local,
         is_quant=is_quant,
         seqused_k=seqused_k,
+        gather_kv_indices=gather_kv_indices,
         out=out,
         lse=lse,
         is_autotune=is_autotune,
@@ -1621,6 +1629,7 @@ def flash_gated_attn_with_kvcache_func(
     window_sizes: Optional[torch.Tensor] = None,
     is_local: bool = False,
     is_quant: bool = False,
+    gather_kv_indices: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = False,
@@ -1645,6 +1654,7 @@ def flash_gated_attn_with_kvcache_func(
     :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
+    :param gather_kv_indices: Optional topk gather indices with shape [batch_size, topk_seqlen_k].
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads].
     :param is_autotune: Force re-run Triton autotuner and overwrite cache. Default False uses cached config.
@@ -1681,6 +1691,7 @@ def flash_gated_attn_with_kvcache_func(
         window_sizes=window_sizes,
         is_local=is_local,
         is_quant=is_quant,
+        gather_kv_indices=gather_kv_indices,
         out=out,
         lse=lse,
         is_autotune=is_autotune,
@@ -1816,6 +1827,7 @@ def flash_gated_attn_varlen_with_kvcache_func(
     is_local: bool = False,
     is_quant: bool = False,
     seqused_k: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = False,
@@ -1843,6 +1855,7 @@ def flash_gated_attn_varlen_with_kvcache_func(
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param seqused_k: Optional tensor indicating the actual sequence lengths for keys/values.
+    :param gather_kv_indices: Optional topk gather indices with shape [batch_size, topk_seqlen_k].
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads_q, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads_q].
     :param is_autotune: Force re-run Triton autotuner and overwrite cache. Default False uses cached config.
@@ -1882,6 +1895,7 @@ def flash_gated_attn_varlen_with_kvcache_func(
         is_local=is_local,
         is_quant=is_quant,
         seqused_k=seqused_k,
+        gather_kv_indices=gather_kv_indices,
         out=out,
         lse=lse,
         is_autotune=is_autotune,

--- a/flash_sparse_attn/ops/triton/kernel_repr.py
+++ b/flash_sparse_attn/ops/triton/kernel_repr.py
@@ -78,21 +78,24 @@ def dec_dense_repr(specialization):
     c = specialization.constants
     mask = "local" if _get(c, "IS_LOCAL") else "full"
     varlen = "_varlen" if _get(c, "HAS_CU_SEQLENS_Q") else ""
-    return f"flash_dense_dec_{mask}_{c['TILE_M']}x{c['TILE_N']}{varlen}"
+    gather = "_topk" if _get(c, "HAS_GATHER_KV") else ""
+    return f"flash_dense_dec_{mask}_{c['TILE_M']}x{c['TILE_N']}{gather}{varlen}"
 
 
 def dec_sparse_repr(specialization):
     c = specialization.constants
     mask = "local" if _get(c, "IS_LOCAL") else "full"
     varlen = "_varlen" if _get(c, "HAS_CU_SEQLENS_Q") else ""
-    return f"flash_sparse_dec_{mask}_{c['TILE_M']}x{c['TILE_N']}{varlen}"
+    gather = "_topk" if _get(c, "HAS_GATHER_KV") else ""
+    return f"flash_sparse_dec_{mask}_{c['TILE_M']}x{c['TILE_N']}{gather}{varlen}"
 
 
 def dec_gated_repr(specialization):
     c = specialization.constants
     mask = "local" if _get(c, "IS_LOCAL") else "full"
     varlen = "_varlen" if _get(c, "HAS_CU_SEQLENS_Q") else ""
-    return f"flash_gated_dec_{mask}_{c['TILE_M']}x{c['TILE_N']}{varlen}"
+    gather = "_topk" if _get(c, "HAS_GATHER_KV") else ""
+    return f"flash_gated_dec_{mask}_{c['TILE_M']}x{c['TILE_N']}{gather}{varlen}"
 
 
 def fwd_combine_repr(specialization):

--- a/flash_sparse_attn/ops/triton/scheduler.py
+++ b/flash_sparse_attn/ops/triton/scheduler.py
@@ -2487,6 +2487,9 @@ class AttnDecPointerScheduler:
         return topk_gather_kv.apply_gather_mask(
             acc_s,
             topk_indices,
+            config.actual_seqlen_q,
+            config.QHEAD_PER_KVHEAD_PACKGQA,
+            config.TILE_M,
         )
 
 

--- a/flash_sparse_attn/ops/triton/scheduler.py
+++ b/flash_sparse_attn/ops/triton/scheduler.py
@@ -3,9 +3,13 @@ import triton.language as tl
 from triton.language.core import _aggregate as aggregate
 from triton.runtime.jit import constexpr_function
 
-from flash_sparse_attn.ops.triton import mask
-from flash_sparse_attn.ops.triton import activations
-from flash_sparse_attn.ops.triton import seqlen_info, block_info
+from flash_sparse_attn.ops.triton import (
+    seqlen_info,
+    block_info,
+    mask,
+    activations,
+    topk_gather_kv,
+)
 
 
 @aggregate
@@ -1103,50 +1107,70 @@ class AttnDecBlockScheduler:
         config: AttnDecConfig,
         split_idx,
         num_splits,
+        topk_seqlen_k,
         IS_LOCAL: tl.constexpr,
+        HAS_GATHER_KV: tl.constexpr = False,
     ):
-        # Compute non-causal n_block range for this m_block
-        (
-            n_block_min,
-            n_block_max,
-            n_block_window_min,
-            n_block_window_max,
-            n_block_sink_min,
-            n_block_sink_max,
-        ) = block_info.get_n_block_min_max(
-            seqlen_q=1,
-            seqlen_k=config.actual_seqlen_k,
-            m_block=0,
-            split_idx=split_idx,
-            num_splits=num_splits,
-            window_size_sink=config.window_size_sink,
-            window_size_left=config.window_size_left,
-            window_size_right=config.window_size_right,
-            window_size_dist=config.window_size_dist,
-            TILE_N=config.TILE_N,
-            TILE_M=config.TILE_M,
-            IS_CAUSAL=False,
-            IS_LOCAL=IS_LOCAL,
-            IS_SPLIT_KV=True,
-            QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
-        )
-        n_block_max_no_mask = block_info.get_n_block_min_causal_local_mask(
-            seqlen_q=1,
-            seqlen_k=config.actual_seqlen_k,
-            m_block=0,
-            n_block_min=n_block_min,
-            window_size_right=0,
-            window_size_dist=0,
-            TILE_N=config.TILE_N,
-            TILE_M=config.TILE_M,
-            IS_LOCAL=False,
-            QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
-        )
+        if HAS_GATHER_KV:
+            (
+                n_block_min,
+                n_block_max,
+                n_block_window_min,
+                n_block_window_max,
+                n_block_sink_min,
+                n_block_sink_max,
+            ) = block_info.get_topk_n_block_min_max(
+                topk_seqlen_k=topk_seqlen_k,
+                split_idx=split_idx,
+                num_splits=num_splits,
+                TILE_N=config.TILE_N,
+            )
+            n_block_max_no_mask = n_block_max
+            n_block_window_min_no_mask = 0
+            n_block_window_max_no_mask = 0
+        else:
+            # Compute non-causal n_block range for this m_block
+            (
+                n_block_min,
+                n_block_max,
+                n_block_window_min,
+                n_block_window_max,
+                n_block_sink_min,
+                n_block_sink_max,
+            ) = block_info.get_n_block_min_max(
+                seqlen_q=1,
+                seqlen_k=config.actual_seqlen_k,
+                m_block=0,
+                split_idx=split_idx,
+                num_splits=num_splits,
+                window_size_sink=config.window_size_sink,
+                window_size_left=config.window_size_left,
+                window_size_right=config.window_size_right,
+                window_size_dist=config.window_size_dist,
+                TILE_N=config.TILE_N,
+                TILE_M=config.TILE_M,
+                IS_CAUSAL=False,
+                IS_LOCAL=IS_LOCAL,
+                IS_SPLIT_KV=True,
+                QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
+            )
+            n_block_max_no_mask = block_info.get_n_block_min_causal_local_mask(
+                seqlen_q=1,
+                seqlen_k=config.actual_seqlen_k,
+                m_block=0,
+                n_block_min=n_block_min,
+                window_size_right=0,
+                window_size_dist=0,
+                TILE_N=config.TILE_N,
+                TILE_M=config.TILE_M,
+                IS_LOCAL=False,
+                QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
+            )
 
-        # Clamp to split's range so the no-mask loop stays within bounds
-        n_block_max_no_mask = tl.minimum(n_block_max_no_mask, n_block_max)
+            # Clamp to split's range so the no-mask loop stays within bounds
+            n_block_max_no_mask = tl.minimum(n_block_max_no_mask, n_block_max)
 
-        if IS_LOCAL:
+        if IS_LOCAL and not HAS_GATHER_KV:
             # Compute local n_block range for this m_block
             n_block_max_no_mask = tl.where(
                 split_idx >= num_splits - 1,
@@ -1193,7 +1217,7 @@ class AttnDecBlockScheduler:
                 tl.minimum(n_block_window_min_no_mask, n_block_window_max),
                 n_block_window_min,
             )
-        else:
+        elif not HAS_GATHER_KV:
             n_block_window_min = 0
             n_block_window_max = 0
             n_block_window_min_no_mask = 0
@@ -2113,10 +2137,12 @@ class AttnDecPointerScheduler:
     d_base: tl.tensor
     out_base: tl.tensor
     lse_base: tl.tensor
+    gather_kv_base: tl.tensor
     stride_qh: tl.tensor
     stride_kn: tl.tensor
     stride_vn: tl.tensor
     stride_oh: tl.tensor
+    stride_gn: tl.tensor
 
     @constexpr_function
     def __init__(
@@ -2128,10 +2154,12 @@ class AttnDecPointerScheduler:
         d_base,
         out_base,
         lse_base,
+        gather_kv_base,
         stride_qh,
         stride_kn,
         stride_vn,
         stride_oh,
+        stride_gn,
     ):
         self.q_base = q_base
         self.k_base = k_base
@@ -2140,10 +2168,12 @@ class AttnDecPointerScheduler:
         self.d_base = d_base
         self.out_base = out_base
         self.lse_base = lse_base
+        self.gather_kv_base = gather_kv_base
         self.stride_qh = stride_qh
         self.stride_kn = stride_kn
         self.stride_vn = stride_vn
         self.stride_oh = stride_oh
+        self.stride_gn = stride_gn
 
     @staticmethod
     @triton.jit
@@ -2154,6 +2184,7 @@ class AttnDecPointerScheduler:
         V=None,
         A=None,
         D=None,
+        GatherKVIndices=None,
         Out=None,
         Lse=None,
         batch_idx=0,
@@ -2181,7 +2212,10 @@ class AttnDecPointerScheduler:
         stride_lh=0,
         stride_lm=0,
         stride_ls=0,
+        stride_gb=0,
+        stride_gn=0,
         IS_GATED: tl.constexpr = False,
+        HAS_GATHER_KV: tl.constexpr = False,
         HAS_CU_SEQLENS_Q: tl.constexpr = False,
         HAS_CU_SEQLENS_K: tl.constexpr = False,
     ):
@@ -2236,6 +2270,10 @@ class AttnDecPointerScheduler:
             HAS_CU_SEQLENS_Q,
             USE_PADDED=False,
         )
+        if HAS_GATHER_KV:
+            gather_kv_base = GatherKVIndices + batch_idx * stride_gb
+        else:
+            gather_kv_base = tl.full((), 0, tl.int64)
 
         if IS_GATED:
             a_base = seqlen_info.offset_batch_Q(
@@ -2275,10 +2313,12 @@ class AttnDecPointerScheduler:
             d_base,
             out_base,
             lse_base,
+            gather_kv_base,
             stride_qh + tl.full((), 0, tl.int64),
             stride_kn + tl.full((), 0, tl.int64),
             stride_vn + tl.full((), 0, tl.int64),
             stride_oh + tl.full((), 0, tl.int64),
+            stride_gn + tl.full((), 0, tl.int64),
         )
 
     @triton.jit
@@ -2349,20 +2389,78 @@ class AttnDecPointerScheduler:
         return q_ptrs.load([0, 0])
 
     @triton.jit
-    def load_k(self, config: AttnDecConfig, k_ptrs, n_block):
-        return k_ptrs.load([n_block * config.TILE_N, 0])
+    def load_k(
+        self,
+        config: AttnDecConfig,
+        k_ptrs,
+        n_block,
+        topk_indices=None,
+        HAS_GATHER_KV: tl.constexpr = False,
+    ):
+        if HAS_GATHER_KV:
+            return topk_gather_kv.load_gathered_k(
+                self.k_base,
+                topk_indices,
+                self.stride_kn,
+                config.head_dim,
+                config.TILE_K,
+            )
+        else:
+            return k_ptrs.load([n_block * config.TILE_N, 0])
 
     @triton.jit
-    def load_v(self, config: AttnDecConfig, v_ptrs, n_block):
-        return v_ptrs.load([n_block * config.TILE_N, 0])
+    def load_v(
+        self,
+        config: AttnDecConfig,
+        v_ptrs,
+        n_block,
+        topk_indices=None,
+        HAS_GATHER_KV: tl.constexpr = False,
+    ):
+        if HAS_GATHER_KV:
+            return topk_gather_kv.load_gathered_v(
+                self.v_base,
+                topk_indices,
+                self.stride_vn,
+                config.head_dim,
+                config.TILE_K,
+            )
+        else:
+            return v_ptrs.load([n_block * config.TILE_N, 0])
 
     @triton.jit
     def load_a(self, config: AttnDecConfig, a_ptrs):
         return a_ptrs.load([0]).to(tl.float32)
 
     @triton.jit
-    def load_d(self, config: AttnDecConfig, d_ptrs, n_block):
-        return d_ptrs.load([n_block * config.TILE_N]).to(tl.float32)
+    def load_d(
+        self,
+        config: AttnDecConfig,
+        d_ptrs,
+        n_block,
+        topk_indices=None,
+        HAS_GATHER_KV: tl.constexpr = False,
+    ):
+        if HAS_GATHER_KV:
+            return topk_gather_kv.load_gathered_d(
+                self.d_base,
+                topk_indices,
+            )
+        else:
+            return d_ptrs.load([n_block * config.TILE_N]).to(tl.float32)
+
+    @triton.jit
+    def load_topk_indices(
+        self,
+        config: AttnDecConfig,
+        n_block,
+    ):
+        return topk_gather_kv.load_topk_indices(
+            self.gather_kv_base,
+            self.stride_gn,
+            n_block,
+            config.TILE_N,
+        )
 
     @triton.jit
     def store_out(self, config: AttnDecConfig, out_ptrs, o_tile):
@@ -2378,6 +2476,18 @@ class AttnDecPointerScheduler:
         self.store_lse(config, lse_ptrs, lse_tile)
         o_tile = tl.zeros((config.TILE_M, config.TILE_K), dtype=Out.dtype.element_ty)
         self.store_out(config, out_ptrs, o_tile)
+
+    @triton.jit
+    def apply_gather_mask(
+        self,
+        config: AttnDecConfig,
+        acc_s,
+        topk_indices,
+    ):
+        return topk_gather_kv.apply_gather_mask(
+            acc_s,
+            topk_indices,
+        )
 
 
 @aggregate

--- a/flash_sparse_attn/ops/triton/scheduler.py
+++ b/flash_sparse_attn/ops/triton/scheduler.py
@@ -2487,9 +2487,6 @@ class AttnDecPointerScheduler:
         return topk_gather_kv.apply_gather_mask(
             acc_s,
             topk_indices,
-            config.actual_seqlen_q,
-            config.QHEAD_PER_KVHEAD_PACKGQA,
-            config.TILE_M,
         )
 
 

--- a/flash_sparse_attn/ops/triton/topk_gather_kv.py
+++ b/flash_sparse_attn/ops/triton/topk_gather_kv.py
@@ -1,0 +1,77 @@
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def load_topk_indices(
+    gather_kv_base,
+    stride_gn,
+    n_block,
+    TILE_N: tl.constexpr,
+):
+    offs_n = n_block * TILE_N + tl.arange(0, TILE_N)
+    return tl.load(gather_kv_base + offs_n * stride_gn)
+
+
+@triton.jit
+def make_valid_mask(indices):
+    return indices >= 0
+
+
+@triton.jit
+def load_gathered_k(
+    k_base,
+    topk_indices,
+    stride_kn,
+    head_dim,
+    TILE_K: tl.constexpr,
+):
+    valid_mask = make_valid_mask(topk_indices)
+    offs_k = tl.arange(0, TILE_K)
+    return tl.load(
+        k_base + topk_indices[:, None] * stride_kn + offs_k[None, :],
+        mask=valid_mask[:, None] & (offs_k[None, :] < head_dim),
+        other=0.0,
+        cache_modifier=".ca",
+    )
+
+
+@triton.jit
+def load_gathered_v(
+    v_base,
+    topk_indices,
+    stride_vn,
+    head_dim,
+    TILE_K: tl.constexpr,
+):
+    valid_mask = make_valid_mask(topk_indices)
+    offs_k = tl.arange(0, TILE_K)
+    return tl.load(
+        v_base + topk_indices[:, None] * stride_vn + offs_k[None, :],
+        mask=valid_mask[:, None] & (offs_k[None, :] < head_dim),
+        other=0.0,
+        cache_modifier=".ca",
+    )
+
+
+@triton.jit
+def load_gathered_d(
+    d_base,
+    topk_indices,
+):
+    valid_mask = make_valid_mask(topk_indices)
+    return tl.load(
+        d_base + topk_indices,
+        mask=valid_mask,
+        other=0.0,
+        cache_modifier=".ca",
+    ).to(tl.float32)
+
+
+@triton.jit
+def apply_gather_mask(
+    acc_s,
+    topk_indices,
+):
+    valid_mask = make_valid_mask(topk_indices)
+    return tl.where(valid_mask[None, :], acc_s, float("-inf"))

--- a/flash_sparse_attn/ops/triton/topk_gather_kv.py
+++ b/flash_sparse_attn/ops/triton/topk_gather_kv.py
@@ -72,6 +72,12 @@ def load_gathered_d(
 def apply_gather_mask(
     acc_s,
     topk_indices,
+    actual_seqlen_q,
+    QHEAD_PER_KVHEAD_PACKGQA: tl.constexpr,
+    TILE_M: tl.constexpr,
 ):
     valid_mask = make_valid_mask(topk_indices)
-    return tl.where(valid_mask[None, :], acc_s, float("-inf"))
+    offs_m = tl.arange(0, TILE_M)
+    q_idx = offs_m // QHEAD_PER_KVHEAD_PACKGQA
+    valid_m = q_idx < actual_seqlen_q
+    return tl.where(valid_m[:, None] & valid_mask[None, :], acc_s, float("-inf"))

--- a/flash_sparse_attn/ops/triton/topk_gather_kv.py
+++ b/flash_sparse_attn/ops/triton/topk_gather_kv.py
@@ -72,12 +72,6 @@ def load_gathered_d(
 def apply_gather_mask(
     acc_s,
     topk_indices,
-    actual_seqlen_q,
-    QHEAD_PER_KVHEAD_PACKGQA: tl.constexpr,
-    TILE_M: tl.constexpr,
 ):
     valid_mask = make_valid_mask(topk_indices)
-    offs_m = tl.arange(0, TILE_M)
-    q_idx = offs_m // QHEAD_PER_KVHEAD_PACKGQA
-    valid_m = q_idx < actual_seqlen_q
-    return tl.where(valid_m[:, None] & valid_mask[None, :], acc_s, float("-inf"))
+    return tl.where(valid_mask[None, :], acc_s, float("-inf"))

--- a/tests/test_topk_gather_decode.py
+++ b/tests/test_topk_gather_decode.py
@@ -322,7 +322,7 @@ def _run_contiguous_topk_matches_regular_case(kind: KernelType) -> None:
     device = torch.device("cuda")
     dtype = torch.bfloat16
     batch_size = 2
-    seqlen_k = 512
+    seqlen_k = 256
     num_heads_q = 32
     num_heads_kv = 2
     head_dim = 64

--- a/tests/test_topk_gather_decode.py
+++ b/tests/test_topk_gather_decode.py
@@ -323,7 +323,7 @@ def _run_contiguous_topk_matches_regular_case(kind: KernelType) -> None:
     dtype = torch.bfloat16
     batch_size = 2
     seqlen_k = 512
-    num_heads_q = 8
+    num_heads_q = 32
     num_heads_kv = 2
     head_dim = 64
     softmax_scale = head_dim**-0.5

--- a/tests/test_topk_gather_decode.py
+++ b/tests/test_topk_gather_decode.py
@@ -1,0 +1,427 @@
+from typing import Literal, Optional, Sequence
+
+import pytest
+import torch
+
+from flash_sparse_attn.ops.triton.interface import (
+    flash_dense_attn_varlen_with_kvcache_func,
+    flash_dense_attn_with_kvcache_func,
+    flash_gated_attn_varlen_with_kvcache_func,
+    flash_gated_attn_with_kvcache_func,
+    flash_sparse_attn_varlen_with_kvcache_func,
+    flash_sparse_attn_with_kvcache_func,
+)
+from test_utils import (
+    _DEFAULT_ATOL,
+    _DEFAULT_RTOL,
+    _assert_close,
+    make_cu_seqlens,
+    set_seed,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is required"
+)
+
+KernelType = Literal["dense", "sparse", "gated"]
+
+
+def _repeat_kv_heads(x: torch.Tensor, num_heads_q: int) -> torch.Tensor:
+    if x.shape[1] == num_heads_q:
+        return x
+    repeat = num_heads_q // x.shape[1]
+    return torch.repeat_interleave(x, repeats=repeat, dim=1)
+
+
+def _make_topk_indices(
+    lengths: Sequence[int],
+    topk_seqlen_k: int,
+    device: torch.device,
+    *,
+    include_invalid: bool,
+) -> torch.Tensor:
+    indices = torch.empty(len(lengths), topk_seqlen_k, device=device, dtype=torch.int32)
+    for batch_idx, seqlen_k in enumerate(lengths):
+        valid_count = min(seqlen_k, topk_seqlen_k)
+        perm = torch.randperm(seqlen_k, device=device, dtype=torch.int32)
+        indices[batch_idx, :valid_count] = perm[:valid_count]
+        if valid_count < topk_seqlen_k:
+            indices[batch_idx, valid_count:] = -1
+        if include_invalid:
+            indices[batch_idx, batch_idx::23] = -1
+    return indices
+
+
+def _gather_topk_3d(x: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+    valid = indices >= 0
+    safe_indices = indices.clamp_min(0).to(torch.long)
+    gathered = torch.stack(
+        [
+            x[batch_idx].index_select(0, safe_indices[batch_idx])
+            for batch_idx in range(x.shape[0])
+        ],
+        dim=0,
+    )
+    return gathered.masked_fill(~valid[:, :, None, None], 0.0)
+
+
+def _gather_topk_2d(x: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+    valid = indices >= 0
+    safe_indices = indices.clamp_min(0).to(torch.long)
+    gathered = torch.stack(
+        [
+            x[batch_idx].index_select(0, safe_indices[batch_idx])
+            for batch_idx in range(x.shape[0])
+        ],
+        dim=0,
+    )
+    return gathered.masked_fill(~valid[:, :, None], 0.0)
+
+
+def _pack_varlen_to_batch(
+    x: torch.Tensor,
+    lengths: Sequence[int],
+) -> torch.Tensor:
+    padded = []
+    offset = 0
+    for seqlen_k in lengths:
+        padded.append(x[offset : offset + seqlen_k])
+        offset += seqlen_k
+    return torch.nn.utils.rnn.pad_sequence(padded, batch_first=True)
+
+
+def _reference_topk_decode(
+    kind: KernelType,
+    q: torch.Tensor,
+    k_topk: torch.Tensor,
+    v_topk: torch.Tensor,
+    gather_kv_indices: torch.Tensor,
+    softmax_scale: float,
+    *,
+    alpha: Optional[torch.Tensor] = None,
+    delta_topk: Optional[torch.Tensor] = None,
+    is_logsigmoid_gate: bool = True,
+) -> torch.Tensor:
+    valid = gather_kv_indices >= 0
+    num_heads_q = q.shape[1]
+
+    qh = q.float().unsqueeze(2)
+    kh = _repeat_kv_heads(k_topk.transpose(1, 2).float(), num_heads_q)
+    vh = _repeat_kv_heads(v_topk.transpose(1, 2).float(), num_heads_q)
+
+    scores = torch.matmul(qh, kh.transpose(-2, -1)) * softmax_scale
+    scores = scores.masked_fill(~valid[:, None, None, :], float("-inf"))
+
+    if kind == "gated":
+        delta_h = _repeat_kv_heads(delta_topk.transpose(1, 2).float(), num_heads_q)
+        raw_gate = alpha.float().unsqueeze(-1).unsqueeze(-1) * delta_h.unsqueeze(2)
+        gate = (
+            torch.nn.functional.logsigmoid(raw_gate) if is_logsigmoid_gate else raw_gate
+        )
+        scores = scores + gate * softmax_scale
+
+    attn = torch.softmax(scores, dim=-1)
+    attn = torch.nan_to_num(attn, nan=0.0)
+    return torch.matmul(attn, vh).squeeze(2).to(q.dtype)
+
+
+def _run_base_topk_case(
+    kind: KernelType,
+    dtype: torch.dtype,
+    topk_seqlen_k: int,
+    is_local: bool,
+) -> None:
+    device = torch.device("cuda")
+    batch_size = 2
+    seqlen_k = 768
+    num_heads_q = 8
+    num_heads_kv = 2
+    head_dim = 64
+    softmax_scale = head_dim**-0.5
+    threshold = -128.0
+
+    q = torch.randn(batch_size, num_heads_q, head_dim, device=device, dtype=dtype)
+    k = torch.randn(
+        batch_size, seqlen_k, num_heads_kv, head_dim, device=device, dtype=dtype
+    )
+    v = torch.randn(
+        batch_size, seqlen_k, num_heads_kv, head_dim, device=device, dtype=dtype
+    )
+    alpha = torch.randn(batch_size, num_heads_q, device=device, dtype=dtype)
+    delta = torch.randn(batch_size, seqlen_k, num_heads_kv, device=device, dtype=dtype)
+    gather_kv_indices = _make_topk_indices(
+        [seqlen_k] * batch_size,
+        topk_seqlen_k,
+        device,
+        include_invalid=True,
+    )
+
+    k_topk = _gather_topk_3d(k, gather_kv_indices)
+    v_topk = _gather_topk_3d(v, gather_kv_indices)
+    delta_topk = _gather_topk_2d(delta, gather_kv_indices)
+
+    if kind == "dense":
+        out = flash_dense_attn_with_kvcache_func(
+            q,
+            k,
+            v,
+            softmax_scale=softmax_scale,
+            is_local=is_local,
+            gather_kv_indices=gather_kv_indices,
+        )
+    elif kind == "sparse":
+        out = flash_sparse_attn_with_kvcache_func(
+            q,
+            k,
+            v,
+            softmax_scale=softmax_scale,
+            softmax_threshold=threshold,
+            is_local=is_local,
+            gather_kv_indices=gather_kv_indices,
+        )
+    else:
+        out = flash_gated_attn_with_kvcache_func(
+            q,
+            k,
+            v,
+            alpha,
+            delta,
+            softmax_scale=softmax_scale,
+            softmax_threshold=threshold,
+            gate_threshold=threshold,
+            is_logsigmoid_gate=True,
+            is_local=is_local,
+            gather_kv_indices=gather_kv_indices,
+        )
+
+    ref = _reference_topk_decode(
+        kind,
+        q,
+        k_topk,
+        v_topk,
+        gather_kv_indices,
+        softmax_scale,
+        alpha=alpha,
+        delta_topk=delta_topk,
+    )
+    _assert_close(
+        name=f"{kind}-base-topk-decode",
+        got=out,
+        ref=ref,
+        rtol=_DEFAULT_RTOL[kind],
+        atol=_DEFAULT_ATOL[kind],
+    )
+
+
+def _run_varlen_topk_case(kind: KernelType, dtype: torch.dtype) -> None:
+    device = torch.device("cuda")
+    lengths = [384, 640, 768]
+    topk_seqlen_k = 512
+    batch_size = len(lengths)
+    num_heads_q = 8
+    num_heads_kv = 2
+    head_dim = 64
+    softmax_scale = head_dim**-0.5
+    threshold = -128.0
+
+    q = torch.randn(batch_size, num_heads_q, head_dim, device=device, dtype=dtype)
+    k = torch.cat(
+        [
+            torch.randn(seqlen_k, num_heads_kv, head_dim, device=device, dtype=dtype)
+            for seqlen_k in lengths
+        ],
+        dim=0,
+    )
+    v = torch.cat(
+        [
+            torch.randn(seqlen_k, num_heads_kv, head_dim, device=device, dtype=dtype)
+            for seqlen_k in lengths
+        ],
+        dim=0,
+    )
+    alpha = torch.randn(batch_size, num_heads_q, device=device, dtype=dtype)
+    delta = torch.cat(
+        [
+            torch.randn(seqlen_k, num_heads_kv, device=device, dtype=dtype)
+            for seqlen_k in lengths
+        ],
+        dim=0,
+    )
+    cu_seqlens_k = make_cu_seqlens(lengths, device)
+    gather_kv_indices = _make_topk_indices(
+        lengths,
+        topk_seqlen_k,
+        device,
+        include_invalid=True,
+    )
+
+    k_batch = _pack_varlen_to_batch(k, lengths)
+    v_batch = _pack_varlen_to_batch(v, lengths)
+    delta_batch = _pack_varlen_to_batch(delta, lengths)
+    k_topk = _gather_topk_3d(k_batch, gather_kv_indices)
+    v_topk = _gather_topk_3d(v_batch, gather_kv_indices)
+    delta_topk = _gather_topk_2d(delta_batch, gather_kv_indices)
+
+    if kind == "dense":
+        out = flash_dense_attn_varlen_with_kvcache_func(
+            q,
+            k,
+            v,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_k=max(lengths),
+            softmax_scale=softmax_scale,
+            gather_kv_indices=gather_kv_indices,
+        )
+    elif kind == "sparse":
+        out = flash_sparse_attn_varlen_with_kvcache_func(
+            q,
+            k,
+            v,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_k=max(lengths),
+            softmax_scale=softmax_scale,
+            softmax_threshold=threshold,
+            gather_kv_indices=gather_kv_indices,
+        )
+    else:
+        out = flash_gated_attn_varlen_with_kvcache_func(
+            q,
+            k,
+            v,
+            alpha,
+            delta,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_k=max(lengths),
+            softmax_scale=softmax_scale,
+            softmax_threshold=threshold,
+            gate_threshold=threshold,
+            is_logsigmoid_gate=True,
+            gather_kv_indices=gather_kv_indices,
+        )
+
+    ref = _reference_topk_decode(
+        kind,
+        q,
+        k_topk,
+        v_topk,
+        gather_kv_indices,
+        softmax_scale,
+        alpha=alpha,
+        delta_topk=delta_topk,
+    )
+    _assert_close(
+        name=f"{kind}-varlen-topk-decode",
+        got=out,
+        ref=ref,
+        rtol=_DEFAULT_RTOL[kind],
+        atol=_DEFAULT_ATOL[kind],
+    )
+
+
+def _run_contiguous_topk_matches_regular_case(kind: KernelType) -> None:
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    batch_size = 2
+    seqlen_k = 512
+    num_heads_q = 8
+    num_heads_kv = 2
+    head_dim = 64
+    softmax_scale = head_dim**-0.5
+    threshold = -128.0
+
+    q = torch.randn(batch_size, num_heads_q, head_dim, device=device, dtype=dtype)
+    k = torch.randn(
+        batch_size, seqlen_k, num_heads_kv, head_dim, device=device, dtype=dtype
+    )
+    v = torch.randn(
+        batch_size, seqlen_k, num_heads_kv, head_dim, device=device, dtype=dtype
+    )
+    alpha = torch.randn(batch_size, num_heads_q, device=device, dtype=dtype)
+    delta = torch.randn(batch_size, seqlen_k, num_heads_kv, device=device, dtype=dtype)
+    gather_kv_indices = (
+        torch.arange(seqlen_k, device=device, dtype=torch.int32)
+        .unsqueeze(0)
+        .repeat(batch_size, 1)
+    )
+
+    if kind == "dense":
+        out = flash_dense_attn_with_kvcache_func(
+            q,
+            k,
+            v,
+            softmax_scale=softmax_scale,
+            gather_kv_indices=gather_kv_indices,
+        )
+        ref = flash_dense_attn_with_kvcache_func(q, k, v, softmax_scale=softmax_scale)
+    elif kind == "sparse":
+        out = flash_sparse_attn_with_kvcache_func(
+            q,
+            k,
+            v,
+            softmax_scale=softmax_scale,
+            softmax_threshold=threshold,
+            gather_kv_indices=gather_kv_indices,
+        )
+        ref = flash_sparse_attn_with_kvcache_func(
+            q, k, v, softmax_scale=softmax_scale, softmax_threshold=threshold
+        )
+    else:
+        out = flash_gated_attn_with_kvcache_func(
+            q,
+            k,
+            v,
+            alpha,
+            delta,
+            softmax_scale=softmax_scale,
+            softmax_threshold=threshold,
+            gate_threshold=threshold,
+            gather_kv_indices=gather_kv_indices,
+        )
+        ref = flash_gated_attn_with_kvcache_func(
+            q,
+            k,
+            v,
+            alpha,
+            delta,
+            softmax_scale=softmax_scale,
+            softmax_threshold=threshold,
+            gate_threshold=threshold,
+        )
+
+    _assert_close(
+        name=f"{kind}-contiguous-topk-decode",
+        got=out,
+        ref=ref,
+        rtol=_DEFAULT_RTOL[kind],
+        atol=_DEFAULT_ATOL[kind],
+    )
+
+
+@pytest.mark.parametrize("kind", ["dense", "sparse", "gated"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("topk_seqlen_k", [256, 512])
+@pytest.mark.parametrize("is_local", [False, True])
+def test_topk_gather_base_decode_matches_reference(
+    kind: KernelType,
+    dtype: torch.dtype,
+    topk_seqlen_k: int,
+    is_local: bool,
+) -> None:
+    set_seed(0)
+    _run_base_topk_case(kind, dtype, topk_seqlen_k, is_local)
+
+
+@pytest.mark.parametrize("kind", ["dense", "sparse", "gated"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_topk_gather_varlen_decode_matches_reference(
+    kind: KernelType,
+    dtype: torch.dtype,
+) -> None:
+    set_seed(1)
+    _run_varlen_topk_case(kind, dtype)
+
+
+@pytest.mark.parametrize("kind", ["dense", "sparse", "gated"])
+def test_contiguous_topk_matches_regular_decode(kind: KernelType) -> None:
+    set_seed(2)
+    _run_contiguous_topk_matches_regular_case(kind)


### PR DESCRIPTION
## Summary

- Add a dedicated Triton top-k gather KV helper for decode, including K/V gather, gated D gather, top-k index loading, and invalid-entry masking.
- Wire optional gather_kv_indices through dense, sparse, and gated KV-cache decode APIs, including varlen decode.
- Keep top-k decode scheduling in the TopK ordinal domain while preserving existing non-gather decode behavior.
- Add decode kernel repr isolation for top-k gather variants and CUDA correctness tests for dense, sparse, and gated decode.

## Scope

This is decode-only. Forward prefill, backward kernels, softmax threshold semantics, and fallback behavior are intentionally unchanged.

## Tests

- pytest -q tests/test_topk_gather_decode.py
- 33 passed in 9.7s

Closes #332