### PR TITLE
Refine Triton launch config controls

### DIFF
--- a/flash_sparse_attn/ops/triton/flash_dense_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_bwd.py
@@ -499,7 +499,9 @@ def _flash_dense_attn_backward(
     is_local: bool = False,
     is_quant: bool = False,
     is_split_qo: bool = False,
-    is_autotune: bool = False,
+    num_splits: Optional[int] = None,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     device = query.device
@@ -538,28 +540,34 @@ def _flash_dense_attn_backward(
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name="bwd_dense",
-        seqlen_q=seqlen_q,
-        seqlen_k=seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_causal=is_causal,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _bwd_dense_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (64, 64)
+        num_warps, num_stages, num_ctas = 8, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        # Placeholder for pre-launch computations
-        TILE_M = TILE_N = 64
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name="bwd_dense",
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_causal=is_causal,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _bwd_dense_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            # Placeholder for pre-launch computations
+            TILE_M = TILE_N = 64
+            num_warps = num_stages = num_ctas = None
 
-    num_splits = (
-        utils.num_splits_heuristic(
+    if is_split_qo and num_splits is None:
+        num_splits = utils.num_splits_heuristic(
             seqlen_q=seqlen_k,
             seqlen_k=seqlen_q,
             num_SMs=num_SMs,
@@ -571,9 +579,8 @@ def _flash_dense_attn_backward(
             if is_local
             else None,
         )
-        if is_split_qo
-        else 1
-    )
+    elif not is_split_qo:
+        num_splits = 1
 
     seqlen_q_rounded = int(math.ceil(seqlen_q / 128) * 128)
     head_dim_rounded = int(math.ceil(head_dim / 32) * 32)
@@ -702,7 +709,7 @@ def _flash_dense_attn_backward(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(
@@ -757,9 +764,11 @@ def _flash_dense_attn_varlen_backward(
     is_local: bool = False,
     is_quant: bool = False,
     is_split_qo: bool = False,
+    num_splits: Optional[int] = None,
     seqused_q: Optional[torch.Tensor] = None,
     seqused_k: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     device = query.device
@@ -801,28 +810,34 @@ def _flash_dense_attn_varlen_backward(
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name="bwd_dense",
-        seqlen_q=seqlen_q,
-        seqlen_k=seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_causal=is_causal,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _bwd_dense_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (64, 64)
+        num_warps, num_stages, num_ctas = 8, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        # Placeholder for pre-launch computations
-        TILE_M = TILE_N = 64
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name="bwd_dense",
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_causal=is_causal,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _bwd_dense_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            # Placeholder for pre-launch computations
+            TILE_M = TILE_N = 64
+            num_warps = num_stages = num_ctas = None
 
-    num_splits = (
-        utils.num_splits_heuristic(
+    if is_split_qo and num_splits is None:
+        num_splits = utils.num_splits_heuristic(
             seqlen_q=seqlen_k,
             seqlen_k=seqlen_q,
             num_SMs=num_SMs,
@@ -834,9 +849,8 @@ def _flash_dense_attn_varlen_backward(
             if is_local
             else None,
         )
-        if is_split_qo
-        else 1
-    )
+    elif not is_split_qo:
+        num_splits = 1
 
     total_q_rounded_padded = int(math.ceil((total_q + batch_size * 128) / 128) * 128)
     head_dim_rounded = int(math.ceil(head_dim / 32) * 32)
@@ -971,7 +985,7 @@ def _flash_dense_attn_varlen_backward(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(

--- a/flash_sparse_attn/ops/triton/flash_dense_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_dec.py
@@ -556,9 +556,11 @@ def _flash_dense_attn_decode(
     is_local: bool = False,
     is_quant: bool = False,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     device = query.device
@@ -595,28 +597,34 @@ def _flash_dense_attn_decode(
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name="dec_dense",
-        seqlen_q=1,
-        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _dec_dense_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (16, 64)
+        num_warps, num_stages, num_ctas = 4, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        TILE_M = max(triton.next_power_of_2(qhead_per_kvhead), 16)
-        TILE_N = 128
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name="dec_dense",
+            seqlen_q=1,
+            seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _dec_dense_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            TILE_M = max(triton.next_power_of_2(qhead_per_kvhead), 16)
+            TILE_N = 128
+            num_warps = num_stages = num_ctas = None
 
-    if gather_kv_indices is not None:
+    if num_splits is None and gather_kv_indices is not None:
         num_splits = 1
-    else:
+    elif num_splits is None:
         num_splits = utils.num_splits_heuristic(
             seqlen_q=qhead_per_kvhead,
             seqlen_k=seqlen_k,
@@ -720,7 +728,7 @@ def _flash_dense_attn_decode(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(
@@ -760,9 +768,11 @@ def _flash_dense_attn_varlen_decode(
     is_quant: bool = False,
     seqused_k: Optional[torch.Tensor] = None,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     device = query.device
@@ -800,28 +810,34 @@ def _flash_dense_attn_varlen_decode(
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name="dec_dense",
-        seqlen_q=1,
-        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _dec_dense_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (16, 64)
+        num_warps, num_stages, num_ctas = 4, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        TILE_M = max(triton.next_power_of_2(qhead_per_kvhead), 16)
-        TILE_N = 128
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name="dec_dense",
+            seqlen_q=1,
+            seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _dec_dense_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            TILE_M = max(triton.next_power_of_2(qhead_per_kvhead), 16)
+            TILE_N = 128
+            num_warps = num_stages = num_ctas = None
 
-    if gather_kv_indices is not None:
+    if num_splits is None and gather_kv_indices is not None:
         num_splits = 1
-    else:
+    elif num_splits is None:
         num_splits = utils.num_splits_heuristic(
             seqlen_q=qhead_per_kvhead,
             seqlen_k=seqlen_k,
@@ -925,7 +941,7 @@ def _flash_dense_attn_varlen_decode(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(

--- a/flash_sparse_attn/ops/triton/flash_dense_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_fwd.py
@@ -531,9 +531,11 @@ def _flash_dense_attn_forward(
     is_quant: bool = False,
     is_split_kv: bool = False,
     pack_gqa: bool = False,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, float]:
     device = query.device
@@ -571,29 +573,35 @@ def _flash_dense_attn_forward(
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
     _kernel_name = f"fwd_dense{'_split' if is_split_kv else ''}"
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name=_kernel_name,
-        seqlen_q=seqlen_q,
-        seqlen_k=seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_causal=is_causal,
-        pack_gqa=pack_gqa,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _fwd_dense_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (64, 64)
+        num_warps, num_stages, num_ctas = 4, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        # Placeholder for pre-launch computations
-        TILE_M = TILE_N = 64
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name=_kernel_name,
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_causal=is_causal,
+            pack_gqa=pack_gqa,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _fwd_dense_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            # Placeholder for pre-launch computations
+            TILE_M = TILE_N = 64
+            num_warps = num_stages = num_ctas = None
 
-    num_splits = (
-        utils.num_splits_heuristic(
+    if is_split_kv and num_splits is None:
+        num_splits = utils.num_splits_heuristic(
             seqlen_q=seqlen_q * qhead_per_kvhead_packgqa,
             seqlen_k=seqlen_k,
             num_SMs=num_SMs,
@@ -605,9 +613,8 @@ def _flash_dense_attn_forward(
             if is_local
             else None,
         )
-        if is_split_kv
-        else 1
-    )
+    elif not is_split_kv:
+        num_splits = 1
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype
     out = out if out is not None else torch.empty_like(query, dtype=out_dtype)
@@ -701,7 +708,7 @@ def _flash_dense_attn_forward(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(
@@ -747,11 +754,13 @@ def _flash_dense_attn_varlen_forward(
     is_quant: bool = False,
     is_split_kv: bool = False,
     pack_gqa: bool = False,
+    num_splits: Optional[int] = None,
     seqused_q: Optional[torch.Tensor] = None,
     seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, float]:
     device = query.device
@@ -792,29 +801,35 @@ def _flash_dense_attn_varlen_forward(
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
     _kernel_name = f"fwd_dense{'_split' if is_split_kv else ''}"
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name=_kernel_name,
-        seqlen_q=seqlen_q,
-        seqlen_k=seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_causal=is_causal,
-        pack_gqa=pack_gqa,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _fwd_dense_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (64, 64)
+        num_warps, num_stages, num_ctas = 4, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        # Placeholder for pre-launch computations
-        TILE_M = TILE_N = 64
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name=_kernel_name,
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_causal=is_causal,
+            pack_gqa=pack_gqa,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _fwd_dense_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            # Placeholder for pre-launch computations
+            TILE_M = TILE_N = 64
+            num_warps = num_stages = num_ctas = None
 
-    num_splits = (
-        utils.num_splits_heuristic(
+    if is_split_kv and num_splits is None:
+        num_splits = utils.num_splits_heuristic(
             seqlen_q=seqlen_q * qhead_per_kvhead_packgqa,
             seqlen_k=seqlen_k,
             num_SMs=num_SMs,
@@ -826,9 +841,8 @@ def _flash_dense_attn_varlen_forward(
             if is_local
             else None,
         )
-        if is_split_kv
-        else 1
-    )
+    elif not is_split_kv:
+        num_splits = 1
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype
     out = torch.empty_like(query, dtype=out_dtype)
@@ -918,7 +932,7 @@ def _flash_dense_attn_varlen_forward(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(

--- a/flash_sparse_attn/ops/triton/flash_gated_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_bwd.py
@@ -708,7 +708,9 @@ def _flash_gated_attn_backward(
     is_local: bool = False,
     is_quant: bool = False,
     is_split_qo: bool = False,
-    is_autotune: bool = False,
+    num_splits: Optional[int] = None,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     device = query.device
@@ -755,28 +757,34 @@ def _flash_gated_attn_backward(
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name="bwd_gated",
-        seqlen_q=seqlen_q,
-        seqlen_k=seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_causal=is_causal,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _bwd_gated_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (64, 64)
+        num_warps, num_stages, num_ctas = 8, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        # Placeholder for pre-launch computations
-        TILE_M = TILE_N = 64
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name="bwd_gated",
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_causal=is_causal,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _bwd_gated_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            # Placeholder for pre-launch computations
+            TILE_M = TILE_N = 64
+            num_warps = num_stages = num_ctas = None
 
-    num_splits = (
-        utils.num_splits_heuristic(
+    if is_split_qo and num_splits is None:
+        num_splits = utils.num_splits_heuristic(
             seqlen_q=seqlen_k,
             seqlen_k=seqlen_q,
             num_SMs=num_SMs,
@@ -788,9 +796,8 @@ def _flash_gated_attn_backward(
             if is_local
             else None,
         )
-        if is_split_qo
-        else 1
-    )
+    elif not is_split_qo:
+        num_splits = 1
 
     seqlen_q_rounded = int(math.ceil(seqlen_q / 128) * 128)
     head_dim_rounded = int(math.ceil(head_dim / 32) * 32)
@@ -950,7 +957,7 @@ def _flash_gated_attn_backward(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(
@@ -1017,7 +1024,9 @@ def _flash_gated_attn_varlen_backward(
     seqused_q: Optional[torch.Tensor] = None,
     seqused_k: Optional[torch.Tensor] = None,
     is_split_qo: bool = False,
-    is_autotune: bool = False,
+    num_splits: Optional[int] = None,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     device = query.device
@@ -1067,28 +1076,34 @@ def _flash_gated_attn_varlen_backward(
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name="bwd_gated",
-        seqlen_q=seqlen_q,
-        seqlen_k=seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_causal=is_causal,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _bwd_gated_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (64, 64)
+        num_warps, num_stages, num_ctas = 8, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        # Placeholder for pre-launch computations
-        TILE_M = TILE_N = 64
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name="bwd_gated",
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_causal=is_causal,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _bwd_gated_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            # Placeholder for pre-launch computations
+            TILE_M = TILE_N = 64
+            num_warps = num_stages = num_ctas = None
 
-    num_splits = (
-        utils.num_splits_heuristic(
+    if is_split_qo and num_splits is None:
+        num_splits = utils.num_splits_heuristic(
             seqlen_q=seqlen_k,
             seqlen_k=seqlen_q,
             num_SMs=num_SMs,
@@ -1100,9 +1115,8 @@ def _flash_gated_attn_varlen_backward(
             if is_local
             else None,
         )
-        if is_split_qo
-        else 1
-    )
+    elif not is_split_qo:
+        num_splits = 1
 
     total_q_rounded_padded = int(math.ceil((total_q + batch_size * 128) / 128) * 128)
     head_dim_rounded = int(math.ceil(head_dim / 32) * 32)
@@ -1265,7 +1279,7 @@ def _flash_gated_attn_varlen_backward(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(

--- a/flash_sparse_attn/ops/triton/flash_gated_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_dec.py
@@ -890,9 +890,11 @@ def _flash_gated_attn_decode(
     is_local: bool = False,
     is_quant: bool = False,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     device = query.device
@@ -937,28 +939,34 @@ def _flash_gated_attn_decode(
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name="dec_gated",
-        seqlen_q=1,
-        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _dec_gated_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (16, 64)
+        num_warps, num_stages, num_ctas = 4, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        TILE_M = max(triton.next_power_of_2(qhead_per_kvhead), 16)
-        TILE_N = 128
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name="dec_gated",
+            seqlen_q=1,
+            seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _dec_gated_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            TILE_M = max(triton.next_power_of_2(qhead_per_kvhead), 16)
+            TILE_N = 128
+            num_warps = num_stages = num_ctas = None
 
-    if gather_kv_indices is not None:
+    if num_splits is None and gather_kv_indices is not None:
         num_splits = 1
-    else:
+    elif num_splits is None:
         num_splits = utils.num_splits_heuristic(
             seqlen_q=qhead_per_kvhead,
             seqlen_k=seqlen_k,
@@ -1071,7 +1079,7 @@ def _flash_gated_attn_decode(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(
@@ -1116,9 +1124,11 @@ def _flash_gated_attn_varlen_decode(
     is_quant: bool = False,
     seqused_k: Optional[torch.Tensor] = None,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     device = query.device
@@ -1164,28 +1174,34 @@ def _flash_gated_attn_varlen_decode(
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name="dec_gated",
-        seqlen_q=1,
-        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _dec_gated_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (16, 64)
+        num_warps, num_stages, num_ctas = 4, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        TILE_M = max(triton.next_power_of_2(qhead_per_kvhead), 16)
-        TILE_N = 128
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name="dec_gated",
+            seqlen_q=1,
+            seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _dec_gated_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            TILE_M = max(triton.next_power_of_2(qhead_per_kvhead), 16)
+            TILE_N = 128
+            num_warps = num_stages = num_ctas = None
 
-    if gather_kv_indices is not None:
+    if num_splits is None and gather_kv_indices is not None:
         num_splits = 1
-    else:
+    elif num_splits is None:
         num_splits = utils.num_splits_heuristic(
             seqlen_q=qhead_per_kvhead,
             seqlen_k=seqlen_k,
@@ -1298,7 +1314,7 @@ def _flash_gated_attn_varlen_decode(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(

--- a/flash_sparse_attn/ops/triton/flash_gated_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_fwd.py
@@ -861,9 +861,11 @@ def _flash_gated_attn_forward(
     is_quant: bool = False,
     is_split_kv: bool = False,
     pack_gqa: bool = False,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, float, float, float]:
     device = query.device
@@ -909,29 +911,35 @@ def _flash_gated_attn_forward(
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
     _kernel_name = f"fwd_gated{'_split' if is_split_kv else ''}"
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name=_kernel_name,
-        seqlen_q=seqlen_q,
-        seqlen_k=seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_causal=is_causal,
-        pack_gqa=pack_gqa,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _fwd_gated_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (64, 64)
+        num_warps, num_stages, num_ctas = 4, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        # Placeholder for pre-launch computations
-        TILE_M = TILE_N = 64
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name=_kernel_name,
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_causal=is_causal,
+            pack_gqa=pack_gqa,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _fwd_gated_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            # Placeholder for pre-launch computations
+            TILE_M = TILE_N = 64
+            num_warps = num_stages = num_ctas = None
 
-    num_splits = (
-        utils.num_splits_heuristic(
+    if is_split_kv and num_splits is None:
+        num_splits = utils.num_splits_heuristic(
             seqlen_q=seqlen_q * qhead_per_kvhead_packgqa,
             seqlen_k=seqlen_k,
             num_SMs=num_SMs,
@@ -943,9 +951,8 @@ def _flash_gated_attn_forward(
             if is_local
             else None,
         )
-        if is_split_kv
-        else 1
-    )
+    elif not is_split_kv:
+        num_splits = 1
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype
     out = out if out is not None else torch.zeros_like(query, dtype=out_dtype)
@@ -1051,7 +1058,7 @@ def _flash_gated_attn_forward(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(
@@ -1103,11 +1110,13 @@ def _flash_gated_attn_varlen_forward(
     is_quant: bool = False,
     is_split_kv: bool = False,
     pack_gqa: bool = False,
+    num_splits: Optional[int] = None,
     seqused_q: Optional[torch.Tensor] = None,
     seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, float, float, float]:
     device = query.device
@@ -1156,29 +1165,35 @@ def _flash_gated_attn_varlen_forward(
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
     _kernel_name = f"fwd_gated{'_split' if is_split_kv else ''}"
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name=_kernel_name,
-        seqlen_q=seqlen_q,
-        seqlen_k=seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_causal=is_causal,
-        pack_gqa=pack_gqa,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _fwd_gated_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (64, 64)
+        num_warps, num_stages, num_ctas = 4, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        # Placeholder for pre-launch computations
-        TILE_M = TILE_N = 64
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name=_kernel_name,
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_causal=is_causal,
+            pack_gqa=pack_gqa,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _fwd_gated_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            # Placeholder for pre-launch computations
+            TILE_M = TILE_N = 64
+            num_warps = num_stages = num_ctas = None
 
-    num_splits = (
-        utils.num_splits_heuristic(
+    if is_split_kv and num_splits is None:
+        num_splits = utils.num_splits_heuristic(
             seqlen_q=seqlen_q * qhead_per_kvhead_packgqa,
             seqlen_k=seqlen_k,
             num_SMs=num_SMs,
@@ -1190,9 +1205,8 @@ def _flash_gated_attn_varlen_forward(
             if is_local
             else None,
         )
-        if is_split_kv
-        else 1
-    )
+    elif not is_split_kv:
+        num_splits = 1
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype
     out = out if out is not None else torch.zeros_like(query, dtype=out_dtype)
@@ -1298,7 +1312,7 @@ def _flash_gated_attn_varlen_forward(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(

--- a/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
@@ -512,7 +512,9 @@ def _flash_sparse_attn_backward(
     is_local: bool = False,
     is_quant: bool = False,
     is_split_qo: bool = False,
-    is_autotune: bool = False,
+    num_splits: Optional[int] = None,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     device = query.device
@@ -554,28 +556,34 @@ def _flash_sparse_attn_backward(
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name="bwd_sparse",
-        seqlen_q=seqlen_q,
-        seqlen_k=seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_causal=is_causal,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _bwd_sparse_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (64, 64)
+        num_warps, num_stages, num_ctas = 8, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        # Placeholder for pre-launch computations
-        TILE_M = TILE_N = 64
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name="bwd_sparse",
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_causal=is_causal,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _bwd_sparse_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            # Placeholder for pre-launch computations
+            TILE_M = TILE_N = 64
+            num_warps = num_stages = num_ctas = None
 
-    num_splits = (
-        utils.num_splits_heuristic(
+    if is_split_qo and num_splits is None:
+        num_splits = utils.num_splits_heuristic(
             seqlen_q=seqlen_k,
             seqlen_k=seqlen_q,
             num_SMs=num_SMs,
@@ -587,9 +595,8 @@ def _flash_sparse_attn_backward(
             if is_local
             else None,
         )
-        if is_split_qo
-        else 1
-    )
+    elif not is_split_qo:
+        num_splits = 1
 
     seqlen_q_rounded = int(math.ceil(seqlen_q / 128) * 128)
     head_dim_rounded = int(math.ceil(head_dim / 32) * 32)
@@ -719,7 +726,7 @@ def _flash_sparse_attn_backward(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(
@@ -777,7 +784,9 @@ def _flash_sparse_attn_varlen_backward(
     seqused_q: Optional[torch.Tensor] = None,
     seqused_k: Optional[torch.Tensor] = None,
     is_split_qo: bool = False,
-    is_autotune: bool = False,
+    num_splits: Optional[int] = None,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     device = query.device
@@ -822,28 +831,34 @@ def _flash_sparse_attn_varlen_backward(
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name="bwd_sparse",
-        seqlen_q=seqlen_q,
-        seqlen_k=seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_causal=is_causal,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _bwd_sparse_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (64, 64)
+        num_warps, num_stages, num_ctas = 8, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        # Placeholder for pre-launch computations
-        TILE_M = TILE_N = 64
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name="bwd_sparse",
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_causal=is_causal,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _bwd_sparse_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            # Placeholder for pre-launch computations
+            TILE_M = TILE_N = 64
+            num_warps = num_stages = num_ctas = None
 
-    num_splits = (
-        utils.num_splits_heuristic(
+    if is_split_qo and num_splits is None:
+        num_splits = utils.num_splits_heuristic(
             seqlen_q=seqlen_k,
             seqlen_k=seqlen_q,
             num_SMs=num_SMs,
@@ -855,9 +870,8 @@ def _flash_sparse_attn_varlen_backward(
             if is_local
             else None,
         )
-        if is_split_qo
-        else 1
-    )
+    elif not is_split_qo:
+        num_splits = 1
 
     total_q_rounded_padded = int(math.ceil((total_q + batch_size * 128) / 128) * 128)
     head_dim_rounded = int(math.ceil(head_dim / 32) * 32)
@@ -993,7 +1007,7 @@ def _flash_sparse_attn_varlen_backward(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(

--- a/flash_sparse_attn/ops/triton/flash_sparse_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_dec.py
@@ -569,9 +569,11 @@ def _flash_sparse_attn_decode(
     is_local: bool = False,
     is_quant: bool = False,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     device = query.device
@@ -611,28 +613,34 @@ def _flash_sparse_attn_decode(
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name="dec_sparse",
-        seqlen_q=1,
-        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _dec_sparse_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (16, 64)
+        num_warps, num_stages, num_ctas = 4, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        TILE_M = max(triton.next_power_of_2(qhead_per_kvhead), 16)
-        TILE_N = 128
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name="dec_sparse",
+            seqlen_q=1,
+            seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _dec_sparse_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            TILE_M = max(triton.next_power_of_2(qhead_per_kvhead), 16)
+            TILE_N = 128
+            num_warps = num_stages = num_ctas = None
 
-    if gather_kv_indices is not None:
+    if num_splits is None and gather_kv_indices is not None:
         num_splits = 1
-    else:
+    elif num_splits is None:
         num_splits = utils.num_splits_heuristic(
             seqlen_q=qhead_per_kvhead,
             seqlen_k=seqlen_k,
@@ -737,7 +745,7 @@ def _flash_sparse_attn_decode(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(
@@ -778,9 +786,11 @@ def _flash_sparse_attn_varlen_decode(
     is_quant: bool = False,
     seqused_k: Optional[torch.Tensor] = None,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     device = query.device
@@ -821,28 +831,34 @@ def _flash_sparse_attn_varlen_decode(
 
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name="dec_sparse",
-        seqlen_q=1,
-        seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _dec_sparse_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (16, 64)
+        num_warps, num_stages, num_ctas = 4, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        TILE_M = max(triton.next_power_of_2(qhead_per_kvhead), 16)
-        TILE_N = 128
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name="dec_sparse",
+            seqlen_q=1,
+            seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _dec_sparse_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            TILE_M = max(triton.next_power_of_2(qhead_per_kvhead), 16)
+            TILE_N = 128
+            num_warps = num_stages = num_ctas = None
 
-    if gather_kv_indices is not None:
+    if num_splits is None and gather_kv_indices is not None:
         num_splits = 1
-    else:
+    elif num_splits is None:
         num_splits = utils.num_splits_heuristic(
             seqlen_q=qhead_per_kvhead,
             seqlen_k=seqlen_k,
@@ -947,7 +963,7 @@ def _flash_sparse_attn_varlen_decode(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(

--- a/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
@@ -536,9 +536,11 @@ def _flash_sparse_attn_forward(
     is_quant: bool = False,
     is_split_kv: bool = False,
     pack_gqa: bool = False,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, float, float]:
     device = query.device
@@ -579,29 +581,35 @@ def _flash_sparse_attn_forward(
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
     _kernel_name = f"fwd_sparse{'_split' if is_split_kv else ''}"
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name=_kernel_name,
-        seqlen_q=seqlen_q,
-        seqlen_k=seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_causal=is_causal,
-        pack_gqa=pack_gqa,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _fwd_sparse_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (64, 64)
+        num_warps, num_stages, num_ctas = 4, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        # Placeholder for pre-launch computations
-        TILE_M = TILE_N = 64
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name=_kernel_name,
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_causal=is_causal,
+            pack_gqa=pack_gqa,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _fwd_sparse_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            # Placeholder for pre-launch computations
+            TILE_M = TILE_N = 64
+            num_warps = num_stages = num_ctas = None
 
-    num_splits = (
-        utils.num_splits_heuristic(
+    if is_split_kv and num_splits is None:
+        num_splits = utils.num_splits_heuristic(
             seqlen_q=seqlen_q * qhead_per_kvhead_packgqa,
             seqlen_k=seqlen_k,
             num_SMs=num_SMs,
@@ -613,9 +621,8 @@ def _flash_sparse_attn_forward(
             if is_local
             else None,
         )
-        if is_split_kv
-        else 1
-    )
+    elif not is_split_kv:
+        num_splits = 1
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype
     out = out if out is not None else torch.empty_like(query, dtype=out_dtype)
@@ -710,7 +717,7 @@ def _flash_sparse_attn_forward(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(
@@ -757,11 +764,13 @@ def _flash_sparse_attn_varlen_forward(
     is_quant: bool = False,
     is_split_kv: bool = False,
     pack_gqa: bool = False,
+    num_splits: Optional[int] = None,
     seqused_q: Optional[torch.Tensor] = None,
     seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, float, float]:
     device = query.device
@@ -805,29 +814,35 @@ def _flash_sparse_attn_varlen_forward(
     TILE_K = max(triton.next_power_of_2(head_dim), 16)
 
     _kernel_name = f"fwd_sparse{'_split' if is_split_kv else ''}"
-    launch_config = launch_template.load_launch_config(
-        device=device,
-        kernel_name=_kernel_name,
-        seqlen_q=seqlen_q,
-        seqlen_k=seqlen_k,
-        tile_k=TILE_K,
-        is_local=is_local,
-        qhead_per_kvhead=qhead_per_kvhead,
-        is_causal=is_causal,
-        pack_gqa=pack_gqa,
-        is_quant=is_quant,
-    )
-    if launch_config is not None and not is_autotune:
+    launch_config = None
+    if not is_autotune:
         kernel = _fwd_sparse_kernel
-        TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        TILE_M, TILE_N = tile_mn if tile_mn is not None else (64, 64)
+        num_warps, num_stages, num_ctas = 4, 1, 1
     else:
-        kernel = _get_autotuned_kernel()
-        # Placeholder for pre-launch computations
-        TILE_M = TILE_N = 64
-        num_warps = num_stages = num_ctas = None
+        launch_config = launch_template.load_launch_config(
+            device=device,
+            kernel_name=_kernel_name,
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            tile_k=TILE_K,
+            is_local=is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_causal=is_causal,
+            pack_gqa=pack_gqa,
+            is_quant=is_quant,
+        )
+        if launch_config is not None:
+            kernel = _fwd_sparse_kernel
+            TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
+        else:
+            kernel = _get_autotuned_kernel()
+            # Placeholder for pre-launch computations
+            TILE_M = TILE_N = 64
+            num_warps = num_stages = num_ctas = None
 
-    num_splits = (
-        utils.num_splits_heuristic(
+    if is_split_kv and num_splits is None:
+        num_splits = utils.num_splits_heuristic(
             seqlen_q=seqlen_q * qhead_per_kvhead_packgqa,
             seqlen_k=seqlen_k,
             num_SMs=num_SMs,
@@ -839,9 +854,8 @@ def _flash_sparse_attn_varlen_forward(
             if is_local
             else None,
         )
-        if is_split_kv
-        else 1
-    )
+    elif not is_split_kv:
+        num_splits = 1
 
     out_dtype = torch.bfloat16 if is_quant else query.dtype
     out = out if out is not None else torch.empty_like(query, dtype=out_dtype)
@@ -936,7 +950,7 @@ def _flash_sparse_attn_varlen_forward(
         num_ctas=num_ctas,
     )
 
-    if launch_config is None or is_autotune:
+    if is_autotune and launch_config is None:
         best = launch_template.extract_best_config(_get_autotuned_kernel())
         if best is not None:
             launch_template.store_launch_config(

--- a/flash_sparse_attn/ops/triton/interface.py
+++ b/flash_sparse_attn/ops/triton/interface.py
@@ -63,9 +63,11 @@ class FlashDenseAttnFunc(torch.autograd.Function):
         is_split_kv: bool = False,
         is_split_qo: bool = False,
         pack_gqa: bool = False,
+        num_splits: Optional[int] = None,
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
-        is_autotune: bool = False,
+        is_autotune: bool = True,
+        tile_mn: Optional[Tuple[int, int]] = None,
         skip_checks: bool = False,
         return_lse: bool = False,
     ):
@@ -74,6 +76,9 @@ class FlashDenseAttnFunc(torch.autograd.Function):
 
         if window_sizes is not None:
             is_local = True
+        if num_splits is not None:
+            is_split_kv = True
+            is_split_qo = True
 
         if is_quant and (
             query_scale is None or key_scale is None or value_scale is None
@@ -96,9 +101,11 @@ class FlashDenseAttnFunc(torch.autograd.Function):
             is_quant=is_quant,
             is_split_kv=is_split_kv,
             pack_gqa=pack_gqa,
+            num_splits=num_splits,
             out=out,
             lse=lse,
             is_autotune=is_autotune,
+            tile_mn=tile_mn,
             skip_checks=skip_checks,
         )
 
@@ -112,7 +119,9 @@ class FlashDenseAttnFunc(torch.autograd.Function):
         ctx.is_local = is_local
         ctx.is_quant = is_quant
         ctx.is_split_qo = is_split_qo
+        ctx.num_splits = num_splits
         ctx.is_autotune = is_autotune
+        ctx.tile_mn = tile_mn
         ctx.skip_checks = skip_checks
 
         if return_lse:
@@ -142,7 +151,9 @@ class FlashDenseAttnFunc(torch.autograd.Function):
             is_local=ctx.is_local,
             is_quant=ctx.is_quant,
             is_split_qo=ctx.is_split_qo,
+            num_splits=ctx.num_splits,
             is_autotune=ctx.is_autotune,
+            tile_mn=ctx.tile_mn,
             skip_checks=ctx.skip_checks,
         )
 
@@ -172,11 +183,13 @@ class FlashDenseAttnVarlenFunc(torch.autograd.Function):
         is_split_kv: bool = False,
         is_split_qo: bool = False,
         pack_gqa: bool = False,
+        num_splits: Optional[int] = None,
         seqused_q: Optional[torch.Tensor] = None,
         seqused_k: Optional[torch.Tensor] = None,
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
-        is_autotune: bool = False,
+        is_autotune: bool = True,
+        tile_mn: Optional[Tuple[int, int]] = None,
         skip_checks: bool = False,
         return_lse: bool = False,
     ):
@@ -185,6 +198,9 @@ class FlashDenseAttnVarlenFunc(torch.autograd.Function):
 
         if window_sizes is not None:
             is_local = True
+        if num_splits is not None:
+            is_split_kv = True
+            is_split_qo = True
 
         if is_quant and (
             query_scale is None or key_scale is None or value_scale is None
@@ -211,11 +227,13 @@ class FlashDenseAttnVarlenFunc(torch.autograd.Function):
             is_quant=is_quant,
             is_split_kv=is_split_kv,
             pack_gqa=pack_gqa,
+            num_splits=num_splits,
             seqused_q=seqused_q,
             seqused_k=seqused_k,
             out=out,
             lse=lse,
             is_autotune=is_autotune,
+            tile_mn=tile_mn,
             skip_checks=skip_checks,
         )
 
@@ -241,7 +259,9 @@ class FlashDenseAttnVarlenFunc(torch.autograd.Function):
         ctx.is_local = is_local
         ctx.is_quant = is_quant
         ctx.is_split_qo = is_split_qo
+        ctx.num_splits = num_splits
         ctx.is_autotune = is_autotune
+        ctx.tile_mn = tile_mn
         ctx.skip_checks = skip_checks
 
         if return_lse:
@@ -285,9 +305,11 @@ class FlashDenseAttnVarlenFunc(torch.autograd.Function):
             is_local=ctx.is_local,
             is_quant=ctx.is_quant,
             is_split_qo=ctx.is_split_qo,
+            num_splits=ctx.num_splits,
             seqused_q=seqused_q,
             seqused_k=seqused_k,
             is_autotune=ctx.is_autotune,
+            tile_mn=ctx.tile_mn,
             skip_checks=ctx.skip_checks,
         )
 
@@ -314,9 +336,11 @@ class FlashSparseAttnFunc(torch.autograd.Function):
         is_split_kv: bool = False,
         is_split_qo: bool = False,
         pack_gqa: bool = False,
+        num_splits: Optional[int] = None,
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
-        is_autotune: bool = False,
+        is_autotune: bool = True,
+        tile_mn: Optional[Tuple[int, int]] = None,
         skip_checks: bool = False,
         return_lse: bool = False,
     ):
@@ -325,6 +349,9 @@ class FlashSparseAttnFunc(torch.autograd.Function):
 
         if window_sizes is not None:
             is_local = True
+        if num_splits is not None:
+            is_split_kv = True
+            is_split_qo = True
 
         if is_quant and (
             query_scale is None or key_scale is None or value_scale is None
@@ -348,9 +375,11 @@ class FlashSparseAttnFunc(torch.autograd.Function):
             is_quant=is_quant,
             is_split_kv=is_split_kv,
             pack_gqa=pack_gqa,
+            num_splits=num_splits,
             out=out,
             lse=lse,
             is_autotune=is_autotune,
+            tile_mn=tile_mn,
             skip_checks=skip_checks,
         )
 
@@ -365,7 +394,9 @@ class FlashSparseAttnFunc(torch.autograd.Function):
         ctx.is_local = is_local
         ctx.is_quant = is_quant
         ctx.is_split_qo = is_split_qo
+        ctx.num_splits = num_splits
         ctx.is_autotune = is_autotune
+        ctx.tile_mn = tile_mn
         ctx.skip_checks = skip_checks
 
         if return_lse:
@@ -396,7 +427,9 @@ class FlashSparseAttnFunc(torch.autograd.Function):
             is_local=ctx.is_local,
             is_quant=ctx.is_quant,
             is_split_qo=ctx.is_split_qo,
+            num_splits=ctx.num_splits,
             is_autotune=ctx.is_autotune,
+            tile_mn=ctx.tile_mn,
             skip_checks=ctx.skip_checks,
         )
 
@@ -427,11 +460,13 @@ class FlashSparseAttnVarlenFunc(torch.autograd.Function):
         is_split_kv: bool = False,
         is_split_qo: bool = False,
         pack_gqa: bool = False,
+        num_splits: Optional[int] = None,
         seqused_q: Optional[torch.Tensor] = None,
         seqused_k: Optional[torch.Tensor] = None,
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
-        is_autotune: bool = False,
+        is_autotune: bool = True,
+        tile_mn: Optional[Tuple[int, int]] = None,
         skip_checks: bool = False,
         return_lse: bool = False,
     ):
@@ -440,6 +475,9 @@ class FlashSparseAttnVarlenFunc(torch.autograd.Function):
 
         if window_sizes is not None:
             is_local = True
+        if num_splits is not None:
+            is_split_kv = True
+            is_split_qo = True
 
         if is_quant and (
             query_scale is None or key_scale is None or value_scale is None
@@ -467,11 +505,13 @@ class FlashSparseAttnVarlenFunc(torch.autograd.Function):
             is_quant=is_quant,
             is_split_kv=is_split_kv,
             pack_gqa=pack_gqa,
+            num_splits=num_splits,
             seqused_q=seqused_q,
             seqused_k=seqused_k,
             out=out,
             lse=lse,
             is_autotune=is_autotune,
+            tile_mn=tile_mn,
             skip_checks=skip_checks,
         )
 
@@ -498,7 +538,9 @@ class FlashSparseAttnVarlenFunc(torch.autograd.Function):
         ctx.is_local = is_local
         ctx.is_quant = is_quant
         ctx.is_split_qo = is_split_qo
+        ctx.num_splits = num_splits
         ctx.is_autotune = is_autotune
+        ctx.tile_mn = tile_mn
         ctx.skip_checks = skip_checks
 
         if return_lse:
@@ -545,7 +587,9 @@ class FlashSparseAttnVarlenFunc(torch.autograd.Function):
             seqused_q=seqused_q,
             seqused_k=seqused_k,
             is_split_qo=ctx.is_split_qo,
+            num_splits=ctx.num_splits,
             is_autotune=ctx.is_autotune,
+            tile_mn=ctx.tile_mn,
             skip_checks=ctx.skip_checks,
         )
 
@@ -577,9 +621,11 @@ class FlashGatedAttnFunc(torch.autograd.Function):
         is_split_kv: bool = False,
         is_split_qo: bool = False,
         pack_gqa: bool = False,
+        num_splits: Optional[int] = None,
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
-        is_autotune: bool = False,
+        is_autotune: bool = True,
+        tile_mn: Optional[Tuple[int, int]] = None,
         skip_checks: bool = False,
         return_lse: bool = False,
     ):
@@ -588,6 +634,9 @@ class FlashGatedAttnFunc(torch.autograd.Function):
 
         if window_sizes is not None:
             is_local = True
+        if num_splits is not None:
+            is_split_kv = True
+            is_split_qo = True
 
         if is_quant and (
             query_scale is None or key_scale is None or value_scale is None
@@ -621,9 +670,11 @@ class FlashGatedAttnFunc(torch.autograd.Function):
                 is_quant=is_quant,
                 is_split_kv=is_split_kv,
                 pack_gqa=pack_gqa,
+                num_splits=num_splits,
                 out=out,
                 lse=lse,
                 is_autotune=is_autotune,
+                tile_mn=tile_mn,
                 skip_checks=skip_checks,
             )
         )
@@ -642,7 +693,9 @@ class FlashGatedAttnFunc(torch.autograd.Function):
         ctx.is_local = is_local
         ctx.is_quant = is_quant
         ctx.is_split_qo = is_split_qo
+        ctx.num_splits = num_splits
         ctx.is_autotune = is_autotune
+        ctx.tile_mn = tile_mn
         ctx.skip_checks = skip_checks
 
         if return_lse:
@@ -678,7 +731,9 @@ class FlashGatedAttnFunc(torch.autograd.Function):
             is_local=ctx.is_local,
             is_quant=ctx.is_quant,
             is_split_qo=ctx.is_split_qo,
+            num_splits=ctx.num_splits,
             is_autotune=ctx.is_autotune,
+            tile_mn=ctx.tile_mn,
             skip_checks=ctx.skip_checks,
         )
 
@@ -718,11 +773,13 @@ class FlashGatedAttnVarlenFunc(torch.autograd.Function):
         is_split_kv: bool = False,
         is_split_qo: bool = False,
         pack_gqa: bool = False,
+        num_splits: Optional[int] = None,
         seqused_q: Optional[torch.Tensor] = None,
         seqused_k: Optional[torch.Tensor] = None,
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
-        is_autotune: bool = False,
+        is_autotune: bool = True,
+        tile_mn: Optional[Tuple[int, int]] = None,
         skip_checks: bool = False,
         return_lse: bool = False,
     ):
@@ -731,6 +788,9 @@ class FlashGatedAttnVarlenFunc(torch.autograd.Function):
 
         if window_sizes is not None:
             is_local = True
+        if num_splits is not None:
+            is_split_kv = True
+            is_split_qo = True
 
         if is_quant and (
             query_scale is None or key_scale is None or value_scale is None
@@ -768,11 +828,13 @@ class FlashGatedAttnVarlenFunc(torch.autograd.Function):
                 is_quant=is_quant,
                 is_split_kv=is_split_kv,
                 pack_gqa=pack_gqa,
+                num_splits=num_splits,
                 seqused_q=seqused_q,
                 seqused_k=seqused_k,
                 out=out,
                 lse=lse,
                 is_autotune=is_autotune,
+                tile_mn=tile_mn,
                 skip_checks=skip_checks,
             )
         )
@@ -805,7 +867,9 @@ class FlashGatedAttnVarlenFunc(torch.autograd.Function):
         ctx.is_local = is_local
         ctx.is_quant = is_quant
         ctx.is_split_qo = is_split_qo
+        ctx.num_splits = num_splits
         ctx.is_autotune = is_autotune
+        ctx.tile_mn = tile_mn
         ctx.skip_checks = skip_checks
 
         if return_lse:
@@ -859,7 +923,9 @@ class FlashGatedAttnVarlenFunc(torch.autograd.Function):
             seqused_q=seqused_q,
             seqused_k=seqused_k,
             is_split_qo=ctx.is_split_qo,
+            num_splits=ctx.num_splits,
             is_autotune=ctx.is_autotune,
+            tile_mn=ctx.tile_mn,
             skip_checks=ctx.skip_checks,
         )
 
@@ -915,9 +981,11 @@ def flash_dense_attn_func(
     is_split_kv: bool = False,
     is_split_qo: bool = False,
     pack_gqa: bool = False,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
     return_lse: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
@@ -938,9 +1006,11 @@ def flash_dense_attn_func(
     :param is_split_kv: Whether to enable split-KV for forward occupancy.
     :param is_split_qo: Whether to enable split-QO for backward occupancy.
     :param pack_gqa: Whether to pack grouped-query attention.
+    :param num_splits: Optional split count for split-KV and split-QO. If provided, enables split-KV and split-QO, if omitted with split-KV and split-QO enabled, a heuristic is used.
     :param out: Optional preallocated output tensor with shape [batch_size, seqlen_q, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads, seqlen_q].
-    :param is_autotune: Force re-run Triton autotuner and overwrite cache. Default False uses cached config.
+    :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
+    :param tile_mn: Tuple of (TILE_M, TILE_N) for launch when is_autotune is False.
     :param skip_checks: Whether to skip input validation checks for faster performance.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
 
@@ -961,9 +1031,11 @@ def flash_dense_attn_func(
         is_split_kv,
         is_split_qo,
         pack_gqa,
+        num_splits,
         out,
         lse,
         is_autotune,
+        tile_mn,
         skip_checks,
         return_lse,
     )
@@ -981,9 +1053,11 @@ def flash_dense_attn_with_kvcache_func(
     is_local: bool = False,
     is_quant: bool = False,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
     return_lse: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
@@ -1001,9 +1075,11 @@ def flash_dense_attn_with_kvcache_func(
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param gather_kv_indices: Optional TopK gather indices with shape [batch_size, topk_seqlen_k]. Each non-negative entry is an original KV sequence position to gather for decode, negative entries are masked out.
+    :param num_splits: Optional split count for decode. If omitted, gather decode uses 1 split and regular decode uses a heuristic.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads].
-    :param is_autotune: Force re-run Triton autotuner and overwrite cache. Default False uses cached config.
+    :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
+    :param tile_mn: Tuple of (TILE_M, TILE_N) for launch when is_autotune is False.
     :param skip_checks: Whether to skip input validation checks for faster performance.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
 
@@ -1030,9 +1106,11 @@ def flash_dense_attn_with_kvcache_func(
         is_local=is_local,
         is_quant=is_quant,
         gather_kv_indices=gather_kv_indices,
+        num_splits=num_splits,
         out=out,
         lse=lse,
         is_autotune=is_autotune,
+        tile_mn=tile_mn,
         skip_checks=skip_checks,
     )
 
@@ -1060,11 +1138,13 @@ def flash_dense_attn_varlen_func(
     is_split_kv: bool = False,
     is_split_qo: bool = False,
     pack_gqa: bool = False,
+    num_splits: Optional[int] = None,
     seqused_q: Optional[torch.Tensor] = None,
     seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
     return_lse: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
@@ -1089,11 +1169,13 @@ def flash_dense_attn_varlen_func(
     :param is_split_kv: Whether to enable split-KV for forward occupancy.
     :param is_split_qo: Whether to enable split-QO for backward occupancy.
     :param pack_gqa: Whether to pack grouped-query attention.
+    :param num_splits: Optional split count for split-KV and split-QO. If provided, enables split-KV and split-QO, if omitted with split-KV and split-QO enabled, a heuristic is used.
     :param seqused_q: Optional tensor of shape [total_seqlen_q] indicating the actual sequence lengths for queries. If provided, overrides cu_seqlens_q for masking.
     :param seqused_k: Optional tensor of shape [total_seqlen_k] indicating the actual sequence lengths for keys/values. If provided, overrides cu_seqlens_k for masking.
     :param out: Optional preallocated output tensor with shape [batch_size, seqlen_q, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads, seqlen_q].
-    :param is_autotune: Force re-run Triton autotuner and overwrite cache. Default False uses cached config.
+    :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
+    :param tile_mn: Tuple of (TILE_M, TILE_N) for launch when is_autotune is False.
     :param skip_checks: Whether to skip input validation checks for faster performance.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
 
@@ -1118,11 +1200,13 @@ def flash_dense_attn_varlen_func(
         is_split_kv,
         is_split_qo,
         pack_gqa,
+        num_splits,
         seqused_q,
         seqused_k,
         out,
         lse,
         is_autotune,
+        tile_mn,
         skip_checks,
         return_lse,
     )
@@ -1143,9 +1227,11 @@ def flash_dense_attn_varlen_with_kvcache_func(
     is_quant: bool = False,
     seqused_k: Optional[torch.Tensor] = None,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
     return_lse: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
@@ -1166,9 +1252,11 @@ def flash_dense_attn_varlen_with_kvcache_func(
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param seqused_k: Optional tensor indicating the actual sequence lengths for keys/values.
     :param gather_kv_indices: Optional TopK gather indices with shape [batch_size, topk_seqlen_k]. Each non-negative entry is a batch-local KV sequence position to gather for decode, negative entries are masked out.
+    :param num_splits: Optional split count for decode. If omitted, gather decode uses 1 split and regular decode uses a heuristic.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads_q, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads_q].
-    :param is_autotune: Force re-run Triton autotuner and overwrite cache. Default False uses cached config.
+    :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
+    :param tile_mn: Tuple of (TILE_M, TILE_N) for launch when is_autotune is False.
     :param skip_checks: Whether to skip input validation checks for faster performance.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
 
@@ -1198,9 +1286,11 @@ def flash_dense_attn_varlen_with_kvcache_func(
         is_quant=is_quant,
         seqused_k=seqused_k,
         gather_kv_indices=gather_kv_indices,
+        num_splits=num_splits,
         out=out,
         lse=lse,
         is_autotune=is_autotune,
+        tile_mn=tile_mn,
         skip_checks=skip_checks,
     )
 
@@ -1225,9 +1315,11 @@ def flash_sparse_attn_func(
     is_split_kv: bool = False,
     is_split_qo: bool = False,
     pack_gqa: bool = False,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
     return_lse: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
@@ -1246,12 +1338,14 @@ def flash_sparse_attn_func(
     :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to head_dim / seqlen_k.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided or will be computed from the input tensors.
-    :param is_split_kv: Whether to enable split-KV for forward ccupancy.
+    :param is_split_kv: Whether to enable split-KV for forward occupancy.
     :param is_split_qo: Whether to enable split-QO for backward occupancy.
     :param pack_gqa: Whether to pack grouped-query attention.
+    :param num_splits: Optional split count for split-KV and split-QO. If provided, enables split-KV and split-QO, if omitted with split-KV and split-QO enabled, a heuristic is used.
     :param out: Optional preallocated output tensor with shape [batch_size, seqlen_q, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads, seqlen_q].
-    :param is_autotune: Force re-run Triton autotuner and overwrite cache. Default False uses cached config.
+    :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
+    :param tile_mn: Tuple of (TILE_M, TILE_N) for launch when is_autotune is False.
     :param skip_checks: Whether to skip input validation checks for faster performance.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
 
@@ -1273,9 +1367,11 @@ def flash_sparse_attn_func(
         is_split_kv,
         is_split_qo,
         pack_gqa,
+        num_splits,
         out,
         lse,
         is_autotune,
+        tile_mn,
         skip_checks,
         return_lse,
     )
@@ -1294,9 +1390,11 @@ def flash_sparse_attn_with_kvcache_func(
     is_local: bool = False,
     is_quant: bool = False,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
     return_lse: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
@@ -1315,9 +1413,11 @@ def flash_sparse_attn_with_kvcache_func(
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param gather_kv_indices: Optional TopK gather indices with shape [batch_size, topk_seqlen_k]. Each non-negative entry is an original KV sequence position to gather for decode, negative entries are masked out.
+    :param num_splits: Optional split count for decode. If omitted, gather decode uses 1 split and regular decode uses a heuristic.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads].
-    :param is_autotune: Force re-run Triton autotuner and overwrite cache. Default False uses cached config.
+    :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
+    :param tile_mn: Tuple of (TILE_M, TILE_N) for launch when is_autotune is False.
     :param skip_checks: Whether to skip input validation checks for faster performance.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
 
@@ -1345,9 +1445,11 @@ def flash_sparse_attn_with_kvcache_func(
         is_local=is_local,
         is_quant=is_quant,
         gather_kv_indices=gather_kv_indices,
+        num_splits=num_splits,
         out=out,
         lse=lse,
         is_autotune=is_autotune,
+        tile_mn=tile_mn,
         skip_checks=skip_checks,
     )
 
@@ -1376,11 +1478,13 @@ def flash_sparse_attn_varlen_func(
     is_split_kv: bool = False,
     is_split_qo: bool = False,
     pack_gqa: bool = False,
+    num_splits: Optional[int] = None,
     seqused_q: Optional[torch.Tensor] = None,
     seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
     return_lse: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
@@ -1406,11 +1510,13 @@ def flash_sparse_attn_varlen_func(
     :param is_split_kv: Whether to enable split-KV for forward occupancy.
     :param is_split_qo: Whether to enable split-QO for backward occupancy.
     :param pack_gqa: Whether to pack grouped-query attention.
+    :param num_splits: Optional split count for split-KV and split-QO. If provided, enables split-KV and split-QO, if omitted with split-KV and split-QO enabled, a heuristic is used.
     :param seqused_q: Optional tensor of shape [total_seqlen_q] indicating the actual sequence lengths for queries. If provided, overrides cu_seqlens_q for masking.
     :param seqused_k: Optional tensor of shape [total_seqlen_k] indicating the actual sequence lengths for keys/values. If provided, overrides cu_seqlens_k for masking.
     :param out: Optional preallocated output tensor with shape [batch_size, seqlen_q, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads, seqlen_q].
-    :param is_autotune: Force re-run Triton autotuner and overwrite cache. Default False uses cached config.
+    :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
+    :param tile_mn: Tuple of (TILE_M, TILE_N) for launch when is_autotune is False.
     :param skip_checks: Whether to skip input validation checks for faster performance.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
 
@@ -1436,11 +1542,13 @@ def flash_sparse_attn_varlen_func(
         is_split_kv,
         is_split_qo,
         pack_gqa,
+        num_splits,
         seqused_q,
         seqused_k,
         out,
         lse,
         is_autotune,
+        tile_mn,
         skip_checks,
         return_lse,
     )
@@ -1462,9 +1570,11 @@ def flash_sparse_attn_varlen_with_kvcache_func(
     is_quant: bool = False,
     seqused_k: Optional[torch.Tensor] = None,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
     return_lse: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
@@ -1486,9 +1596,11 @@ def flash_sparse_attn_varlen_with_kvcache_func(
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param seqused_k: Optional tensor indicating the actual sequence lengths for keys/values.
     :param gather_kv_indices: Optional TopK gather indices with shape [batch_size, topk_seqlen_k]. Each non-negative entry is a batch-local KV sequence position to gather for decode, negative entries are masked out.
+    :param num_splits: Optional split count for decode. If omitted, gather decode uses 1 split and regular decode uses a heuristic.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads_q, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads_q].
-    :param is_autotune: Force re-run Triton autotuner and overwrite cache. Default False uses cached config.
+    :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
+    :param tile_mn: Tuple of (TILE_M, TILE_N) for launch when is_autotune is False.
     :param skip_checks: Whether to skip input validation checks for faster performance.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
 
@@ -1519,9 +1631,11 @@ def flash_sparse_attn_varlen_with_kvcache_func(
         is_quant=is_quant,
         seqused_k=seqused_k,
         gather_kv_indices=gather_kv_indices,
+        num_splits=num_splits,
         out=out,
         lse=lse,
         is_autotune=is_autotune,
+        tile_mn=tile_mn,
         skip_checks=skip_checks,
     )
 
@@ -1551,9 +1665,11 @@ def flash_gated_attn_func(
     is_split_kv: bool = False,
     is_split_qo: bool = False,
     pack_gqa: bool = False,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
     return_lse: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
@@ -1580,9 +1696,11 @@ def flash_gated_attn_func(
     :param is_split_kv: Whether to enable split-KV for forward occupancy.
     :param is_split_qo: Whether to enable split-QO for backward occupancy.
     :param pack_gqa: Whether to pack grouped-query attention.
+    :param num_splits: Optional split count for split-KV and split-QO. If provided, enables split-KV and split-QO, if omitted with split-KV and split-QO enabled, a heuristic is used.
     :param out: Optional preallocated output tensor with shape [batch_size, seqlen_q, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads, seqlen_q].
-    :param is_autotune: Force re-run Triton autotuner and overwrite cache. Default False uses cached config.
+    :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
+    :param tile_mn: Tuple of (TILE_M, TILE_N) for launch when is_autotune is False.
     :param skip_checks: Whether to skip input validation checks for faster performance.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
 
@@ -1609,9 +1727,11 @@ def flash_gated_attn_func(
         is_split_kv,
         is_split_qo,
         pack_gqa,
+        num_splits,
         out,
         lse,
         is_autotune,
+        tile_mn,
         skip_checks,
         return_lse,
     )
@@ -1634,9 +1754,11 @@ def flash_gated_attn_with_kvcache_func(
     is_local: bool = False,
     is_quant: bool = False,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
     return_lse: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
@@ -1659,9 +1781,11 @@ def flash_gated_attn_with_kvcache_func(
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param gather_kv_indices: Optional TopK gather indices with shape [batch_size, topk_seqlen_k]. Each non-negative entry is an original KV sequence position to gather for decode, negative entries are masked out.
+    :param num_splits: Optional split count for decode. If omitted, gather decode uses 1 split and regular decode uses a heuristic.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads].
-    :param is_autotune: Force re-run Triton autotuner and overwrite cache. Default False uses cached config.
+    :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
+    :param tile_mn: Tuple of (TILE_M, TILE_N) for launch when is_autotune is False.
     :param skip_checks: Whether to skip input validation checks for faster performance.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
 
@@ -1696,9 +1820,11 @@ def flash_gated_attn_with_kvcache_func(
         is_local=is_local,
         is_quant=is_quant,
         gather_kv_indices=gather_kv_indices,
+        num_splits=num_splits,
         out=out,
         lse=lse,
         is_autotune=is_autotune,
+        tile_mn=tile_mn,
         skip_checks=skip_checks,
     )
 
@@ -1732,11 +1858,13 @@ def flash_gated_attn_varlen_func(
     is_split_kv: bool = False,
     is_split_qo: bool = False,
     pack_gqa: bool = False,
+    num_splits: Optional[int] = None,
     seqused_q: Optional[torch.Tensor] = None,
     seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
     return_lse: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
@@ -1767,11 +1895,13 @@ def flash_gated_attn_varlen_func(
     :param is_split_kv: Whether to enable split-KV for forward occupancy.
     :param is_split_qo: Whether to enable split-QO for backward occupancy.
     :param pack_gqa: Whether to pack grouped-query attention.
+    :param num_splits: Optional split count for split-KV and split-QO. If provided, enables split-KV and split-QO, if omitted with split-KV and split-QO enabled, a heuristic is used.
     :param seqused_q: Optional tensor of shape [total_seqlen_q] indicating the actual sequence lengths for queries. If provided, overrides cu_seqlens_q for masking.
     :param seqused_k: Optional tensor of shape [total_seqlen_k] indicating the actual sequence lengths for keys/values. If provided, overrides cu_seqlens_k for masking.
     :param out: Optional preallocated output tensor with shape [batch_size, seqlen_q, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads, seqlen_q].
-    :param is_autotune: Force re-run Triton autotuner and overwrite cache. Default False uses cached config.
+    :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
+    :param tile_mn: Tuple of (TILE_M, TILE_N) for launch when is_autotune is False.
     :param skip_checks: Whether to skip input validation checks for faster performance.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
 
@@ -1802,11 +1932,13 @@ def flash_gated_attn_varlen_func(
         is_split_kv,
         is_split_qo,
         pack_gqa,
+        num_splits,
         seqused_q,
         seqused_k,
         out,
         lse,
         is_autotune,
+        tile_mn,
         skip_checks,
         return_lse,
     )
@@ -1832,9 +1964,11 @@ def flash_gated_attn_varlen_with_kvcache_func(
     is_quant: bool = False,
     seqused_k: Optional[torch.Tensor] = None,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    num_splits: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
-    is_autotune: bool = False,
+    is_autotune: bool = True,
+    tile_mn: Optional[Tuple[int, int]] = None,
     skip_checks: bool = False,
     return_lse: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
@@ -1860,9 +1994,11 @@ def flash_gated_attn_varlen_with_kvcache_func(
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param seqused_k: Optional tensor indicating the actual sequence lengths for keys/values.
     :param gather_kv_indices: Optional TopK gather indices with shape [batch_size, topk_seqlen_k]. Each non-negative entry is a batch-local KV sequence position to gather for decode, negative entries are masked out.
+    :param num_splits: Optional split count for decode. If omitted, gather decode uses 1 split and regular decode uses a heuristic.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads_q, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads_q].
-    :param is_autotune: Force re-run Triton autotuner and overwrite cache. Default False uses cached config.
+    :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
+    :param tile_mn: Tuple of (TILE_M, TILE_N) for launch when is_autotune is False.
     :param skip_checks: Whether to skip input validation checks for faster performance.
     :param return_lse: Whether to return the logsumexp tensor for numerical stability analysis. If True, returns a tuple (out, lse). If False, returns only out.
 
@@ -1900,9 +2036,11 @@ def flash_gated_attn_varlen_with_kvcache_func(
         is_quant=is_quant,
         seqused_k=seqused_k,
         gather_kv_indices=gather_kv_indices,
+        num_splits=num_splits,
         out=out,
         lse=lse,
         is_autotune=is_autotune,
+        tile_mn=tile_mn,
         skip_checks=skip_checks,
     )
 

--- a/tests/benchmark_backward.py
+++ b/tests/benchmark_backward.py
@@ -43,7 +43,7 @@ def benchmark_triton_dense_backward(
         v,
         is_causal=cfg.is_causal,
         softmax_scale=softmax_scale,
-        is_autotune=False,
+        is_autotune=True,
         skip_checks=True,
     )
     dout = torch.randn_like(out)
@@ -79,7 +79,7 @@ def benchmark_triton_dense_backward_quant(
         is_causal=cfg.is_causal,
         softmax_scale=softmax_scale,
         is_quant=True,
-        is_autotune=False,
+        is_autotune=True,
         skip_checks=True,
     )
     dout = torch.randn_like(out)
@@ -116,7 +116,7 @@ def benchmark_triton_sparse_backward(
         is_causal=cfg.is_causal,
         softmax_scale=softmax_scale,
         softmax_threshold=softmax_threshold,
-        is_autotune=False,
+        is_autotune=True,
         skip_checks=True,
     )
     dout = torch.randn_like(out)
@@ -154,7 +154,7 @@ def benchmark_triton_sparse_backward_quant(
         softmax_scale=softmax_scale,
         softmax_threshold=softmax_threshold,
         is_quant=True,
-        is_autotune=False,
+        is_autotune=True,
         skip_checks=True,
     )
     dout = torch.randn_like(out)
@@ -203,7 +203,7 @@ def benchmark_triton_gated_backward(
         gate_threshold=gate_threshold,
         is_logsigmoid_gate=False,
         is_adapt_gate=False,
-        is_autotune=False,
+        is_autotune=True,
         skip_checks=True,
     )
     dout = torch.randn_like(out)
@@ -255,7 +255,7 @@ def benchmark_triton_gated_backward_quant(
         is_logsigmoid_gate=False,
         is_adapt_gate=False,
         is_quant=True,
-        is_autotune=False,
+        is_autotune=True,
         skip_checks=True,
     )
     dout = torch.randn_like(out)

--- a/tests/benchmark_decode.py
+++ b/tests/benchmark_decode.py
@@ -127,7 +127,7 @@ def benchmark_triton_dense_decode(
             softmax_scale=softmax_scale,
             out=out,
             lse=lse,
-            is_autotune=False,
+            is_autotune=True,
             skip_checks=True,
         )
 
@@ -168,7 +168,7 @@ def benchmark_triton_dense_decode_quant(
             is_quant=True,
             out=out,
             lse=lse,
-            is_autotune=False,
+            is_autotune=True,
             skip_checks=True,
         )
 
@@ -202,7 +202,7 @@ def benchmark_triton_sparse_decode(
             softmax_threshold=softmax_threshold,
             out=out,
             lse=lse,
-            is_autotune=False,
+            is_autotune=True,
             skip_checks=True,
         )
 
@@ -244,7 +244,7 @@ def benchmark_triton_sparse_decode_quant(
             is_quant=True,
             out=out,
             lse=lse,
-            is_autotune=False,
+            is_autotune=True,
             skip_checks=True,
         )
 
@@ -287,7 +287,7 @@ def benchmark_triton_gated_decode(
             is_logsigmoid_gate=False,
             out=out,
             lse=lse,
-            is_autotune=False,
+            is_autotune=True,
             skip_checks=True,
         )
 
@@ -344,7 +344,7 @@ def benchmark_triton_gated_decode_quant(
             is_quant=True,
             out=out,
             lse=lse,
-            is_autotune=False,
+            is_autotune=True,
             skip_checks=True,
         )
 

--- a/tests/benchmark_forward.py
+++ b/tests/benchmark_forward.py
@@ -42,7 +42,7 @@ def benchmark_triton_dense_forward(
             v,
             is_causal=cfg.is_causal,
             softmax_scale=softmax_scale,
-            is_autotune=False,
+            is_autotune=True,
             skip_checks=True,
         )
 
@@ -77,7 +77,7 @@ def benchmark_triton_dense_forward_quant(
             key_scale=k_scale,
             value_scale=v_scale,
             is_quant=True,
-            is_autotune=False,
+            is_autotune=True,
             skip_checks=True,
         )
 
@@ -105,7 +105,7 @@ def benchmark_triton_sparse_forward(
             is_causal=cfg.is_causal,
             softmax_scale=softmax_scale,
             softmax_threshold=softmax_threshold,
-            is_autotune=False,
+            is_autotune=True,
             skip_checks=True,
         )
 
@@ -142,7 +142,7 @@ def benchmark_triton_sparse_forward_quant(
             key_scale=k_scale,
             value_scale=v_scale,
             is_quant=True,
-            is_autotune=False,
+            is_autotune=True,
             skip_checks=True,
         )
 
@@ -182,7 +182,7 @@ def benchmark_triton_gated_forward(
             gate_threshold=gate_threshold,
             is_logsigmoid_gate=False,
             is_adapt_gate=False,
-            is_autotune=False,
+            is_autotune=True,
             skip_checks=True,
         )
 
@@ -235,7 +235,7 @@ def benchmark_triton_gated_forward_quant(
             key_scale=k_scale,
             value_scale=v_scale,
             is_quant=True,
-            is_autotune=False,
+            is_autotune=True,
             skip_checks=True,
         )
 


### PR DESCRIPTION
## Summary

- make Triton APIs default to `is_autotune=True`, reusing cached JSON launch configs or autotuning and storing on cache miss
- expose `tile_mn` for manual launch when `is_autotune=False`, with fixed warp/stage/CTA defaults
- expose `num_splits` for train and decode APIs so callers can override split heuristics
- align benchmark calls with the new default autotune path

## Validation

- `python -m compileall -q flash_sparse_attn/ops/triton tests`
- `git diff --check -- flash_sparse_attn/ops/triton tests`

Closes #336