### PR TITLE
Reduce Triton graph-capture temporary allocations

### DIFF
--- a/flash_sparse_attn/ops/triton/flash_dense_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_bwd.py
@@ -157,6 +157,7 @@ def _bwd_dense_kernel(
     TILE_K: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
     IS_LOCAL: tl.constexpr,
+    IS_QUANT: tl.constexpr,
     IS_SPLIT_QO: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
     HAS_CU_SEQLENS_K: tl.constexpr,
@@ -206,6 +207,7 @@ def _bwd_dense_kernel(
         TILE_N=TILE_N,
         TILE_K=TILE_K,
         IS_CAUSAL=IS_CAUSAL,
+        IS_QUANT=IS_QUANT,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
         HAS_SEQUSED_Q=HAS_SEQUSED_Q,
@@ -510,8 +512,6 @@ def _flash_dense_attn_backward(
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(
@@ -578,14 +578,9 @@ def _flash_dense_attn_backward(
     seqlen_q_rounded = int(math.ceil(seqlen_q / 128) * 128)
     head_dim_rounded = int(math.ceil(head_dim / 32) * 32)
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
-    dq = torch.empty_like(query, dtype=query_scale.dtype)
-    dk = torch.empty_like(key, dtype=key_scale.dtype)
-    dv = torch.empty_like(value, dtype=value_scale.dtype)
+    dq = torch.empty_like(query, dtype=dout.dtype)
+    dk = torch.empty_like(key, dtype=dout.dtype)
+    dv = torch.empty_like(value, dtype=dout.dtype)
     lse_log2 = torch.empty(
         (batch_size, num_heads_q, seqlen_q_rounded),
         dtype=torch.float32,
@@ -679,7 +674,7 @@ def _flash_dense_attn_backward(
         dv_accum.stride(-2),
         dv_accum.stride(-3),
         dv_accum.stride(0) if is_split_qo and num_splits > 1 else 0,
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         None,
         None,
         None,
@@ -696,6 +691,7 @@ def _flash_dense_attn_backward(
         TILE_K=TILE_K,
         IS_CAUSAL=is_causal,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         IS_SPLIT_QO=is_split_qo and num_splits > 1,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
@@ -779,8 +775,6 @@ def _flash_dense_attn_varlen_backward(
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(
@@ -847,14 +841,9 @@ def _flash_dense_attn_varlen_backward(
     total_q_rounded_padded = int(math.ceil((total_q + batch_size * 128) / 128) * 128)
     head_dim_rounded = int(math.ceil(head_dim / 32) * 32)
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
-    dq = torch.empty_like(query, dtype=query_scale.dtype)
-    dk = torch.empty_like(key, dtype=key_scale.dtype)
-    dv = torch.empty_like(value, dtype=value_scale.dtype)
+    dq = torch.empty_like(query, dtype=dout.dtype)
+    dk = torch.empty_like(key, dtype=dout.dtype)
+    dv = torch.empty_like(value, dtype=dout.dtype)
     lse_log2 = torch.empty(
         num_heads_q,
         total_q_rounded_padded,
@@ -954,7 +943,7 @@ def _flash_dense_attn_varlen_backward(
         dv_accum.stride(-2),
         dv_accum.stride(-3),
         dv_accum.stride(0) if is_split_qo and num_splits > 1 else 0,
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         cu_seqlens_q,
         cu_seqlens_k,
         seqused_q,
@@ -971,6 +960,7 @@ def _flash_dense_attn_varlen_backward(
         TILE_K=TILE_K,
         IS_CAUSAL=is_causal,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         IS_SPLIT_QO=is_split_qo and num_splits > 1,
         HAS_CU_SEQLENS_Q=True,
         HAS_CU_SEQLENS_K=True,

--- a/flash_sparse_attn/ops/triton/flash_dense_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_dec.py
@@ -157,6 +157,7 @@ def _dec_dense_kernel(
     TILE_K: tl.constexpr,
     topk_seqlen_k: tl.constexpr,
     IS_LOCAL: tl.constexpr,
+    IS_QUANT: tl.constexpr,
     HAS_GATHER_KV: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
     HAS_CU_SEQLENS_K: tl.constexpr,
@@ -202,6 +203,7 @@ def _dec_dense_kernel(
         TILE_M=TILE_M,
         TILE_N=TILE_N,
         TILE_K=TILE_K,
+        IS_QUANT=IS_QUANT,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
         HAS_SEQUSED_Q=HAS_SEQUSED_Q,
@@ -572,8 +574,6 @@ def _flash_dense_attn_decode(
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(
@@ -653,11 +653,6 @@ def _flash_dense_attn_decode(
         device=device,
     )
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
     grid = launch_grid.get_dec_grid(
         batch_size=batch_size,
         num_heads_kv=num_heads_kv,
@@ -695,7 +690,7 @@ def _flash_dense_attn_decode(
         lse_partial.stride(-1),
         1,
         lse_partial.stride(0),
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
         gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
@@ -714,6 +709,7 @@ def _flash_dense_attn_decode(
         TILE_K=TILE_K,
         topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         HAS_GATHER_KV=gather_kv_indices is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
@@ -783,8 +779,6 @@ def _flash_dense_attn_varlen_decode(
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(
@@ -864,11 +858,6 @@ def _flash_dense_attn_varlen_decode(
         device=device,
     )
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
     grid = launch_grid.get_dec_grid(
         batch_size=batch_size,
         num_heads_kv=num_heads_kv,
@@ -906,7 +895,7 @@ def _flash_dense_attn_varlen_decode(
         lse_partial.stride(-1),
         1,
         lse_partial.stride(0),
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
         gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
@@ -925,6 +914,7 @@ def _flash_dense_attn_varlen_decode(
         TILE_K=TILE_K,
         topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         HAS_GATHER_KV=gather_kv_indices is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=True,

--- a/flash_sparse_attn/ops/triton/flash_dense_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_fwd.py
@@ -133,6 +133,7 @@ def _fwd_dense_kernel(
     TILE_K: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
     IS_LOCAL: tl.constexpr,
+    IS_QUANT: tl.constexpr,
     IS_SPLIT_KV: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
     HAS_CU_SEQLENS_K: tl.constexpr,
@@ -183,6 +184,8 @@ def _fwd_dense_kernel(
         TILE_M=TILE_M,
         TILE_N=TILE_N,
         TILE_K=TILE_K,
+        IS_CAUSAL=IS_CAUSAL,
+        IS_QUANT=IS_QUANT,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
         HAS_SEQUSED_Q=HAS_SEQUSED_Q,
@@ -544,8 +547,6 @@ def _flash_dense_attn_forward(
     qhead_per_kvhead_packgqa = num_heads_q // num_heads_kv if pack_gqa else 1
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(
@@ -632,11 +633,6 @@ def _flash_dense_attn_forward(
             device=query.device,
         )
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
     grid = launch_grid.get_fwd_grid(
         batch_size=batch_size,
         seqlen_q=seqlen_q,
@@ -675,7 +671,7 @@ def _flash_dense_attn_forward(
         lse.stride(0) if not is_split_kv else lse_partial.stride(1),
         lse.stride(-2) if not is_split_kv else lse_partial.stride(-2),
         0 if not is_split_kv else lse_partial.stride(0),
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         None,
         None,
         None,
@@ -694,6 +690,7 @@ def _flash_dense_attn_forward(
         TILE_K=TILE_K,
         IS_CAUSAL=is_causal,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         IS_SPLIT_KV=is_split_kv,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
@@ -771,8 +768,6 @@ def _flash_dense_attn_varlen_forward(
     qhead_per_kvhead_packgqa = num_heads_q // num_heads_kv if pack_gqa else 1
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(
@@ -855,11 +850,6 @@ def _flash_dense_attn_varlen_forward(
             device=query.device,
         )
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
     grid = launch_grid.get_fwd_grid(
         batch_size=batch_size,
         seqlen_q=seqlen_q,
@@ -898,7 +888,7 @@ def _flash_dense_attn_varlen_forward(
         0,
         lse.stride(-2) if not is_split_kv else lse_partial.stride(-2),
         0 if not is_split_kv else lse_partial.stride(0),
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         cu_seqlens_q,
         cu_seqlens_k,
         seqused_q,
@@ -917,6 +907,7 @@ def _flash_dense_attn_varlen_forward(
         TILE_K=TILE_K,
         IS_CAUSAL=is_causal,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         IS_SPLIT_KV=is_split_kv,
         HAS_CU_SEQLENS_Q=True,
         HAS_CU_SEQLENS_K=True,

--- a/flash_sparse_attn/ops/triton/flash_gated_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_bwd.py
@@ -242,6 +242,7 @@ def _bwd_gated_kernel(
     TILE_K: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
     IS_LOCAL: tl.constexpr,
+    IS_QUANT: tl.constexpr,
     IS_SPLIT_QO: tl.constexpr,
     IS_LOGSIGMOID_GATE: tl.constexpr,
     IS_ADAPT_GATE: tl.constexpr,
@@ -295,6 +296,7 @@ def _bwd_gated_kernel(
         TILE_N=TILE_N,
         TILE_K=TILE_K,
         IS_CAUSAL=IS_CAUSAL,
+        IS_QUANT=IS_QUANT,
         IS_LOGSIGMOID_GATE=IS_LOGSIGMOID_GATE,
         IS_ADAPT_GATE=IS_ADAPT_GATE,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
@@ -725,8 +727,6 @@ def _flash_gated_attn_backward(
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(
@@ -795,14 +795,9 @@ def _flash_gated_attn_backward(
     seqlen_q_rounded = int(math.ceil(seqlen_q / 128) * 128)
     head_dim_rounded = int(math.ceil(head_dim / 32) * 32)
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
-    dq = torch.empty_like(query, dtype=query_scale.dtype)
-    dk = torch.empty_like(key, dtype=key_scale.dtype)
-    dv = torch.empty_like(value, dtype=value_scale.dtype)
+    dq = torch.empty_like(query, dtype=dout.dtype)
+    dk = torch.empty_like(key, dtype=dout.dtype)
+    dv = torch.empty_like(value, dtype=dout.dtype)
     da = torch.empty_like(alpha)
     dd = torch.empty_like(delta)
     lse_log2 = torch.empty(
@@ -925,7 +920,7 @@ def _flash_gated_attn_backward(
         dd_accum.stride(-3) if is_split_qo and num_splits > 1 else dd_accum.stride(0),
         dd_accum.stride(-2),
         dd_accum.stride(0) if is_split_qo and num_splits > 1 else 0,
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         None,
         None,
         None,
@@ -942,6 +937,7 @@ def _flash_gated_attn_backward(
         TILE_K=TILE_K,
         IS_CAUSAL=is_causal,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         IS_SPLIT_QO=is_split_qo and num_splits > 1,
         IS_LOGSIGMOID_GATE=is_logsigmoid_gate,
         IS_ADAPT_GATE=is_adapt_gate,
@@ -1043,8 +1039,6 @@ def _flash_gated_attn_varlen_backward(
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(
@@ -1113,14 +1107,9 @@ def _flash_gated_attn_varlen_backward(
     total_q_rounded_padded = int(math.ceil((total_q + batch_size * 128) / 128) * 128)
     head_dim_rounded = int(math.ceil(head_dim / 32) * 32)
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
-    dq = torch.empty_like(query, dtype=query_scale.dtype)
-    dk = torch.empty_like(key, dtype=key_scale.dtype)
-    dv = torch.empty_like(value, dtype=value_scale.dtype)
+    dq = torch.empty_like(query, dtype=dout.dtype)
+    dk = torch.empty_like(key, dtype=dout.dtype)
+    dv = torch.empty_like(value, dtype=dout.dtype)
     da = torch.empty_like(alpha)
     dd = torch.empty_like(delta)
     lse_log2 = torch.empty(
@@ -1246,7 +1235,7 @@ def _flash_gated_attn_varlen_backward(
         0,
         dd_accum.stride(-2),
         dd_accum.stride(0) if is_split_qo and num_splits > 1 else 0,
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         cu_seqlens_q,
         cu_seqlens_k,
         seqused_q,
@@ -1263,6 +1252,7 @@ def _flash_gated_attn_varlen_backward(
         TILE_K=TILE_K,
         IS_CAUSAL=is_causal,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         IS_SPLIT_QO=is_split_qo and num_splits > 1,
         IS_LOGSIGMOID_GATE=is_logsigmoid_gate,
         IS_ADAPT_GATE=is_adapt_gate,

--- a/flash_sparse_attn/ops/triton/flash_gated_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_dec.py
@@ -212,6 +212,7 @@ def _dec_gated_kernel(
     TILE_K: tl.constexpr,
     topk_seqlen_k: tl.constexpr,
     IS_LOCAL: tl.constexpr,
+    IS_QUANT: tl.constexpr,
     HAS_GATHER_KV: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
     HAS_CU_SEQLENS_K: tl.constexpr,
@@ -260,6 +261,7 @@ def _dec_gated_kernel(
         TILE_M=TILE_M,
         TILE_N=TILE_N,
         TILE_K=TILE_K,
+        IS_QUANT=IS_QUANT,
         IS_LOGSIGMOID_GATE=IS_LOGSIGMOID_GATE,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
@@ -912,8 +914,6 @@ def _flash_gated_attn_decode(
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(
@@ -995,11 +995,6 @@ def _flash_gated_attn_decode(
         device=device,
     )
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
     grid = launch_grid.get_dec_grid(
         batch_size=batch_size,
         num_heads_kv=num_heads_kv,
@@ -1045,7 +1040,7 @@ def _flash_gated_attn_decode(
         lse_partial.stride(-1),
         1,
         lse_partial.stride(0),
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
         gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
@@ -1064,6 +1059,7 @@ def _flash_gated_attn_decode(
         TILE_K=TILE_K,
         topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         HAS_GATHER_KV=gather_kv_indices is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
@@ -1145,8 +1141,6 @@ def _flash_gated_attn_varlen_decode(
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(
@@ -1228,11 +1222,6 @@ def _flash_gated_attn_varlen_decode(
         device=device,
     )
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
     grid = launch_grid.get_dec_grid(
         batch_size=batch_size,
         num_heads_kv=num_heads_kv,
@@ -1278,7 +1267,7 @@ def _flash_gated_attn_varlen_decode(
         lse_partial.stride(-1),
         1,
         lse_partial.stride(0),
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
         gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
@@ -1297,6 +1286,7 @@ def _flash_gated_attn_varlen_decode(
         TILE_K=TILE_K,
         topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         HAS_GATHER_KV=gather_kv_indices is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=True,

--- a/flash_sparse_attn/ops/triton/flash_gated_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_fwd.py
@@ -184,6 +184,7 @@ def _fwd_gated_kernel(
     TILE_K: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
     IS_LOCAL: tl.constexpr,
+    IS_QUANT: tl.constexpr,
     IS_SPLIT_KV: tl.constexpr,
     IS_LOGSIGMOID_GATE: tl.constexpr,
     IS_ADAPT_GATE: tl.constexpr,
@@ -239,6 +240,7 @@ def _fwd_gated_kernel(
         TILE_N=TILE_N,
         TILE_K=TILE_K,
         IS_CAUSAL=IS_CAUSAL,
+        IS_QUANT=IS_QUANT,
         IS_LOGSIGMOID_GATE=IS_LOGSIGMOID_GATE,
         IS_ADAPT_GATE=IS_ADAPT_GATE,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
@@ -881,8 +883,6 @@ def _flash_gated_attn_forward(
     qhead_per_kvhead_packgqa = num_heads_q // num_heads_kv if pack_gqa else 1
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(
@@ -971,11 +971,6 @@ def _flash_gated_attn_forward(
             device=query.device,
         )
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
     grid = launch_grid.get_fwd_grid(
         batch_size=batch_size,
         seqlen_q=seqlen_q,
@@ -1024,7 +1019,7 @@ def _flash_gated_attn_forward(
         lse.stride(0) if not is_split_kv else lse_partial.stride(1),
         lse.stride(-2) if not is_split_kv else lse_partial.stride(-2),
         0 if not is_split_kv else lse_partial.stride(0),
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         None,
         None,
         None,
@@ -1043,6 +1038,7 @@ def _flash_gated_attn_forward(
         TILE_K=TILE_K,
         IS_CAUSAL=is_causal,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         IS_SPLIT_KV=is_split_kv,
         IS_LOGSIGMOID_GATE=is_logsigmoid_gate,
         IS_ADAPT_GATE=is_adapt_gate,
@@ -1134,8 +1130,6 @@ def _flash_gated_attn_varlen_forward(
     qhead_per_kvhead_packgqa = num_heads_q // num_heads_kv if pack_gqa else 1
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(
@@ -1224,11 +1218,6 @@ def _flash_gated_attn_varlen_forward(
             device=query.device,
         )
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
     grid = launch_grid.get_fwd_grid(
         batch_size=batch_size,
         seqlen_q=seqlen_q,
@@ -1277,7 +1266,7 @@ def _flash_gated_attn_varlen_forward(
         0,
         lse.stride(-2) if not is_split_kv else lse_partial.stride(-2),
         0 if not is_split_kv else lse_partial.stride(0),
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         cu_seqlens_q,
         cu_seqlens_k,
         seqused_q,
@@ -1296,6 +1285,7 @@ def _flash_gated_attn_varlen_forward(
         TILE_K=TILE_K,
         IS_CAUSAL=is_causal,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         IS_SPLIT_KV=is_split_kv,
         IS_LOGSIGMOID_GATE=is_logsigmoid_gate,
         IS_ADAPT_GATE=is_adapt_gate,

--- a/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
@@ -168,6 +168,7 @@ def _bwd_sparse_kernel(
     TILE_K: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
     IS_LOCAL: tl.constexpr,
+    IS_QUANT: tl.constexpr,
     IS_SPLIT_QO: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
     HAS_CU_SEQLENS_K: tl.constexpr,
@@ -218,6 +219,7 @@ def _bwd_sparse_kernel(
         TILE_N=TILE_N,
         TILE_K=TILE_K,
         IS_CAUSAL=IS_CAUSAL,
+        IS_QUANT=IS_QUANT,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
         HAS_SEQUSED_Q=HAS_SEQUSED_Q,
@@ -526,8 +528,6 @@ def _flash_sparse_attn_backward(
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(
@@ -594,14 +594,9 @@ def _flash_sparse_attn_backward(
     seqlen_q_rounded = int(math.ceil(seqlen_q / 128) * 128)
     head_dim_rounded = int(math.ceil(head_dim / 32) * 32)
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
-    dq = torch.empty_like(query, dtype=query_scale.dtype)
-    dk = torch.empty_like(key, dtype=key_scale.dtype)
-    dv = torch.empty_like(value, dtype=value_scale.dtype)
+    dq = torch.empty_like(query, dtype=dout.dtype)
+    dk = torch.empty_like(key, dtype=dout.dtype)
+    dv = torch.empty_like(value, dtype=dout.dtype)
     lse_log2 = torch.empty(
         (batch_size, num_heads_q, seqlen_q_rounded),
         dtype=torch.float32,
@@ -696,7 +691,7 @@ def _flash_sparse_attn_backward(
         dv_accum.stride(-2),
         dv_accum.stride(-3),
         dv_accum.stride(0) if is_split_qo and num_splits > 1 else 0,
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         None,
         None,
         None,
@@ -713,6 +708,7 @@ def _flash_sparse_attn_backward(
         TILE_K=TILE_K,
         IS_CAUSAL=is_causal,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         IS_SPLIT_QO=is_split_qo and num_splits > 1,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
@@ -800,8 +796,6 @@ def _flash_sparse_attn_varlen_backward(
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_bwd_inputs(
@@ -868,14 +862,9 @@ def _flash_sparse_attn_varlen_backward(
     total_q_rounded_padded = int(math.ceil((total_q + batch_size * 128) / 128) * 128)
     head_dim_rounded = int(math.ceil(head_dim / 32) * 32)
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
-    dq = torch.empty_like(query, dtype=query_scale.dtype)
-    dk = torch.empty_like(key, dtype=key_scale.dtype)
-    dv = torch.empty_like(value, dtype=value_scale.dtype)
+    dq = torch.empty_like(query, dtype=dout.dtype)
+    dk = torch.empty_like(key, dtype=dout.dtype)
+    dv = torch.empty_like(value, dtype=dout.dtype)
     lse_log2 = torch.empty(
         num_heads_q,
         total_q_rounded_padded,
@@ -976,7 +965,7 @@ def _flash_sparse_attn_varlen_backward(
         dv_accum.stride(-2),
         dv_accum.stride(-3),
         dv_accum.stride(0) if is_split_qo and num_splits > 1 else 0,
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         cu_seqlens_q,
         cu_seqlens_k,
         seqused_q,
@@ -993,6 +982,7 @@ def _flash_sparse_attn_varlen_backward(
         TILE_K=TILE_K,
         IS_CAUSAL=is_causal,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         IS_SPLIT_QO=is_split_qo and num_splits > 1,
         HAS_CU_SEQLENS_Q=True,
         HAS_CU_SEQLENS_K=True,

--- a/flash_sparse_attn/ops/triton/flash_sparse_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_dec.py
@@ -160,6 +160,7 @@ def _dec_sparse_kernel(
     TILE_K: tl.constexpr,
     topk_seqlen_k: tl.constexpr,
     IS_LOCAL: tl.constexpr,
+    IS_QUANT: tl.constexpr,
     HAS_GATHER_KV: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
     HAS_CU_SEQLENS_K: tl.constexpr,
@@ -206,6 +207,7 @@ def _dec_sparse_kernel(
         TILE_M=TILE_M,
         TILE_N=TILE_N,
         TILE_K=TILE_K,
+        IS_QUANT=IS_QUANT,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
         HAS_SEQUSED_Q=HAS_SEQUSED_Q,
@@ -588,8 +590,6 @@ def _flash_sparse_attn_decode(
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(
@@ -669,11 +669,6 @@ def _flash_sparse_attn_decode(
         device=device,
     )
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
     grid = launch_grid.get_dec_grid(
         batch_size=batch_size,
         num_heads_kv=num_heads_kv,
@@ -712,7 +707,7 @@ def _flash_sparse_attn_decode(
         lse_partial.stride(-1),
         1,
         lse_partial.stride(0),
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
         gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
@@ -731,6 +726,7 @@ def _flash_sparse_attn_decode(
         TILE_K=TILE_K,
         topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         HAS_GATHER_KV=gather_kv_indices is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
@@ -804,8 +800,6 @@ def _flash_sparse_attn_varlen_decode(
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_dec_inputs(
@@ -885,11 +879,6 @@ def _flash_sparse_attn_varlen_decode(
         device=device,
     )
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
     grid = launch_grid.get_dec_grid(
         batch_size=batch_size,
         num_heads_kv=num_heads_kv,
@@ -928,7 +917,7 @@ def _flash_sparse_attn_varlen_decode(
         lse_partial.stride(-1),
         1,
         lse_partial.stride(0),
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
         gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
@@ -947,6 +936,7 @@ def _flash_sparse_attn_varlen_decode(
         TILE_K=TILE_K,
         topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         HAS_GATHER_KV=gather_kv_indices is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=True,

--- a/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
@@ -136,6 +136,7 @@ def _fwd_sparse_kernel(
     TILE_K: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
     IS_LOCAL: tl.constexpr,
+    IS_QUANT: tl.constexpr,
     IS_SPLIT_KV: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
     HAS_CU_SEQLENS_K: tl.constexpr,
@@ -187,6 +188,8 @@ def _fwd_sparse_kernel(
         TILE_M=TILE_M,
         TILE_N=TILE_N,
         TILE_K=TILE_K,
+        IS_CAUSAL=IS_CAUSAL,
+        IS_QUANT=IS_QUANT,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
         HAS_SEQUSED_Q=HAS_SEQUSED_Q,
@@ -552,8 +555,6 @@ def _flash_sparse_attn_forward(
     qhead_per_kvhead_packgqa = num_heads_q // num_heads_kv if pack_gqa else 1
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(
@@ -640,11 +641,6 @@ def _flash_sparse_attn_forward(
             device=query.device,
         )
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
     grid = launch_grid.get_fwd_grid(
         batch_size=batch_size,
         seqlen_q=seqlen_q,
@@ -684,7 +680,7 @@ def _flash_sparse_attn_forward(
         lse.stride(0) if not is_split_kv else lse_partial.stride(1),
         lse.stride(-2) if not is_split_kv else lse_partial.stride(-2),
         0 if not is_split_kv else lse_partial.stride(0),
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         None,
         None,
         None,
@@ -703,6 +699,7 @@ def _flash_sparse_attn_forward(
         TILE_K=TILE_K,
         IS_CAUSAL=is_causal,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         IS_SPLIT_KV=is_split_kv,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
@@ -784,8 +781,6 @@ def _flash_sparse_attn_varlen_forward(
     qhead_per_kvhead_packgqa = num_heads_q // num_heads_kv if pack_gqa else 1
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
-    elif not is_local:
-        window_sizes = torch.zeros((num_heads_kv, 4), dtype=torch.int32, device=device)
 
     if not skip_checks:
         assert_inputs.assert_fwd_inputs(
@@ -872,11 +867,6 @@ def _flash_sparse_attn_varlen_forward(
             device=query.device,
         )
 
-    if not is_quant:
-        query_scale = torch.ones(1, device=device, dtype=query.dtype)
-        key_scale = torch.ones(1, device=device, dtype=query.dtype)
-        value_scale = torch.ones(1, device=device, dtype=query.dtype)
-
     grid = launch_grid.get_fwd_grid(
         batch_size=batch_size,
         seqlen_q=seqlen_q,
@@ -916,7 +906,7 @@ def _flash_sparse_attn_varlen_forward(
         0,
         lse.stride(-2) if not is_split_kv else lse_partial.stride(-2),
         0 if not is_split_kv else lse_partial.stride(0),
-        window_sizes.stride(0),
+        window_sizes.stride(0) if window_sizes is not None else 0,
         cu_seqlens_q,
         cu_seqlens_k,
         seqused_q,
@@ -935,6 +925,7 @@ def _flash_sparse_attn_varlen_forward(
         TILE_K=TILE_K,
         IS_CAUSAL=is_causal,
         IS_LOCAL=is_local,
+        IS_QUANT=is_quant,
         IS_SPLIT_KV=is_split_kv,
         HAS_CU_SEQLENS_Q=True,
         HAS_CU_SEQLENS_K=True,

--- a/flash_sparse_attn/ops/triton/scheduler.py
+++ b/flash_sparse_attn/ops/triton/scheduler.py
@@ -259,6 +259,7 @@ class AttnFwdConfig:
         TILE_N: tl.constexpr = 64,
         TILE_K: tl.constexpr = 64,
         IS_CAUSAL: tl.constexpr = False,
+        IS_QUANT: tl.constexpr = False,
         IS_LOGSIGMOID_GATE: tl.constexpr = False,
         IS_ADAPT_GATE: tl.constexpr = False,
         HAS_CU_SEQLENS_Q: tl.constexpr = False,
@@ -289,12 +290,14 @@ class AttnFwdConfig:
             HAS_SEQUSED_Q=HAS_SEQUSED_Q,
             HAS_SEQUSED_K=HAS_SEQUSED_K,
         )
-        # Load query scale
-        q_scale = tl.load(query_scale)
-        # Load key scale
-        k_scale = tl.load(key_scale)
-        # Load value scale
-        v_scale = tl.load(value_scale)
+        if IS_QUANT:
+            q_scale = tl.load(query_scale)
+            k_scale = tl.load(key_scale)
+            v_scale = tl.load(value_scale)
+        else:
+            q_scale = 1.0
+            k_scale = 1.0
+            v_scale = 1.0
         LOG2E: tl.constexpr = 1.44269504089
         softmax_scale_log2 = softmax_scale * LOG2E * q_scale * k_scale
         softmax_threshold_log2 = seqlen_info.get_softmax_threshold(
@@ -460,6 +463,7 @@ class AttnBwdConfig:
         TILE_N: tl.constexpr = 64,
         TILE_K: tl.constexpr = 64,
         IS_CAUSAL: tl.constexpr = False,
+        IS_QUANT: tl.constexpr = False,
         IS_LOGSIGMOID_GATE: tl.constexpr = False,
         IS_ADAPT_GATE: tl.constexpr = False,
         HAS_CU_SEQLENS_Q: tl.constexpr = False,
@@ -490,12 +494,14 @@ class AttnBwdConfig:
             HAS_SEQUSED_Q=HAS_SEQUSED_Q,
             HAS_SEQUSED_K=HAS_SEQUSED_K,
         )
-        # Load query scale
-        q_scale = tl.load(query_scale)
-        # Load key scale
-        k_scale = tl.load(key_scale)
-        # Load value scale
-        v_scale = tl.load(value_scale)
+        if IS_QUANT:
+            q_scale = tl.load(query_scale)
+            k_scale = tl.load(key_scale)
+            v_scale = tl.load(value_scale)
+        else:
+            q_scale = 1.0
+            k_scale = 1.0
+            v_scale = 1.0
         LOG2E: tl.constexpr = 1.44269504089
         softmax_scale_log2 = softmax_scale * LOG2E
         softmax_threshold = tl.full((), softmax_threshold, tl.float32)
@@ -656,6 +662,7 @@ class AttnDecConfig:
         TILE_M: tl.constexpr = 16,
         TILE_N: tl.constexpr = 64,
         TILE_K: tl.constexpr = 64,
+        IS_QUANT: tl.constexpr = False,
         IS_LOGSIGMOID_GATE: tl.constexpr = False,
         HAS_CU_SEQLENS_Q: tl.constexpr = False,
         HAS_CU_SEQLENS_K: tl.constexpr = False,
@@ -685,12 +692,14 @@ class AttnDecConfig:
             HAS_SEQUSED_Q=HAS_SEQUSED_Q,
             HAS_SEQUSED_K=HAS_SEQUSED_K,
         )
-        # Load query scale
-        q_scale = tl.load(query_scale)
-        # Load key scale
-        k_scale = tl.load(key_scale)
-        # Load value scale
-        v_scale = tl.load(value_scale)
+        if IS_QUANT:
+            q_scale = tl.load(query_scale)
+            k_scale = tl.load(key_scale)
+            v_scale = tl.load(value_scale)
+        else:
+            q_scale = 1.0
+            k_scale = 1.0
+            v_scale = 1.0
         LOG2E: tl.constexpr = 1.44269504089
         softmax_scale_log2 = softmax_scale * LOG2E * q_scale * k_scale
         softmax_threshold_log2 = seqlen_info.get_softmax_threshold(


### PR DESCRIPTION
## Summary

- avoid allocating non-local `window_sizes` tensors and pass a zero stride when absent
- add `IS_QUANT` constexpr handling so non-quantized scheduler paths use constant scale `1.0`
- allocate Triton backward `dq/dk/dv` buffers with `dout.dtype`

Fixes #334

## Tests

- `python -m compileall -q flash_sparse_attn/ops/triton`