### PR TITLE
Support paged KV for Triton dense, sparse, and gated fwd/dec

### DIFF
--- a/flash_sparse_attn/ops/triton/assert_inputs.py
+++ b/flash_sparse_attn/ops/triton/assert_inputs.py
@@ -20,6 +20,8 @@ def assert_fwd_inputs(
     num_heads_q: int = None,
     num_heads_kv: int = None,
     head_dim: int = None,
+    page_size: Optional[int] = None,
+    tile_mn: Optional[tuple] = None,
     is_quant: bool = False,
     device: torch.device = None,
 ):
@@ -42,6 +44,8 @@ def assert_fwd_inputs(
     :param num_heads_q: Number of query heads
     :param num_heads_kv: Number of key/value heads
     :param head_dim: Head dimension
+    :param page_size: Optional paged KV page size
+    :param tile_mn: Optional launch tile size
     :param is_quant: Whether the inputs are quantized
     :param device: Device of the tensors
 
@@ -84,6 +88,12 @@ def assert_fwd_inputs(
     assert head_dim <= 512, (
         "head_dim must be less than or equal to 512 for efficient memory access"
     )
+    if page_size is not None:
+        assert page_size in [32, 64, 128, 256], (
+            "paged KV page_size must be one of 32, 64, 128, or 256"
+        )
+        if tile_mn is not None:
+            assert tile_mn[1] == page_size, "paged KV requires tile_mn[1] == page_size"
     if alpha is not None and delta is not None:
         assert device == alpha.device == delta.device, (
             "All inputs must be on the same device"
@@ -243,11 +253,15 @@ def assert_dec_inputs(
     window_sizes: Optional[torch.Tensor] = None,
     alpha: Optional[torch.Tensor] = None,
     delta: Optional[torch.Tensor] = None,
+    page_table: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
     cu_seqlens_k: Optional[torch.Tensor] = None,
     seqused_k: Optional[torch.Tensor] = None,
     num_heads_q: int = None,
     num_heads_kv: int = None,
     head_dim: int = None,
+    page_size: Optional[int] = None,
+    tile_mn: Optional[tuple] = None,
     is_quant: bool = False,
     device: torch.device = None,
 ):
@@ -263,11 +277,15 @@ def assert_dec_inputs(
     :param window_sizes: Optional window sizes tensor for local attention
     :param alpha: Alpha tensor for gated attention
     :param delta: Delta tensor for gated attention
+    :param page_table: Optional paged KV table
+    :param gather_kv_indices: Optional TopK gather indices
     :param cu_seqlens_k: Cumulative sequence lengths for keys
     :param seqused_k: Sequence used for keys
     :param num_heads_q: Number of query heads
     :param num_heads_kv: Number of key/value heads
     :param head_dim: Head dimension
+    :param page_size: Optional paged KV page size
+    :param tile_mn: Optional launch tile size
     :param is_quant: Whether the inputs are quantized
     :param device: Device of the tensors
 
@@ -309,6 +327,15 @@ def assert_dec_inputs(
     )
     assert head_dim <= 512, (
         "head_dim must be less than or equal to 512 for efficient memory access"
+    )
+    if page_size is not None:
+        assert page_size in [32, 64, 128, 256], (
+            "paged KV page_size must be one of 32, 64, 128, or 256"
+        )
+        if tile_mn is not None:
+            assert tile_mn[1] == page_size, "paged KV requires tile_mn[1] == page_size"
+    assert page_table is None or gather_kv_indices is None, (
+        "decode does not support gather_kv_indices with paged KV"
     )
     if alpha is not None and delta is not None:
         assert device == alpha.device == delta.device, (

--- a/flash_sparse_attn/ops/triton/autotuner.py
+++ b/flash_sparse_attn/ops/triton/autotuner.py
@@ -123,10 +123,11 @@ def get_fwd_dense_autotune_configs(tile_n=None):
     return configs
 
 
-def get_fwd_sparse_autotune_configs():
+def get_fwd_sparse_autotune_configs(tile_n=None):
     configs = []
+    tile_ns = [tile_n] if tile_n is not None else [32, 64, 128]
     for tile_m in [64, 128, 256]:
-        for tile_n in [32, 64, 128]:
+        for tile_n in tile_ns:
             for num_warps in [4, 8]:
                 for num_stages in [1, 2, 3]:
                     configs.append(
@@ -140,10 +141,11 @@ def get_fwd_sparse_autotune_configs():
     return configs
 
 
-def get_fwd_gated_autotune_configs():
+def get_fwd_gated_autotune_configs(tile_n=None):
     configs = []
+    tile_ns = [tile_n] if tile_n is not None else [32, 64, 128]
     for tile_m in [64, 128, 256]:
-        for tile_n in [32, 64, 128]:
+        for tile_n in tile_ns:
             for num_warps in [4, 8]:
                 for num_stages in [1, 2, 3]:
                     configs.append(
@@ -226,10 +228,11 @@ def get_dec_dense_autotune_configs(tile_n=None):
     return configs
 
 
-def get_dec_sparse_autotune_configs():
+def get_dec_sparse_autotune_configs(tile_n=None):
     configs = []
+    tile_ns = [tile_n] if tile_n is not None else [64, 128, 256]
     for tile_m in [16, 32, 64]:
-        for tile_n in [64, 128, 256]:
+        for tile_n in tile_ns:
             for num_warps in [4, 8]:
                 for num_stages in [1, 2, 3]:
                     configs.append(
@@ -243,10 +246,11 @@ def get_dec_sparse_autotune_configs():
     return configs
 
 
-def get_dec_gated_autotune_configs():
+def get_dec_gated_autotune_configs(tile_n=None):
     configs = []
+    tile_ns = [tile_n] if tile_n is not None else [64, 128, 256]
     for tile_m in [16, 32, 64]:
-        for tile_n in [64, 128, 256]:
+        for tile_n in tile_ns:
             for num_warps in [4, 8]:
                 for num_stages in [1, 2, 3]:
                     configs.append(
@@ -269,8 +273,8 @@ def make_fwd_dense_autotuned_kernel(jit_kernel, tile_n=None):
     )(jit_kernel)
 
 
-def make_fwd_sparse_autotuned_kernel(jit_kernel):
-    configs = get_fwd_sparse_autotune_configs()
+def make_fwd_sparse_autotuned_kernel(jit_kernel, tile_n=None):
+    configs = get_fwd_sparse_autotune_configs(tile_n=tile_n)
     return triton.autotune(
         configs=configs,
         key=["SEQLEN_Q_CACHE", "SEQLEN_K_CACHE", "TILE_K", "IS_CAUSAL", "IS_LOCAL"],
@@ -278,8 +282,8 @@ def make_fwd_sparse_autotuned_kernel(jit_kernel):
     )(jit_kernel)
 
 
-def make_fwd_gated_autotuned_kernel(jit_kernel):
-    configs = get_fwd_gated_autotune_configs()
+def make_fwd_gated_autotuned_kernel(jit_kernel, tile_n=None):
+    configs = get_fwd_gated_autotune_configs(tile_n=tile_n)
     return triton.autotune(
         configs=configs,
         key=["SEQLEN_Q_CACHE", "SEQLEN_K_CACHE", "TILE_K", "IS_CAUSAL", "IS_LOCAL"],
@@ -323,8 +327,8 @@ def make_dec_dense_autotuned_kernel(jit_kernel, tile_n=None):
     )(jit_kernel)
 
 
-def make_dec_sparse_autotuned_kernel(jit_kernel):
-    configs = get_dec_sparse_autotune_configs()
+def make_dec_sparse_autotuned_kernel(jit_kernel, tile_n=None):
+    configs = get_dec_sparse_autotune_configs(tile_n=tile_n)
     return triton.autotune(
         configs=configs,
         key=["SEQLEN_Q_CACHE", "SEQLEN_K_CACHE", "TILE_K", "IS_LOCAL"],
@@ -332,8 +336,8 @@ def make_dec_sparse_autotuned_kernel(jit_kernel):
     )(jit_kernel)
 
 
-def make_dec_gated_autotuned_kernel(jit_kernel):
-    configs = get_dec_gated_autotune_configs()
+def make_dec_gated_autotuned_kernel(jit_kernel, tile_n=None):
+    configs = get_dec_gated_autotune_configs(tile_n=tile_n)
     return triton.autotune(
         configs=configs,
         key=["SEQLEN_Q_CACHE", "SEQLEN_K_CACHE", "TILE_K", "IS_LOCAL"],

--- a/flash_sparse_attn/ops/triton/autotuner.py
+++ b/flash_sparse_attn/ops/triton/autotuner.py
@@ -105,10 +105,11 @@ def _prune_dec_configs(configs, named_args, **kwargs):
     return pruned
 
 
-def get_fwd_dense_autotune_configs():
+def get_fwd_dense_autotune_configs(tile_n=None):
     configs = []
+    tile_ns = [tile_n] if tile_n is not None else [32, 64, 128]
     for tile_m in [64, 128, 256]:
-        for tile_n in [32, 64, 128]:
+        for tile_n in tile_ns:
             for num_warps in [4, 8]:
                 for num_stages in [1, 2, 3]:
                     configs.append(
@@ -207,10 +208,11 @@ def get_bwd_gated_autotune_configs():
     return configs
 
 
-def get_dec_dense_autotune_configs():
+def get_dec_dense_autotune_configs(tile_n=None):
     configs = []
+    tile_ns = [tile_n] if tile_n is not None else [64, 128, 256]
     for tile_m in [16, 32, 64]:
-        for tile_n in [64, 128, 256]:
+        for tile_n in tile_ns:
             for num_warps in [4, 8]:
                 for num_stages in [1, 2, 3]:
                     configs.append(
@@ -258,8 +260,8 @@ def get_dec_gated_autotune_configs():
     return configs
 
 
-def make_fwd_dense_autotuned_kernel(jit_kernel):
-    configs = get_fwd_dense_autotune_configs()
+def make_fwd_dense_autotuned_kernel(jit_kernel, tile_n=None):
+    configs = get_fwd_dense_autotune_configs(tile_n=tile_n)
     return triton.autotune(
         configs=configs,
         key=["SEQLEN_Q_CACHE", "SEQLEN_K_CACHE", "TILE_K", "IS_CAUSAL", "IS_LOCAL"],
@@ -312,8 +314,8 @@ def make_bwd_gated_autotuned_kernel(jit_kernel):
     )(jit_kernel)
 
 
-def make_dec_dense_autotuned_kernel(jit_kernel):
-    configs = get_dec_dense_autotune_configs()
+def make_dec_dense_autotuned_kernel(jit_kernel, tile_n=None):
+    configs = get_dec_dense_autotune_configs(tile_n=tile_n)
     return triton.autotune(
         configs=configs,
         key=["SEQLEN_Q_CACHE", "SEQLEN_K_CACHE", "TILE_K", "IS_LOCAL"],

--- a/flash_sparse_attn/ops/triton/flash_dense_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_dec.py
@@ -44,7 +44,6 @@ def _dec_inner_dense_kernel(
     MASK_LOCAL: tl.constexpr,
     MASK_SINK: tl.constexpr,
     CHECK_INF: tl.constexpr,
-    HAS_GATHER_KV: tl.constexpr,
 ):
     next_topk_indices = topk_indices
 
@@ -53,20 +52,14 @@ def _dec_inner_dense_kernel(
 
     # Prefetch next key tile
     if n_block > n_block_min:
-        if HAS_GATHER_KV:
+        if config.IS_GATHER_KV:
             # Load next topk indices
             next_topk_indices = ptrs_sched.load_topk_indices(config, n_block - 1)
 
         # Load next key tile
-        k_tile = ptrs_sched.load_k(
-            config,
-            k_ptrs,
-            n_block - 1,
-            next_topk_indices,
-            HAS_GATHER_KV=HAS_GATHER_KV,
-        )
+        k_tile = ptrs_sched.load_k(config, k_ptrs, n_block - 1, next_topk_indices)
 
-    if HAS_GATHER_KV:
+    if config.IS_GATHER_KV:
         # Apply mask to attention scores
         acc_s = ptrs_sched.apply_gather_mask(
             config,
@@ -92,9 +85,7 @@ def _dec_inner_dense_kernel(
     )
 
     # Load value tile
-    v_tile = ptrs_sched.load_v(
-        config, v_ptrs, n_block, topk_indices, HAS_GATHER_KV=HAS_GATHER_KV
-    )
+    v_tile = ptrs_sched.load_v(config, v_ptrs, n_block, topk_indices)
 
     # Rescale output accumulator
     acc_o = softmax_sched.rescale_o(
@@ -120,6 +111,7 @@ def _dec_dense_kernel(
     key_scale,
     value_scale,
     window_sizes,
+    page_table,
     gather_kv_indices,
     stride_qb,
     stride_qh,
@@ -139,6 +131,7 @@ def _dec_dense_kernel(
     stride_lm,
     stride_ls,
     stride_wh,
+    stride_pb,
     stride_gb,
     stride_gn,
     cu_seqlens_q,
@@ -158,7 +151,8 @@ def _dec_dense_kernel(
     topk_seqlen_k: tl.constexpr,
     IS_LOCAL: tl.constexpr,
     IS_QUANT: tl.constexpr,
-    HAS_GATHER_KV: tl.constexpr,
+    IS_PAGED_KV: tl.constexpr,
+    IS_GATHER_KV: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
     HAS_CU_SEQLENS_K: tl.constexpr,
     HAS_SEQUSED_Q: tl.constexpr,
@@ -204,6 +198,8 @@ def _dec_dense_kernel(
         TILE_N=TILE_N,
         TILE_K=TILE_K,
         IS_QUANT=IS_QUANT,
+        IS_PAGED_KV=IS_PAGED_KV,
+        IS_GATHER_KV=IS_GATHER_KV,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
         HAS_SEQUSED_Q=HAS_SEQUSED_Q,
@@ -216,6 +212,7 @@ def _dec_dense_kernel(
         Q=Q,
         K=K,
         V=V,
+        PageTable=page_table,
         GatherKVIndices=gather_kv_indices,
         Out=Out,
         Lse=Lse,
@@ -240,9 +237,10 @@ def _dec_dense_kernel(
         stride_lh=stride_lh,
         stride_lm=stride_lm,
         stride_ls=stride_ls,
+        stride_pb=stride_pb,
         stride_gb=stride_gb,
         stride_gn=stride_gn,
-        HAS_GATHER_KV=HAS_GATHER_KV,
+        IS_PAGED_KV=IS_PAGED_KV,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
     )
@@ -254,7 +252,7 @@ def _dec_dense_kernel(
         num_splits=num_splits,
         topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=IS_LOCAL,
-        HAS_GATHER_KV=HAS_GATHER_KV,
+        IS_GATHER_KV=IS_GATHER_KV,
     )
 
     # Create mask scheduler
@@ -287,17 +285,13 @@ def _dec_dense_kernel(
     # Load query tile
     q_tile = ptrs_sched.load_q(config, q_ptrs)
 
-    if HAS_GATHER_KV:
+    if IS_GATHER_KV:
         # Load topk indices
         topk_indices = ptrs_sched.load_topk_indices(config, block_sched.n_block_max - 1)
 
     # Load key tile
     k_tile = ptrs_sched.load_k(
-        config,
-        k_ptrs,
-        block_sched.n_block_max - 1,
-        topk_indices,
-        HAS_GATHER_KV=HAS_GATHER_KV,
+        config, k_ptrs, block_sched.n_block_max - 1, topk_indices
     )
 
     # Process n_blocks with seqlen masking
@@ -323,14 +317,13 @@ def _dec_dense_kernel(
             MASK_LOCAL=True if IS_LOCAL else False,
             MASK_SINK=False,
             CHECK_INF=True,
-            HAS_GATHER_KV=HAS_GATHER_KV,
         )
 
     # Process n_blocks without masking
     if (
-        not IS_LOCAL or HAS_GATHER_KV
+        not IS_LOCAL or IS_GATHER_KV
     ) and block_sched.n_block_max_no_mask > block_sched.n_block_min:
-        if HAS_GATHER_KV:
+        if IS_GATHER_KV:
             # Load topk indices
             topk_indices = ptrs_sched.load_topk_indices(
                 config,
@@ -339,11 +332,7 @@ def _dec_dense_kernel(
 
         # Load key tile
         k_tile = ptrs_sched.load_k(
-            config,
-            k_ptrs,
-            block_sched.n_block_max_no_mask - 1,
-            topk_indices,
-            HAS_GATHER_KV=HAS_GATHER_KV,
+            config, k_ptrs, block_sched.n_block_max_no_mask - 1, topk_indices
         )
 
         for n_block in tl.range(
@@ -367,11 +356,10 @@ def _dec_dense_kernel(
                 IS_MASK=False,
                 MASK_LOCAL=False,
                 MASK_SINK=False,
-                CHECK_INF=True if HAS_GATHER_KV else False,
-                HAS_GATHER_KV=HAS_GATHER_KV,
+                CHECK_INF=True if IS_GATHER_KV else False,
             )
 
-    if IS_LOCAL and not HAS_GATHER_KV:
+    if IS_LOCAL and not IS_GATHER_KV:
         # Process n_blocks with local right masking
         if block_sched.n_block_window_max > block_sched.n_block_window_max_no_mask:
             # Load key tile
@@ -403,7 +391,6 @@ def _dec_dense_kernel(
                     MASK_LOCAL=True,
                     MASK_SINK=False,
                     CHECK_INF=True,
-                    HAS_GATHER_KV=False,
                 )
 
         # Process n_blocks without masking
@@ -440,7 +427,6 @@ def _dec_dense_kernel(
                     MASK_LOCAL=False,
                     MASK_SINK=False,
                     CHECK_INF=False,
-                    HAS_GATHER_KV=False,
                 )
 
         # Process n_blocks with local left masking
@@ -474,7 +460,6 @@ def _dec_dense_kernel(
                     MASK_LOCAL=True,
                     MASK_SINK=False,
                     CHECK_INF=True,
-                    HAS_GATHER_KV=False,
                 )
 
         # Process n_blocks with local sink masking
@@ -506,7 +491,6 @@ def _dec_dense_kernel(
                     MASK_LOCAL=True,
                     MASK_SINK=True,
                     CHECK_INF=True,
-                    HAS_GATHER_KV=False,
                 )
 
     # Finalize softmax
@@ -532,16 +516,16 @@ def _dec_dense_kernel(
 _dec_dense_kernel = cache_utils.wrap_kernel(_dec_dense_kernel)
 
 
-_dec_dense_autotuned_kernel = None
+_dec_dense_autotuned_kernel = {}
 
 
-def _get_autotuned_kernel():
+def _get_autotuned_kernel(tile_n=None):
     global _dec_dense_autotuned_kernel
-    if _dec_dense_autotuned_kernel is None:
+    if tile_n not in _dec_dense_autotuned_kernel:
         jit_kernel = _dec_dense_kernel._kernel
-        autotuned = autotuner.make_dec_dense_autotuned_kernel(jit_kernel)
-        _dec_dense_autotuned_kernel = autotuner.AutotunedKernel(autotuned)
-    return _dec_dense_autotuned_kernel
+        autotuned = autotuner.make_dec_dense_autotuned_kernel(jit_kernel, tile_n=tile_n)
+        _dec_dense_autotuned_kernel[tile_n] = autotuner.AutotunedKernel(autotuned)
+    return _dec_dense_autotuned_kernel[tile_n]
 
 
 def _flash_dense_attn_decode(
@@ -555,8 +539,10 @@ def _flash_dense_attn_decode(
     window_sizes: Optional[torch.Tensor] = None,
     is_local: bool = False,
     is_quant: bool = False,
-    gather_kv_indices: Optional[torch.Tensor] = None,
     num_splits: Optional[int] = None,
+    page_table: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = True,
@@ -566,10 +552,15 @@ def _flash_dense_attn_decode(
     device = query.device
     num_SMs = cache_utils.get_device_num_sms(device)
     batch_size, num_heads_q, head_dim = query.shape
-    _, seqlen_k, num_heads_kv, _ = key.shape
-    topk_seqlen_k = (
-        gather_kv_indices.shape[-1] if gather_kv_indices is not None else seqlen_k
-    )
+    if page_table is not None:
+        _, page_size, num_heads_kv, _ = key.shape
+        seqlen_k = page_table.shape[1] * page_size
+    else:
+        page_size = None
+        _, seqlen_k, num_heads_kv, _ = key.shape
+    is_paged_kv = page_table is not None
+    is_gather_kv = gather_kv_indices is not None and not is_paged_kv
+    topk_seqlen_k = gather_kv_indices.shape[-1] if is_gather_kv else seqlen_k
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
@@ -586,11 +577,15 @@ def _flash_dense_attn_decode(
             key_scale=key_scale,
             value_scale=value_scale,
             window_sizes=window_sizes,
+            page_table=page_table,
+            gather_kv_indices=gather_kv_indices,
             cu_seqlens_k=None,
-            seqused_k=None,
+            seqused_k=seqused_k,
             num_heads_q=num_heads_q,
             num_heads_kv=num_heads_kv,
             head_dim=head_dim,
+            page_size=page_size,
+            tile_mn=tile_mn,
             is_quant=is_quant,
             device=device,
         )
@@ -600,15 +595,23 @@ def _flash_dense_attn_decode(
     launch_config = None
     if not is_autotune:
         kernel = _dec_dense_kernel
-        TILE_M, TILE_N = tile_mn if tile_mn is not None else (16, 64)
+        TILE_M, TILE_N = (
+            tile_mn
+            if tile_mn is not None
+            else (
+                16,
+                page_size if page_table is not None else 64,
+            )
+        )
         num_warps, num_stages, num_ctas = 4, 1, 1
     else:
         launch_config = launch_template.load_launch_config(
             device=device,
             kernel_name="dec_dense",
             seqlen_q=1,
-            seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
+            seqlen_k=topk_seqlen_k if is_gather_kv else seqlen_k,
             tile_k=TILE_K,
+            tile_n=page_size if page_table is not None else None,
             is_local=is_local,
             qhead_per_kvhead=qhead_per_kvhead,
             is_quant=is_quant,
@@ -617,12 +620,14 @@ def _flash_dense_attn_decode(
             kernel = _dec_dense_kernel
             TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
         else:
-            kernel = _get_autotuned_kernel()
+            kernel = _get_autotuned_kernel(
+                page_size if page_table is not None else None
+            )
             TILE_M = max(triton.next_power_of_2(qhead_per_kvhead), 16)
-            TILE_N = 128
+            TILE_N = page_size if page_table is not None else 128
             num_warps = num_stages = num_ctas = None
 
-    if num_splits is None and gather_kv_indices is not None:
+    if num_splits is None and is_gather_kv:
         num_splits = 1
     elif num_splits is None:
         num_splits = utils.num_splits_heuristic(
@@ -680,6 +685,7 @@ def _flash_dense_attn_decode(
         key_scale,
         value_scale,
         window_sizes,
+        page_table,
         gather_kv_indices,
         query.stride(0),
         query.stride(-2),
@@ -699,12 +705,13 @@ def _flash_dense_attn_decode(
         1,
         lse_partial.stride(0),
         window_sizes.stride(0) if window_sizes is not None else 0,
+        page_table.stride(0) if page_table is not None else 0,
         gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
         gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
         None,
         None,
-        None,
+        seqused_k,
         num_splits,
         seqlen_q=1,
         seqlen_k=seqlen_k,
@@ -718,25 +725,29 @@ def _flash_dense_attn_decode(
         topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
         IS_QUANT=is_quant,
-        HAS_GATHER_KV=gather_kv_indices is not None,
+        IS_PAGED_KV=is_paged_kv,
+        IS_GATHER_KV=is_gather_kv,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
         HAS_SEQUSED_Q=False,
-        HAS_SEQUSED_K=False,
+        HAS_SEQUSED_K=seqused_k is not None,
         num_warps=num_warps,
         num_stages=num_stages,
         num_ctas=num_ctas,
     )
 
     if is_autotune and launch_config is None:
-        best = launch_template.extract_best_config(_get_autotuned_kernel())
+        best = launch_template.extract_best_config(
+            _get_autotuned_kernel(page_size if page_table is not None else None)
+        )
         if best is not None:
             launch_template.store_launch_config(
                 device=device,
                 kernel_name="dec_dense",
                 seqlen_q=1,
-                seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
+                seqlen_k=topk_seqlen_k if is_gather_kv else seqlen_k,
                 tile_k=TILE_K,
+                tile_n=page_size if page_table is not None else None,
                 config=best,
                 is_local=is_local,
                 qhead_per_kvhead=qhead_per_kvhead,
@@ -822,6 +833,7 @@ def _flash_dense_attn_varlen_decode(
             seqlen_q=1,
             seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
             tile_k=TILE_K,
+            tile_n=None,
             is_local=is_local,
             qhead_per_kvhead=qhead_per_kvhead,
             is_quant=is_quant,
@@ -893,6 +905,7 @@ def _flash_dense_attn_varlen_decode(
         key_scale,
         value_scale,
         window_sizes,
+        None,
         gather_kv_indices,
         query.stride(0),
         query.stride(-2),
@@ -912,6 +925,7 @@ def _flash_dense_attn_varlen_decode(
         1,
         lse_partial.stride(0),
         window_sizes.stride(0) if window_sizes is not None else 0,
+        0,
         gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
         gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
@@ -931,7 +945,8 @@ def _flash_dense_attn_varlen_decode(
         topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
         IS_QUANT=is_quant,
-        HAS_GATHER_KV=gather_kv_indices is not None,
+        IS_PAGED_KV=False,
+        IS_GATHER_KV=gather_kv_indices is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=True,
         HAS_SEQUSED_Q=False,
@@ -950,6 +965,7 @@ def _flash_dense_attn_varlen_decode(
                 seqlen_q=1,
                 seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
                 tile_k=TILE_K,
+                tile_n=None,
                 config=best,
                 is_local=is_local,
                 qhead_per_kvhead=qhead_per_kvhead,

--- a/flash_sparse_attn/ops/triton/flash_dense_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_dense_fwd.py
@@ -98,6 +98,7 @@ def _fwd_dense_kernel(
     key_scale,
     value_scale,
     window_sizes,
+    page_table,
     stride_qb,
     stride_qh,
     stride_qm,
@@ -115,6 +116,7 @@ def _fwd_dense_kernel(
     stride_lh,
     stride_ls,
     stride_wh,
+    stride_pb,
     cu_seqlens_q,
     cu_seqlens_k,
     seqused_q,
@@ -135,6 +137,7 @@ def _fwd_dense_kernel(
     IS_LOCAL: tl.constexpr,
     IS_QUANT: tl.constexpr,
     IS_SPLIT_KV: tl.constexpr,
+    IS_PAGED_KV: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
     HAS_CU_SEQLENS_K: tl.constexpr,
     HAS_SEQUSED_Q: tl.constexpr,
@@ -186,6 +189,7 @@ def _fwd_dense_kernel(
         TILE_K=TILE_K,
         IS_CAUSAL=IS_CAUSAL,
         IS_QUANT=IS_QUANT,
+        IS_PAGED_KV=IS_PAGED_KV,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
         HAS_SEQUSED_Q=HAS_SEQUSED_Q,
@@ -198,6 +202,7 @@ def _fwd_dense_kernel(
         Q=Q,
         K=K,
         V=V,
+        PageTable=page_table,
         Out=Out,
         Lse=Lse,
         batch_idx=grid_idx.batch_idx,
@@ -220,7 +225,9 @@ def _fwd_dense_kernel(
         stride_lb=stride_lb,
         stride_lh=stride_lh,
         stride_ls=stride_ls,
+        stride_pb=stride_pb,
         IS_SPLIT_KV=IS_SPLIT_KV,
+        IS_PAGED_KV=IS_PAGED_KV,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
     )
@@ -505,16 +512,16 @@ def _fwd_dense_kernel(
 _fwd_dense_kernel = cache_utils.wrap_kernel(_fwd_dense_kernel)
 
 
-_fwd_dense_kernel_autotuned = None
+_fwd_dense_kernel_autotuned = {}
 
 
-def _get_autotuned_kernel():
+def _get_autotuned_kernel(tile_n=None):
     global _fwd_dense_kernel_autotuned
-    if _fwd_dense_kernel_autotuned is None:
+    if tile_n not in _fwd_dense_kernel_autotuned:
         jit_kernel = _fwd_dense_kernel._kernel
-        autotuned = autotuner.make_fwd_dense_autotuned_kernel(jit_kernel)
-        _fwd_dense_kernel_autotuned = autotuner.AutotunedKernel(autotuned)
-    return _fwd_dense_kernel_autotuned
+        autotuned = autotuner.make_fwd_dense_autotuned_kernel(jit_kernel, tile_n=tile_n)
+        _fwd_dense_kernel_autotuned[tile_n] = autotuner.AutotunedKernel(autotuned)
+    return _fwd_dense_kernel_autotuned[tile_n]
 
 
 def _flash_dense_attn_forward(
@@ -532,6 +539,8 @@ def _flash_dense_attn_forward(
     is_split_kv: bool = False,
     pack_gqa: bool = False,
     num_splits: Optional[int] = None,
+    page_table: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = True,
@@ -541,7 +550,12 @@ def _flash_dense_attn_forward(
     device = query.device
     num_SMs = cache_utils.get_device_num_sms(device)
     batch_size, seqlen_q, num_heads_q, head_dim = query.shape
-    _, seqlen_k, num_heads_kv, _ = key.shape
+    if page_table is not None:
+        _, page_size, num_heads_kv, _ = key.shape
+        seqlen_k = page_table.shape[1] * page_size
+    else:
+        page_size = None
+        _, seqlen_k, num_heads_kv, _ = key.shape
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
@@ -562,10 +576,12 @@ def _flash_dense_attn_forward(
             cu_seqlens_q=None,
             cu_seqlens_k=None,
             seqused_q=None,
-            seqused_k=None,
+            seqused_k=seqused_k,
             num_heads_q=num_heads_q,
             num_heads_kv=num_heads_kv,
             head_dim=head_dim,
+            page_size=page_size,
+            tile_mn=tile_mn,
             is_quant=is_quant,
             device=device,
         )
@@ -576,7 +592,14 @@ def _flash_dense_attn_forward(
     launch_config = None
     if not is_autotune:
         kernel = _fwd_dense_kernel
-        TILE_M, TILE_N = tile_mn if tile_mn is not None else (64, 64)
+        TILE_M, TILE_N = (
+            tile_mn
+            if tile_mn is not None
+            else (
+                64,
+                page_size if page_table is not None else 64,
+            )
+        )
         num_warps, num_stages, num_ctas = 4, 1, 1
     else:
         launch_config = launch_template.load_launch_config(
@@ -585,6 +608,7 @@ def _flash_dense_attn_forward(
             seqlen_q=seqlen_q,
             seqlen_k=seqlen_k,
             tile_k=TILE_K,
+            tile_n=page_size if page_table is not None else None,
             is_local=is_local,
             qhead_per_kvhead=qhead_per_kvhead,
             is_causal=is_causal,
@@ -595,9 +619,12 @@ def _flash_dense_attn_forward(
             kernel = _fwd_dense_kernel
             TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
         else:
-            kernel = _get_autotuned_kernel()
+            kernel = _get_autotuned_kernel(
+                page_size if page_table is not None else None
+            )
             # Placeholder for pre-launch computations
-            TILE_M = TILE_N = 64
+            TILE_M = 64
+            TILE_N = page_size if page_table is not None else 64
             num_warps = num_stages = num_ctas = None
 
     if is_split_kv and num_splits is None:
@@ -662,6 +689,7 @@ def _flash_dense_attn_forward(
         key_scale,
         value_scale,
         window_sizes,
+        page_table,
         query.stride(0),
         query.stride(-2),
         query.stride(-3),
@@ -679,10 +707,11 @@ def _flash_dense_attn_forward(
         lse.stride(-2) if not is_split_kv else lse_partial.stride(-2),
         0 if not is_split_kv else lse_partial.stride(0),
         window_sizes.stride(0) if window_sizes is not None else 0,
+        page_table.stride(0) if page_table is not None else 0,
         None,
         None,
         None,
-        None,
+        seqused_k,
         num_splits,
         seqlen_q=seqlen_q,
         seqlen_k=seqlen_k,
@@ -699,17 +728,20 @@ def _flash_dense_attn_forward(
         IS_LOCAL=is_local,
         IS_QUANT=is_quant,
         IS_SPLIT_KV=is_split_kv,
+        IS_PAGED_KV=page_table is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
         HAS_SEQUSED_Q=False,
-        HAS_SEQUSED_K=False,
+        HAS_SEQUSED_K=seqused_k is not None,
         num_warps=num_warps,
         num_stages=num_stages,
         num_ctas=num_ctas,
     )
 
     if is_autotune and launch_config is None:
-        best = launch_template.extract_best_config(_get_autotuned_kernel())
+        best = launch_template.extract_best_config(
+            _get_autotuned_kernel(page_size if page_table is not None else None)
+        )
         if best is not None:
             launch_template.store_launch_config(
                 device=device,
@@ -717,6 +749,7 @@ def _flash_dense_attn_forward(
                 seqlen_q=seqlen_q,
                 seqlen_k=seqlen_k,
                 tile_k=TILE_K,
+                tile_n=page_size if page_table is not None else None,
                 config=best,
                 is_local=is_local,
                 qhead_per_kvhead=qhead_per_kvhead,
@@ -813,6 +846,7 @@ def _flash_dense_attn_varlen_forward(
             seqlen_q=seqlen_q,
             seqlen_k=seqlen_k,
             tile_k=TILE_K,
+            tile_n=None,
             is_local=is_local,
             qhead_per_kvhead=qhead_per_kvhead,
             is_causal=is_causal,
@@ -886,6 +920,7 @@ def _flash_dense_attn_varlen_forward(
         key_scale,
         value_scale,
         window_sizes,
+        None,
         0,
         query.stride(-2),
         query.stride(0),
@@ -903,6 +938,7 @@ def _flash_dense_attn_varlen_forward(
         lse.stride(-2) if not is_split_kv else lse_partial.stride(-2),
         0 if not is_split_kv else lse_partial.stride(0),
         window_sizes.stride(0) if window_sizes is not None else 0,
+        0,
         cu_seqlens_q,
         cu_seqlens_k,
         seqused_q,
@@ -923,6 +959,7 @@ def _flash_dense_attn_varlen_forward(
         IS_LOCAL=is_local,
         IS_QUANT=is_quant,
         IS_SPLIT_KV=is_split_kv,
+        IS_PAGED_KV=False,
         HAS_CU_SEQLENS_Q=True,
         HAS_CU_SEQLENS_K=True,
         HAS_SEQUSED_Q=seqused_q is not None,
@@ -941,6 +978,7 @@ def _flash_dense_attn_varlen_forward(
                 seqlen_q=seqlen_q,
                 seqlen_k=seqlen_k,
                 tile_k=TILE_K,
+                tile_n=None,
                 config=best,
                 is_local=is_local,
                 qhead_per_kvhead=qhead_per_kvhead,

--- a/flash_sparse_attn/ops/triton/flash_fwd_combine.py
+++ b/flash_sparse_attn/ops/triton/flash_fwd_combine.py
@@ -45,6 +45,7 @@ def _fwd_combine_kernel(
     bh_idx = tl.program_id(1)
     batch_idx = bh_idx // num_heads_q
     head_idx = bh_idx - batch_idx * num_heads_q
+    offs_m = m_block * TILE_M + tl.arange(0, TILE_M)
 
     # Get seqlen info for this batch
     offset_q, actual_seqlen_q = seqlen_info.get_seqlen_info(
@@ -105,24 +106,14 @@ def _fwd_combine_kernel(
         strides=[stride_ops, stride_opm, 1],
         block_shape=[1, TILE_M, TILE_K],
     )
-    lse_part_desc = tl.make_tensor_descriptor(
-        base=lse_part_base,
-        shape=[num_splits, actual_seqlen_q],
-        strides=[stride_lps, 1],
-        block_shape=[1, TILE_M],
-    )
     out_desc = tl.make_tensor_descriptor(
         base=out_base,
         shape=[actual_seqlen_q, head_dim],
         strides=[stride_om, 1],
         block_shape=[TILE_M, TILE_K],
     )
-    lse_desc = tl.make_tensor_descriptor(
-        base=lse_base,
-        shape=[actual_seqlen_q],
-        strides=[1],
-        block_shape=[TILE_M],
-    )
+    lse_part_ptrs = lse_part_base + offs_m
+    lse_ptrs = lse_base + offs_m
 
     # Initialize accumulators
     e_sum = tl.zeros((TILE_M,), dtype=tl.float32)
@@ -132,7 +123,11 @@ def _fwd_combine_kernel(
     # Combine split outputs
     for s in tl.range(0, num_splits):
         # Load partial LSE
-        lse_s = tl.sum(lse_part_desc.load([s, m_block * TILE_M]), axis=0)
+        lse_s = tl.load(
+            lse_part_ptrs + s * stride_lps,
+            mask=offs_m < actual_seqlen_q,
+            other=float("-inf"),
+        )
 
         # Compute normalized exponentials
         new_e_max = tl.maximum(lse_s, e_max)
@@ -163,7 +158,7 @@ def _fwd_combine_kernel(
     lse = tl.where(e_sum > 0.0, (e_max + tl.log2(e_sum)) * ln2, float("-inf"))
 
     # Store LSE
-    lse_desc.store([m_block * TILE_M], lse)
+    tl.store(lse_ptrs, lse, mask=offs_m < actual_seqlen_q)
 
 
 _fwd_combine_kernel = cache_utils.wrap_kernel(_fwd_combine_kernel)

--- a/flash_sparse_attn/ops/triton/flash_gated_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_dec.py
@@ -50,12 +50,11 @@ def _dec_inner_gated_kernel(
     MASK_LOCAL: tl.constexpr,
     MASK_SINK: tl.constexpr,
     CHECK_INF: tl.constexpr,
-    HAS_GATHER_KV: tl.constexpr,
 ):
     next_topk_indices = topk_indices
     skip_gate_next = True
     if not skip_gate_curr:
-        if HAS_GATHER_KV:
+        if config.IS_GATHER_KV:
             # Apply mask to attention scores
             acc_s = ptrs_sched.apply_gather_mask(
                 config,
@@ -85,9 +84,7 @@ def _dec_inner_gated_kernel(
 
         if not skip_softmax:
             # Load value tile
-            v_tile = ptrs_sched.load_v(
-                config, v_ptrs, n_block, topk_indices, HAS_GATHER_KV=HAS_GATHER_KV
-            )
+            v_tile = ptrs_sched.load_v(config, v_ptrs, n_block, topk_indices)
 
             # Rescale output accumulator
             acc_o = softmax_sched.rescale_o(
@@ -99,18 +96,12 @@ def _dec_inner_gated_kernel(
             acc_o += tl.dot(p.to(v_tile.dtype), v_tile)
 
     if n_block > n_block_min:
-        if HAS_GATHER_KV:
+        if config.IS_GATHER_KV:
             # Load next topk indices
             next_topk_indices = ptrs_sched.load_topk_indices(config, n_block - 1)
 
         # Load next delta tile
-        d_tile = ptrs_sched.load_d(
-            config,
-            d_ptrs,
-            n_block - 1,
-            next_topk_indices,
-            HAS_GATHER_KV=HAS_GATHER_KV,
-        )
+        d_tile = ptrs_sched.load_d(config, d_ptrs, n_block - 1, next_topk_indices)
         d_max = tl.max(d_tile)
         d_min = tl.min(d_tile)
 
@@ -133,13 +124,7 @@ def _dec_inner_gated_kernel(
                 )
 
             # Load next key tile
-            k_tile = ptrs_sched.load_k(
-                config,
-                k_ptrs,
-                n_block - 1,
-                next_topk_indices,
-                HAS_GATHER_KV=HAS_GATHER_KV,
-            )
+            k_tile = ptrs_sched.load_k(config, k_ptrs, n_block - 1, next_topk_indices)
 
             # Compute attention scores for next tile
             acc_s += tl.dot(q_tile, k_tile.T)
@@ -171,6 +156,7 @@ def _dec_gated_kernel(
     softmax_threshold,
     gate_threshold,
     window_sizes,
+    page_table,
     gather_kv_indices,
     stride_qb,
     stride_qh,
@@ -194,6 +180,7 @@ def _dec_gated_kernel(
     stride_lm,
     stride_ls,
     stride_wh,
+    stride_pb,
     stride_gb,
     stride_gn,
     cu_seqlens_q,
@@ -213,7 +200,8 @@ def _dec_gated_kernel(
     topk_seqlen_k: tl.constexpr,
     IS_LOCAL: tl.constexpr,
     IS_QUANT: tl.constexpr,
-    HAS_GATHER_KV: tl.constexpr,
+    IS_PAGED_KV: tl.constexpr,
+    IS_GATHER_KV: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
     HAS_CU_SEQLENS_K: tl.constexpr,
     HAS_SEQUSED_Q: tl.constexpr,
@@ -262,6 +250,8 @@ def _dec_gated_kernel(
         TILE_N=TILE_N,
         TILE_K=TILE_K,
         IS_QUANT=IS_QUANT,
+        IS_PAGED_KV=IS_PAGED_KV,
+        IS_GATHER_KV=IS_GATHER_KV,
         IS_LOGSIGMOID_GATE=IS_LOGSIGMOID_GATE,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
@@ -277,6 +267,7 @@ def _dec_gated_kernel(
         V=V,
         A=A,
         D=D,
+        PageTable=page_table,
         GatherKVIndices=gather_kv_indices,
         Out=Out,
         Lse=Lse,
@@ -305,10 +296,11 @@ def _dec_gated_kernel(
         stride_lh=stride_lh,
         stride_lm=stride_lm,
         stride_ls=stride_ls,
+        stride_pb=stride_pb,
         stride_gb=stride_gb,
         stride_gn=stride_gn,
+        IS_PAGED_KV=IS_PAGED_KV,
         IS_GATED=True,
-        HAS_GATHER_KV=HAS_GATHER_KV,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
     )
@@ -320,7 +312,7 @@ def _dec_gated_kernel(
         num_splits=num_splits,
         topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=IS_LOCAL,
-        HAS_GATHER_KV=HAS_GATHER_KV,
+        IS_GATHER_KV=IS_GATHER_KV,
     )
 
     # Create mask scheduler
@@ -361,17 +353,13 @@ def _dec_gated_kernel(
     a_max = tl.max(a_tile)
     a_min = tl.min(a_tile)
 
-    if HAS_GATHER_KV:
+    if IS_GATHER_KV:
         # Load topk indices
         topk_indices = ptrs_sched.load_topk_indices(config, block_sched.n_block_max - 1)
 
     # Load delta tile
     d_tile = ptrs_sched.load_d(
-        config,
-        d_ptrs,
-        block_sched.n_block_max - 1,
-        topk_indices,
-        HAS_GATHER_KV=HAS_GATHER_KV,
+        config, d_ptrs, block_sched.n_block_max - 1, topk_indices
     )
     d_max = tl.max(d_tile)
     d_min = tl.min(d_tile)
@@ -398,11 +386,7 @@ def _dec_gated_kernel(
 
     # Load key tile
     k_tile = ptrs_sched.load_k(
-        config,
-        k_ptrs,
-        block_sched.n_block_max - 1,
-        topk_indices,
-        HAS_GATHER_KV=HAS_GATHER_KV,
+        config, k_ptrs, block_sched.n_block_max - 1, topk_indices
     )
 
     # Compute attention scores for first tile
@@ -445,14 +429,13 @@ def _dec_gated_kernel(
             MASK_LOCAL=True if IS_LOCAL else False,
             MASK_SINK=False,
             CHECK_INF=True,
-            HAS_GATHER_KV=HAS_GATHER_KV,
         )
 
     # Process n_blocks without masking
     if (
-        not IS_LOCAL or HAS_GATHER_KV
+        not IS_LOCAL or IS_GATHER_KV
     ) and block_sched.n_block_max_no_mask > block_sched.n_block_min:
-        if HAS_GATHER_KV:
+        if IS_GATHER_KV:
             # Load topk indices
             topk_indices = ptrs_sched.load_topk_indices(
                 config,
@@ -461,20 +444,12 @@ def _dec_gated_kernel(
 
         # Load key tile
         k_tile = ptrs_sched.load_k(
-            config,
-            k_ptrs,
-            block_sched.n_block_max_no_mask - 1,
-            topk_indices,
-            HAS_GATHER_KV=HAS_GATHER_KV,
+            config, k_ptrs, block_sched.n_block_max_no_mask - 1, topk_indices
         )
 
         # Load delta tile
         d_tile = ptrs_sched.load_d(
-            config,
-            d_ptrs,
-            block_sched.n_block_max_no_mask - 1,
-            topk_indices,
-            HAS_GATHER_KV=HAS_GATHER_KV,
+            config, d_ptrs, block_sched.n_block_max_no_mask - 1, topk_indices
         )
         d_max = tl.max(d_tile)
         d_min = tl.min(d_tile)
@@ -534,11 +509,10 @@ def _dec_gated_kernel(
                 IS_MASK=False,
                 MASK_LOCAL=False,
                 MASK_SINK=False,
-                CHECK_INF=True if HAS_GATHER_KV else False,
-                HAS_GATHER_KV=HAS_GATHER_KV,
+                CHECK_INF=True if IS_GATHER_KV else False,
             )
 
-    if IS_LOCAL and not HAS_GATHER_KV:
+    if IS_LOCAL and not IS_GATHER_KV:
         # Process n_blocks with local right masking
         if block_sched.n_block_window_max > block_sched.n_block_window_max_no_mask:
             # Load key tile
@@ -611,7 +585,6 @@ def _dec_gated_kernel(
                     MASK_LOCAL=True,
                     MASK_SINK=False,
                     CHECK_INF=True,
-                    HAS_GATHER_KV=False,
                 )
 
         # Process n_blocks without masking
@@ -689,7 +662,6 @@ def _dec_gated_kernel(
                     MASK_LOCAL=False,
                     MASK_SINK=False,
                     CHECK_INF=False,
-                    HAS_GATHER_KV=False,
                 )
 
         # Process n_blocks with local left masking
@@ -764,7 +736,6 @@ def _dec_gated_kernel(
                     MASK_LOCAL=True,
                     MASK_SINK=False,
                     CHECK_INF=True,
-                    HAS_GATHER_KV=False,
                 )
 
         # Process n_blocks with local sink masking
@@ -835,7 +806,6 @@ def _dec_gated_kernel(
                     MASK_LOCAL=True,
                     MASK_SINK=True,
                     CHECK_INF=True,
-                    HAS_GATHER_KV=False,
                 )
 
     # Finalize softmax
@@ -861,16 +831,16 @@ def _dec_gated_kernel(
 _dec_gated_kernel = cache_utils.wrap_kernel(_dec_gated_kernel)
 
 
-_dec_gated_kernel_autotuned = None
+_dec_gated_kernel_autotuned = {}
 
 
-def _get_autotuned_kernel():
+def _get_autotuned_kernel(tile_n=None):
     global _dec_gated_kernel_autotuned
-    if _dec_gated_kernel_autotuned is None:
+    if tile_n not in _dec_gated_kernel_autotuned:
         jit_kernel = _dec_gated_kernel._kernel
-        autotuned = autotuner.make_dec_gated_autotuned_kernel(jit_kernel)
-        _dec_gated_kernel_autotuned = autotuner.AutotunedKernel(autotuned)
-    return _dec_gated_kernel_autotuned
+        autotuned = autotuner.make_dec_gated_autotuned_kernel(jit_kernel, tile_n=tile_n)
+        _dec_gated_kernel_autotuned[tile_n] = autotuner.AutotunedKernel(autotuned)
+    return _dec_gated_kernel_autotuned[tile_n]
 
 
 def _flash_gated_attn_decode(
@@ -889,8 +859,10 @@ def _flash_gated_attn_decode(
     window_sizes: Optional[torch.Tensor] = None,
     is_local: bool = False,
     is_quant: bool = False,
-    gather_kv_indices: Optional[torch.Tensor] = None,
     num_splits: Optional[int] = None,
+    page_table: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = True,
@@ -900,10 +872,15 @@ def _flash_gated_attn_decode(
     device = query.device
     num_SMs = cache_utils.get_device_num_sms(device)
     batch_size, num_heads_q, head_dim = query.shape
-    _, seqlen_k, num_heads_kv, _ = key.shape
-    topk_seqlen_k = (
-        gather_kv_indices.shape[-1] if gather_kv_indices is not None else seqlen_k
-    )
+    if page_table is not None:
+        _, page_size, num_heads_kv, _ = key.shape
+        seqlen_k = page_table.shape[1] * page_size
+    else:
+        page_size = None
+        _, seqlen_k, num_heads_kv, _ = key.shape
+    is_paged_kv = page_table is not None
+    is_gather_kv = gather_kv_indices is not None and not is_paged_kv
+    topk_seqlen_k = gather_kv_indices.shape[-1] if is_gather_kv else seqlen_k
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
@@ -928,11 +905,15 @@ def _flash_gated_attn_decode(
             key_scale=key_scale,
             value_scale=value_scale,
             window_sizes=window_sizes,
+            page_table=page_table,
+            gather_kv_indices=gather_kv_indices,
             cu_seqlens_k=None,
-            seqused_k=None,
+            seqused_k=seqused_k,
             num_heads_q=num_heads_q,
             num_heads_kv=num_heads_kv,
             head_dim=head_dim,
+            page_size=page_size,
+            tile_mn=tile_mn,
             is_quant=is_quant,
             device=device,
         )
@@ -942,15 +923,23 @@ def _flash_gated_attn_decode(
     launch_config = None
     if not is_autotune:
         kernel = _dec_gated_kernel
-        TILE_M, TILE_N = tile_mn if tile_mn is not None else (16, 64)
+        TILE_M, TILE_N = (
+            tile_mn
+            if tile_mn is not None
+            else (
+                16,
+                page_size if page_table is not None else 64,
+            )
+        )
         num_warps, num_stages, num_ctas = 4, 1, 1
     else:
         launch_config = launch_template.load_launch_config(
             device=device,
             kernel_name="dec_gated",
             seqlen_q=1,
-            seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
+            seqlen_k=topk_seqlen_k if is_gather_kv else seqlen_k,
             tile_k=TILE_K,
+            tile_n=page_size if page_table is not None else None,
             is_local=is_local,
             qhead_per_kvhead=qhead_per_kvhead,
             is_quant=is_quant,
@@ -959,12 +948,14 @@ def _flash_gated_attn_decode(
             kernel = _dec_gated_kernel
             TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
         else:
-            kernel = _get_autotuned_kernel()
+            kernel = _get_autotuned_kernel(
+                page_size if page_table is not None else None
+            )
             TILE_M = max(triton.next_power_of_2(qhead_per_kvhead), 16)
-            TILE_N = 128
+            TILE_N = page_size if page_table is not None else 128
             num_warps = num_stages = num_ctas = None
 
-    if num_splits is None and gather_kv_indices is not None:
+    if num_splits is None and is_gather_kv:
         num_splits = 1
     elif num_splits is None:
         num_splits = utils.num_splits_heuristic(
@@ -1026,6 +1017,7 @@ def _flash_gated_attn_decode(
         softmax_threshold,
         gate_threshold,
         window_sizes,
+        page_table,
         gather_kv_indices,
         query.stride(0),
         query.stride(-2),
@@ -1049,12 +1041,13 @@ def _flash_gated_attn_decode(
         1,
         lse_partial.stride(0),
         window_sizes.stride(0) if window_sizes is not None else 0,
+        page_table.stride(0) if page_table is not None else 0,
         gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
         gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
         None,
         None,
-        None,
+        seqused_k,
         num_splits,
         seqlen_q=1,
         seqlen_k=seqlen_k,
@@ -1068,11 +1061,12 @@ def _flash_gated_attn_decode(
         topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
         IS_QUANT=is_quant,
-        HAS_GATHER_KV=gather_kv_indices is not None,
+        IS_PAGED_KV=is_paged_kv,
+        IS_GATHER_KV=is_gather_kv,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
         HAS_SEQUSED_Q=False,
-        HAS_SEQUSED_K=False,
+        HAS_SEQUSED_K=seqused_k is not None,
         IS_LOGSIGMOID_GATE=is_logsigmoid_gate,
         num_warps=num_warps,
         num_stages=num_stages,
@@ -1080,14 +1074,17 @@ def _flash_gated_attn_decode(
     )
 
     if is_autotune and launch_config is None:
-        best = launch_template.extract_best_config(_get_autotuned_kernel())
+        best = launch_template.extract_best_config(
+            _get_autotuned_kernel(page_size if page_table is not None else None)
+        )
         if best is not None:
             launch_template.store_launch_config(
                 device=device,
                 kernel_name="dec_gated",
                 seqlen_q=1,
-                seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
+                seqlen_k=topk_seqlen_k if is_gather_kv else seqlen_k,
                 tile_k=TILE_K,
+                tile_n=page_size if page_table is not None else None,
                 config=best,
                 is_local=is_local,
                 qhead_per_kvhead=qhead_per_kvhead,
@@ -1261,6 +1258,7 @@ def _flash_gated_attn_varlen_decode(
         softmax_threshold,
         gate_threshold,
         window_sizes,
+        None,
         gather_kv_indices,
         query.stride(0),
         query.stride(-2),
@@ -1284,6 +1282,7 @@ def _flash_gated_attn_varlen_decode(
         1,
         lse_partial.stride(0),
         window_sizes.stride(0) if window_sizes is not None else 0,
+        0,
         gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
         gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
@@ -1303,7 +1302,8 @@ def _flash_gated_attn_varlen_decode(
         topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
         IS_QUANT=is_quant,
-        HAS_GATHER_KV=gather_kv_indices is not None,
+        IS_PAGED_KV=False,
+        IS_GATHER_KV=gather_kv_indices is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=True,
         HAS_SEQUSED_Q=False,

--- a/flash_sparse_attn/ops/triton/flash_gated_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_fwd.py
@@ -143,6 +143,7 @@ def _fwd_gated_kernel(
     key_scale,
     value_scale,
     window_sizes,
+    page_table,
     stride_qb,
     stride_qh,
     stride_qm,
@@ -166,6 +167,7 @@ def _fwd_gated_kernel(
     stride_lh,
     stride_ls,
     stride_wh,
+    stride_pb,
     cu_seqlens_q,
     cu_seqlens_k,
     seqused_q,
@@ -186,6 +188,7 @@ def _fwd_gated_kernel(
     IS_LOCAL: tl.constexpr,
     IS_QUANT: tl.constexpr,
     IS_SPLIT_KV: tl.constexpr,
+    IS_PAGED_KV: tl.constexpr,
     IS_LOGSIGMOID_GATE: tl.constexpr,
     IS_ADAPT_GATE: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
@@ -241,6 +244,7 @@ def _fwd_gated_kernel(
         TILE_K=TILE_K,
         IS_CAUSAL=IS_CAUSAL,
         IS_QUANT=IS_QUANT,
+        IS_PAGED_KV=IS_PAGED_KV,
         IS_LOGSIGMOID_GATE=IS_LOGSIGMOID_GATE,
         IS_ADAPT_GATE=IS_ADAPT_GATE,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
@@ -257,6 +261,7 @@ def _fwd_gated_kernel(
         V=V,
         A=A,
         D=D,
+        PageTable=page_table,
         Out=Out,
         Lse=Lse,
         batch_idx=grid_idx.batch_idx,
@@ -285,7 +290,9 @@ def _fwd_gated_kernel(
         stride_lb=stride_lb,
         stride_lh=stride_lh,
         stride_ls=stride_ls,
+        stride_pb=stride_pb,
         IS_SPLIT_KV=IS_SPLIT_KV,
+        IS_PAGED_KV=IS_PAGED_KV,
         IS_GATED=True,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
@@ -829,16 +836,16 @@ def _fwd_gated_kernel(
 _fwd_gated_kernel = cache_utils.wrap_kernel(_fwd_gated_kernel)
 
 
-_fwd_gated_kernel_autotuned = None
+_fwd_gated_kernel_autotuned = {}
 
 
-def _get_autotuned_kernel():
+def _get_autotuned_kernel(tile_n=None):
     global _fwd_gated_kernel_autotuned
-    if _fwd_gated_kernel_autotuned is None:
+    if tile_n not in _fwd_gated_kernel_autotuned:
         jit_kernel = _fwd_gated_kernel._kernel
-        autotuned = autotuner.make_fwd_gated_autotuned_kernel(jit_kernel)
-        _fwd_gated_kernel_autotuned = autotuner.AutotunedKernel(autotuned)
-    return _fwd_gated_kernel_autotuned
+        autotuned = autotuner.make_fwd_gated_autotuned_kernel(jit_kernel, tile_n=tile_n)
+        _fwd_gated_kernel_autotuned[tile_n] = autotuner.AutotunedKernel(autotuned)
+    return _fwd_gated_kernel_autotuned[tile_n]
 
 
 def _flash_gated_attn_forward(
@@ -862,6 +869,8 @@ def _flash_gated_attn_forward(
     is_split_kv: bool = False,
     pack_gqa: bool = False,
     num_splits: Optional[int] = None,
+    page_table: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = True,
@@ -871,7 +880,12 @@ def _flash_gated_attn_forward(
     device = query.device
     num_SMs = cache_utils.get_device_num_sms(device)
     batch_size, seqlen_q, num_heads_q, head_dim = query.shape
-    _, seqlen_k, num_heads_kv, _ = key.shape
+    if page_table is not None:
+        _, page_size, num_heads_kv, _ = key.shape
+        seqlen_k = page_table.shape[1] * page_size
+    else:
+        page_size = None
+        _, seqlen_k, num_heads_kv, _ = key.shape
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
@@ -900,10 +914,12 @@ def _flash_gated_attn_forward(
             cu_seqlens_q=None,
             cu_seqlens_k=None,
             seqused_q=None,
-            seqused_k=None,
+            seqused_k=seqused_k,
             num_heads_q=num_heads_q,
             num_heads_kv=num_heads_kv,
             head_dim=head_dim,
+            page_size=page_size,
+            tile_mn=tile_mn,
             is_quant=is_quant,
             device=device,
         )
@@ -914,7 +930,14 @@ def _flash_gated_attn_forward(
     launch_config = None
     if not is_autotune:
         kernel = _fwd_gated_kernel
-        TILE_M, TILE_N = tile_mn if tile_mn is not None else (64, 64)
+        TILE_M, TILE_N = (
+            tile_mn
+            if tile_mn is not None
+            else (
+                64,
+                page_size if page_table is not None else 64,
+            )
+        )
         num_warps, num_stages, num_ctas = 4, 1, 1
     else:
         launch_config = launch_template.load_launch_config(
@@ -923,6 +946,7 @@ def _flash_gated_attn_forward(
             seqlen_q=seqlen_q,
             seqlen_k=seqlen_k,
             tile_k=TILE_K,
+            tile_n=page_size if page_table is not None else None,
             is_local=is_local,
             qhead_per_kvhead=qhead_per_kvhead,
             is_causal=is_causal,
@@ -933,9 +957,12 @@ def _flash_gated_attn_forward(
             kernel = _fwd_gated_kernel
             TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
         else:
-            kernel = _get_autotuned_kernel()
+            kernel = _get_autotuned_kernel(
+                page_size if page_table is not None else None
+            )
             # Placeholder for pre-launch computations
-            TILE_M = TILE_N = 64
+            TILE_M = 64
+            TILE_N = page_size if page_table is not None else 64
             num_warps = num_stages = num_ctas = None
 
     if is_split_kv and num_splits is None:
@@ -1004,6 +1031,7 @@ def _flash_gated_attn_forward(
         key_scale,
         value_scale,
         window_sizes,
+        page_table,
         query.stride(0),
         query.stride(-2),
         query.stride(-3),
@@ -1027,10 +1055,11 @@ def _flash_gated_attn_forward(
         lse.stride(-2) if not is_split_kv else lse_partial.stride(-2),
         0 if not is_split_kv else lse_partial.stride(0),
         window_sizes.stride(0) if window_sizes is not None else 0,
+        page_table.stride(0) if page_table is not None else 0,
         None,
         None,
         None,
-        None,
+        seqused_k,
         num_splits,
         seqlen_q=seqlen_q,
         seqlen_k=seqlen_k,
@@ -1047,19 +1076,22 @@ def _flash_gated_attn_forward(
         IS_LOCAL=is_local,
         IS_QUANT=is_quant,
         IS_SPLIT_KV=is_split_kv,
+        IS_PAGED_KV=page_table is not None,
         IS_LOGSIGMOID_GATE=is_logsigmoid_gate,
         IS_ADAPT_GATE=is_adapt_gate,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
         HAS_SEQUSED_Q=False,
-        HAS_SEQUSED_K=False,
+        HAS_SEQUSED_K=seqused_k is not None,
         num_warps=num_warps,
         num_stages=num_stages,
         num_ctas=num_ctas,
     )
 
     if is_autotune and launch_config is None:
-        best = launch_template.extract_best_config(_get_autotuned_kernel())
+        best = launch_template.extract_best_config(
+            _get_autotuned_kernel(page_size if page_table is not None else None)
+        )
         if best is not None:
             launch_template.store_launch_config(
                 device=device,
@@ -1067,6 +1099,7 @@ def _flash_gated_attn_forward(
                 seqlen_q=seqlen_q,
                 seqlen_k=seqlen_k,
                 tile_k=TILE_K,
+                tile_n=page_size if page_table is not None else None,
                 config=best,
                 is_local=is_local,
                 qhead_per_kvhead=qhead_per_kvhead,
@@ -1258,6 +1291,7 @@ def _flash_gated_attn_varlen_forward(
         key_scale,
         value_scale,
         window_sizes,
+        None,
         0,
         query.stride(-2),
         query.stride(0),
@@ -1281,6 +1315,7 @@ def _flash_gated_attn_varlen_forward(
         lse.stride(-2) if not is_split_kv else lse_partial.stride(-2),
         0 if not is_split_kv else lse_partial.stride(0),
         window_sizes.stride(0) if window_sizes is not None else 0,
+        0,
         cu_seqlens_q,
         cu_seqlens_k,
         seqused_q,
@@ -1301,6 +1336,7 @@ def _flash_gated_attn_varlen_forward(
         IS_LOCAL=is_local,
         IS_QUANT=is_quant,
         IS_SPLIT_KV=is_split_kv,
+        IS_PAGED_KV=False,
         IS_LOGSIGMOID_GATE=is_logsigmoid_gate,
         IS_ADAPT_GATE=is_adapt_gate,
         HAS_CU_SEQLENS_Q=True,

--- a/flash_sparse_attn/ops/triton/flash_sparse_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_dec.py
@@ -44,7 +44,6 @@ def _dec_inner_sparse_kernel(
     MASK_LOCAL: tl.constexpr,
     MASK_SINK: tl.constexpr,
     CHECK_INF: tl.constexpr,
-    HAS_GATHER_KV: tl.constexpr,
 ):
     next_topk_indices = topk_indices
 
@@ -53,20 +52,14 @@ def _dec_inner_sparse_kernel(
 
     # Prefetch next key tile
     if n_block > n_block_min:
-        if HAS_GATHER_KV:
+        if config.IS_GATHER_KV:
             # Load next topk indices
             next_topk_indices = ptrs_sched.load_topk_indices(config, n_block - 1)
 
         # Load next key tile
-        k_tile = ptrs_sched.load_k(
-            config,
-            k_ptrs,
-            n_block - 1,
-            next_topk_indices,
-            HAS_GATHER_KV=HAS_GATHER_KV,
-        )
+        k_tile = ptrs_sched.load_k(config, k_ptrs, n_block - 1, next_topk_indices)
 
-    if HAS_GATHER_KV:
+    if config.IS_GATHER_KV:
         # Apply mask to attention scores
         acc_s = ptrs_sched.apply_gather_mask(
             config,
@@ -94,9 +87,7 @@ def _dec_inner_sparse_kernel(
 
     if not skip_softmax:
         # Load value tile
-        v_tile = ptrs_sched.load_v(
-            config, v_ptrs, n_block, topk_indices, HAS_GATHER_KV=HAS_GATHER_KV
-        )
+        v_tile = ptrs_sched.load_v(config, v_ptrs, n_block, topk_indices)
 
         # Rescale output accumulator
         acc_o = softmax_sched.rescale_o(
@@ -123,6 +114,7 @@ def _dec_sparse_kernel(
     value_scale,
     softmax_threshold,
     window_sizes,
+    page_table,
     gather_kv_indices,
     stride_qb,
     stride_qh,
@@ -142,6 +134,7 @@ def _dec_sparse_kernel(
     stride_lm,
     stride_ls,
     stride_wh,
+    stride_pb,
     stride_gb,
     stride_gn,
     cu_seqlens_q,
@@ -161,7 +154,8 @@ def _dec_sparse_kernel(
     topk_seqlen_k: tl.constexpr,
     IS_LOCAL: tl.constexpr,
     IS_QUANT: tl.constexpr,
-    HAS_GATHER_KV: tl.constexpr,
+    IS_PAGED_KV: tl.constexpr,
+    IS_GATHER_KV: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
     HAS_CU_SEQLENS_K: tl.constexpr,
     HAS_SEQUSED_Q: tl.constexpr,
@@ -208,6 +202,8 @@ def _dec_sparse_kernel(
         TILE_N=TILE_N,
         TILE_K=TILE_K,
         IS_QUANT=IS_QUANT,
+        IS_PAGED_KV=IS_PAGED_KV,
+        IS_GATHER_KV=IS_GATHER_KV,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
         HAS_SEQUSED_Q=HAS_SEQUSED_Q,
@@ -220,6 +216,7 @@ def _dec_sparse_kernel(
         Q=Q,
         K=K,
         V=V,
+        PageTable=page_table,
         GatherKVIndices=gather_kv_indices,
         Out=Out,
         Lse=Lse,
@@ -244,9 +241,10 @@ def _dec_sparse_kernel(
         stride_lh=stride_lh,
         stride_lm=stride_lm,
         stride_ls=stride_ls,
+        stride_pb=stride_pb,
         stride_gb=stride_gb,
         stride_gn=stride_gn,
-        HAS_GATHER_KV=HAS_GATHER_KV,
+        IS_PAGED_KV=IS_PAGED_KV,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
     )
@@ -258,7 +256,7 @@ def _dec_sparse_kernel(
         num_splits=num_splits,
         topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=IS_LOCAL,
-        HAS_GATHER_KV=HAS_GATHER_KV,
+        IS_GATHER_KV=IS_GATHER_KV,
     )
 
     # Create mask scheduler
@@ -291,17 +289,13 @@ def _dec_sparse_kernel(
     # Load query tile
     q_tile = ptrs_sched.load_q(config, q_ptrs)
 
-    if HAS_GATHER_KV:
+    if IS_GATHER_KV:
         # Load topk indices
         topk_indices = ptrs_sched.load_topk_indices(config, block_sched.n_block_max - 1)
 
     # Load key tile
     k_tile = ptrs_sched.load_k(
-        config,
-        k_ptrs,
-        block_sched.n_block_max - 1,
-        topk_indices,
-        HAS_GATHER_KV=HAS_GATHER_KV,
+        config, k_ptrs, block_sched.n_block_max - 1, topk_indices
     )
 
     # Process n_blocks with seqlen masking
@@ -327,14 +321,13 @@ def _dec_sparse_kernel(
             MASK_LOCAL=True if IS_LOCAL else False,
             MASK_SINK=False,
             CHECK_INF=True,
-            HAS_GATHER_KV=HAS_GATHER_KV,
         )
 
     # Process n_blocks without masking
     if (
-        not IS_LOCAL or HAS_GATHER_KV
+        not IS_LOCAL or IS_GATHER_KV
     ) and block_sched.n_block_max_no_mask > block_sched.n_block_min:
-        if HAS_GATHER_KV:
+        if IS_GATHER_KV:
             # Load topk indices
             topk_indices = ptrs_sched.load_topk_indices(
                 config,
@@ -343,11 +336,7 @@ def _dec_sparse_kernel(
 
         # Load key tile
         k_tile = ptrs_sched.load_k(
-            config,
-            k_ptrs,
-            block_sched.n_block_max_no_mask - 1,
-            topk_indices,
-            HAS_GATHER_KV=HAS_GATHER_KV,
+            config, k_ptrs, block_sched.n_block_max_no_mask - 1, topk_indices
         )
 
         for n_block in tl.range(
@@ -371,11 +360,10 @@ def _dec_sparse_kernel(
                 IS_MASK=False,
                 MASK_LOCAL=False,
                 MASK_SINK=False,
-                CHECK_INF=True if HAS_GATHER_KV else False,
-                HAS_GATHER_KV=HAS_GATHER_KV,
+                CHECK_INF=True if IS_GATHER_KV else False,
             )
 
-    if IS_LOCAL and not HAS_GATHER_KV:
+    if IS_LOCAL and not IS_GATHER_KV:
         # Process n_blocks with local right masking
         if block_sched.n_block_window_max > block_sched.n_block_window_max_no_mask:
             # Load key tile
@@ -408,7 +396,6 @@ def _dec_sparse_kernel(
                         MASK_LOCAL=True,
                         MASK_SINK=False,
                         CHECK_INF=True,
-                        HAS_GATHER_KV=False,
                     )
                 )
 
@@ -447,7 +434,6 @@ def _dec_sparse_kernel(
                         MASK_LOCAL=False,
                         MASK_SINK=False,
                         CHECK_INF=False,
-                        HAS_GATHER_KV=False,
                     )
                 )
 
@@ -483,7 +469,6 @@ def _dec_sparse_kernel(
                         MASK_LOCAL=True,
                         MASK_SINK=False,
                         CHECK_INF=True,
-                        HAS_GATHER_KV=False,
                     )
                 )
 
@@ -517,7 +502,6 @@ def _dec_sparse_kernel(
                         MASK_LOCAL=True,
                         MASK_SINK=True,
                         CHECK_INF=True,
-                        HAS_GATHER_KV=False,
                     )
                 )
 
@@ -544,16 +528,18 @@ def _dec_sparse_kernel(
 _dec_sparse_kernel = cache_utils.wrap_kernel(_dec_sparse_kernel)
 
 
-_dec_sparse_kernel_autotuned = None
+_dec_sparse_kernel_autotuned = {}
 
 
-def _get_autotuned_kernel():
+def _get_autotuned_kernel(tile_n=None):
     global _dec_sparse_kernel_autotuned
-    if _dec_sparse_kernel_autotuned is None:
+    if tile_n not in _dec_sparse_kernel_autotuned:
         jit_kernel = _dec_sparse_kernel._kernel
-        autotuned = autotuner.make_dec_sparse_autotuned_kernel(jit_kernel)
-        _dec_sparse_kernel_autotuned = autotuner.AutotunedKernel(autotuned)
-    return _dec_sparse_kernel_autotuned
+        autotuned = autotuner.make_dec_sparse_autotuned_kernel(
+            jit_kernel, tile_n=tile_n
+        )
+        _dec_sparse_kernel_autotuned[tile_n] = autotuner.AutotunedKernel(autotuned)
+    return _dec_sparse_kernel_autotuned[tile_n]
 
 
 def _flash_sparse_attn_decode(
@@ -568,8 +554,10 @@ def _flash_sparse_attn_decode(
     window_sizes: Optional[torch.Tensor] = None,
     is_local: bool = False,
     is_quant: bool = False,
-    gather_kv_indices: Optional[torch.Tensor] = None,
     num_splits: Optional[int] = None,
+    page_table: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = True,
@@ -579,10 +567,15 @@ def _flash_sparse_attn_decode(
     device = query.device
     num_SMs = cache_utils.get_device_num_sms(device)
     batch_size, num_heads_q, head_dim = query.shape
-    _, seqlen_k, num_heads_kv, _ = key.shape
-    topk_seqlen_k = (
-        gather_kv_indices.shape[-1] if gather_kv_indices is not None else seqlen_k
-    )
+    if page_table is not None:
+        _, page_size, num_heads_kv, _ = key.shape
+        seqlen_k = page_table.shape[1] * page_size
+    else:
+        page_size = None
+        _, seqlen_k, num_heads_kv, _ = key.shape
+    is_paged_kv = page_table is not None
+    is_gather_kv = gather_kv_indices is not None and not is_paged_kv
+    topk_seqlen_k = gather_kv_indices.shape[-1] if is_gather_kv else seqlen_k
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
@@ -602,11 +595,15 @@ def _flash_sparse_attn_decode(
             key_scale=key_scale,
             value_scale=value_scale,
             window_sizes=window_sizes,
+            page_table=page_table,
+            gather_kv_indices=gather_kv_indices,
             cu_seqlens_k=None,
-            seqused_k=None,
+            seqused_k=seqused_k,
             num_heads_q=num_heads_q,
             num_heads_kv=num_heads_kv,
             head_dim=head_dim,
+            page_size=page_size,
+            tile_mn=tile_mn,
             is_quant=is_quant,
             device=device,
         )
@@ -616,15 +613,23 @@ def _flash_sparse_attn_decode(
     launch_config = None
     if not is_autotune:
         kernel = _dec_sparse_kernel
-        TILE_M, TILE_N = tile_mn if tile_mn is not None else (16, 64)
+        TILE_M, TILE_N = (
+            tile_mn
+            if tile_mn is not None
+            else (
+                16,
+                page_size if page_table is not None else 64,
+            )
+        )
         num_warps, num_stages, num_ctas = 4, 1, 1
     else:
         launch_config = launch_template.load_launch_config(
             device=device,
             kernel_name="dec_sparse",
             seqlen_q=1,
-            seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
+            seqlen_k=topk_seqlen_k if is_gather_kv else seqlen_k,
             tile_k=TILE_K,
+            tile_n=page_size if page_table is not None else None,
             is_local=is_local,
             qhead_per_kvhead=qhead_per_kvhead,
             is_quant=is_quant,
@@ -633,12 +638,14 @@ def _flash_sparse_attn_decode(
             kernel = _dec_sparse_kernel
             TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
         else:
-            kernel = _get_autotuned_kernel()
+            kernel = _get_autotuned_kernel(
+                page_size if page_table is not None else None
+            )
             TILE_M = max(triton.next_power_of_2(qhead_per_kvhead), 16)
-            TILE_N = 128
+            TILE_N = page_size if page_table is not None else 128
             num_warps = num_stages = num_ctas = None
 
-    if num_splits is None and gather_kv_indices is not None:
+    if num_splits is None and is_gather_kv:
         num_splits = 1
     elif num_splits is None:
         num_splits = utils.num_splits_heuristic(
@@ -697,6 +704,7 @@ def _flash_sparse_attn_decode(
         value_scale,
         softmax_threshold,
         window_sizes,
+        page_table,
         gather_kv_indices,
         query.stride(0),
         query.stride(-2),
@@ -716,12 +724,13 @@ def _flash_sparse_attn_decode(
         1,
         lse_partial.stride(0),
         window_sizes.stride(0) if window_sizes is not None else 0,
+        page_table.stride(0) if page_table is not None else 0,
         gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
         gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
         None,
         None,
-        None,
+        seqused_k,
         num_splits,
         seqlen_q=1,
         seqlen_k=seqlen_k,
@@ -735,25 +744,29 @@ def _flash_sparse_attn_decode(
         topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
         IS_QUANT=is_quant,
-        HAS_GATHER_KV=gather_kv_indices is not None,
+        IS_PAGED_KV=is_paged_kv,
+        IS_GATHER_KV=is_gather_kv,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
         HAS_SEQUSED_Q=False,
-        HAS_SEQUSED_K=False,
+        HAS_SEQUSED_K=seqused_k is not None,
         num_warps=num_warps,
         num_stages=num_stages,
         num_ctas=num_ctas,
     )
 
     if is_autotune and launch_config is None:
-        best = launch_template.extract_best_config(_get_autotuned_kernel())
+        best = launch_template.extract_best_config(
+            _get_autotuned_kernel(page_size if page_table is not None else None)
+        )
         if best is not None:
             launch_template.store_launch_config(
                 device=device,
                 kernel_name="dec_sparse",
                 seqlen_q=1,
-                seqlen_k=seqlen_k if gather_kv_indices is None else topk_seqlen_k,
+                seqlen_k=topk_seqlen_k if is_gather_kv else seqlen_k,
                 tile_k=TILE_K,
+                tile_n=page_size if page_table is not None else None,
                 config=best,
                 is_local=is_local,
                 qhead_per_kvhead=qhead_per_kvhead,
@@ -915,6 +928,7 @@ def _flash_sparse_attn_varlen_decode(
         value_scale,
         softmax_threshold,
         window_sizes,
+        None,
         gather_kv_indices,
         query.stride(0),
         query.stride(-2),
@@ -934,6 +948,7 @@ def _flash_sparse_attn_varlen_decode(
         1,
         lse_partial.stride(0),
         window_sizes.stride(0) if window_sizes is not None else 0,
+        0,
         gather_kv_indices.stride(0) if gather_kv_indices is not None else 0,
         gather_kv_indices.stride(-1) if gather_kv_indices is not None else 0,
         None,
@@ -953,7 +968,8 @@ def _flash_sparse_attn_varlen_decode(
         topk_seqlen_k=topk_seqlen_k,
         IS_LOCAL=is_local,
         IS_QUANT=is_quant,
-        HAS_GATHER_KV=gather_kv_indices is not None,
+        IS_PAGED_KV=False,
+        IS_GATHER_KV=gather_kv_indices is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=True,
         HAS_SEQUSED_Q=False,

--- a/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
@@ -101,6 +101,7 @@ def _fwd_sparse_kernel(
     key_scale,
     value_scale,
     window_sizes,
+    page_table,
     stride_qb,
     stride_qh,
     stride_qm,
@@ -118,6 +119,7 @@ def _fwd_sparse_kernel(
     stride_lh,
     stride_ls,
     stride_wh,
+    stride_pb,
     cu_seqlens_q,
     cu_seqlens_k,
     seqused_q,
@@ -138,6 +140,7 @@ def _fwd_sparse_kernel(
     IS_LOCAL: tl.constexpr,
     IS_QUANT: tl.constexpr,
     IS_SPLIT_KV: tl.constexpr,
+    IS_PAGED_KV: tl.constexpr,
     HAS_CU_SEQLENS_Q: tl.constexpr,
     HAS_CU_SEQLENS_K: tl.constexpr,
     HAS_SEQUSED_Q: tl.constexpr,
@@ -190,6 +193,7 @@ def _fwd_sparse_kernel(
         TILE_K=TILE_K,
         IS_CAUSAL=IS_CAUSAL,
         IS_QUANT=IS_QUANT,
+        IS_PAGED_KV=IS_PAGED_KV,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
         HAS_SEQUSED_Q=HAS_SEQUSED_Q,
@@ -202,6 +206,7 @@ def _fwd_sparse_kernel(
         Q=Q,
         K=K,
         V=V,
+        PageTable=page_table,
         Out=Out,
         Lse=Lse,
         batch_idx=grid_idx.batch_idx,
@@ -224,7 +229,9 @@ def _fwd_sparse_kernel(
         stride_lb=stride_lb,
         stride_lh=stride_lh,
         stride_ls=stride_ls,
+        stride_pb=stride_pb,
         IS_SPLIT_KV=IS_SPLIT_KV,
+        IS_PAGED_KV=IS_PAGED_KV,
         HAS_CU_SEQLENS_Q=HAS_CU_SEQLENS_Q,
         HAS_CU_SEQLENS_K=HAS_CU_SEQLENS_K,
     )
@@ -509,16 +516,18 @@ def _fwd_sparse_kernel(
 _fwd_sparse_kernel = cache_utils.wrap_kernel(_fwd_sparse_kernel)
 
 
-_fwd_sparse_kernel_autotuned = None
+_fwd_sparse_kernel_autotuned = {}
 
 
-def _get_autotuned_kernel():
+def _get_autotuned_kernel(tile_n=None):
     global _fwd_sparse_kernel_autotuned
-    if _fwd_sparse_kernel_autotuned is None:
+    if tile_n not in _fwd_sparse_kernel_autotuned:
         jit_kernel = _fwd_sparse_kernel._kernel
-        autotuned = autotuner.make_fwd_sparse_autotuned_kernel(jit_kernel)
-        _fwd_sparse_kernel_autotuned = autotuner.AutotunedKernel(autotuned)
-    return _fwd_sparse_kernel_autotuned
+        autotuned = autotuner.make_fwd_sparse_autotuned_kernel(
+            jit_kernel, tile_n=tile_n
+        )
+        _fwd_sparse_kernel_autotuned[tile_n] = autotuner.AutotunedKernel(autotuned)
+    return _fwd_sparse_kernel_autotuned[tile_n]
 
 
 def _flash_sparse_attn_forward(
@@ -537,6 +546,8 @@ def _flash_sparse_attn_forward(
     is_split_kv: bool = False,
     pack_gqa: bool = False,
     num_splits: Optional[int] = None,
+    page_table: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = True,
@@ -546,7 +557,12 @@ def _flash_sparse_attn_forward(
     device = query.device
     num_SMs = cache_utils.get_device_num_sms(device)
     batch_size, seqlen_q, num_heads_q, head_dim = query.shape
-    _, seqlen_k, num_heads_kv, _ = key.shape
+    if page_table is not None:
+        _, page_size, num_heads_kv, _ = key.shape
+        seqlen_k = page_table.shape[1] * page_size
+    else:
+        page_size = None
+        _, seqlen_k, num_heads_kv, _ = key.shape
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
@@ -570,10 +586,12 @@ def _flash_sparse_attn_forward(
             cu_seqlens_q=None,
             cu_seqlens_k=None,
             seqused_q=None,
-            seqused_k=None,
+            seqused_k=seqused_k,
             num_heads_q=num_heads_q,
             num_heads_kv=num_heads_kv,
             head_dim=head_dim,
+            page_size=page_size,
+            tile_mn=tile_mn,
             is_quant=is_quant,
             device=device,
         )
@@ -584,7 +602,14 @@ def _flash_sparse_attn_forward(
     launch_config = None
     if not is_autotune:
         kernel = _fwd_sparse_kernel
-        TILE_M, TILE_N = tile_mn if tile_mn is not None else (64, 64)
+        TILE_M, TILE_N = (
+            tile_mn
+            if tile_mn is not None
+            else (
+                64,
+                page_size if page_table is not None else 64,
+            )
+        )
         num_warps, num_stages, num_ctas = 4, 1, 1
     else:
         launch_config = launch_template.load_launch_config(
@@ -593,6 +618,7 @@ def _flash_sparse_attn_forward(
             seqlen_q=seqlen_q,
             seqlen_k=seqlen_k,
             tile_k=TILE_K,
+            tile_n=page_size if page_table is not None else None,
             is_local=is_local,
             qhead_per_kvhead=qhead_per_kvhead,
             is_causal=is_causal,
@@ -603,9 +629,12 @@ def _flash_sparse_attn_forward(
             kernel = _fwd_sparse_kernel
             TILE_M, TILE_N, num_warps, num_stages, num_ctas = launch_config
         else:
-            kernel = _get_autotuned_kernel()
+            kernel = _get_autotuned_kernel(
+                page_size if page_table is not None else None
+            )
             # Placeholder for pre-launch computations
-            TILE_M = TILE_N = 64
+            TILE_M = 64
+            TILE_N = page_size if page_table is not None else 64
             num_warps = num_stages = num_ctas = None
 
     if is_split_kv and num_splits is None:
@@ -671,6 +700,7 @@ def _flash_sparse_attn_forward(
         key_scale,
         value_scale,
         window_sizes,
+        page_table,
         query.stride(0),
         query.stride(-2),
         query.stride(-3),
@@ -688,10 +718,11 @@ def _flash_sparse_attn_forward(
         lse.stride(-2) if not is_split_kv else lse_partial.stride(-2),
         0 if not is_split_kv else lse_partial.stride(0),
         window_sizes.stride(0) if window_sizes is not None else 0,
+        page_table.stride(0) if page_table is not None else 0,
         None,
         None,
         None,
-        None,
+        seqused_k,
         num_splits,
         seqlen_q=seqlen_q,
         seqlen_k=seqlen_k,
@@ -708,17 +739,20 @@ def _flash_sparse_attn_forward(
         IS_LOCAL=is_local,
         IS_QUANT=is_quant,
         IS_SPLIT_KV=is_split_kv,
+        IS_PAGED_KV=page_table is not None,
         HAS_CU_SEQLENS_Q=False,
         HAS_CU_SEQLENS_K=False,
         HAS_SEQUSED_Q=False,
-        HAS_SEQUSED_K=False,
+        HAS_SEQUSED_K=seqused_k is not None,
         num_warps=num_warps,
         num_stages=num_stages,
         num_ctas=num_ctas,
     )
 
     if is_autotune and launch_config is None:
-        best = launch_template.extract_best_config(_get_autotuned_kernel())
+        best = launch_template.extract_best_config(
+            _get_autotuned_kernel(page_size if page_table is not None else None)
+        )
         if best is not None:
             launch_template.store_launch_config(
                 device=device,
@@ -726,6 +760,7 @@ def _flash_sparse_attn_forward(
                 seqlen_q=seqlen_q,
                 seqlen_k=seqlen_k,
                 tile_k=TILE_K,
+                tile_n=page_size if page_table is not None else None,
                 config=best,
                 is_local=is_local,
                 qhead_per_kvhead=qhead_per_kvhead,
@@ -904,6 +939,7 @@ def _flash_sparse_attn_varlen_forward(
         key_scale,
         value_scale,
         window_sizes,
+        None,
         0,
         query.stride(-2),
         query.stride(0),
@@ -921,6 +957,7 @@ def _flash_sparse_attn_varlen_forward(
         lse.stride(-2) if not is_split_kv else lse_partial.stride(-2),
         0 if not is_split_kv else lse_partial.stride(0),
         window_sizes.stride(0) if window_sizes is not None else 0,
+        0,
         cu_seqlens_q,
         cu_seqlens_k,
         seqused_q,
@@ -941,6 +978,7 @@ def _flash_sparse_attn_varlen_forward(
         IS_LOCAL=is_local,
         IS_QUANT=is_quant,
         IS_SPLIT_KV=is_split_kv,
+        IS_PAGED_KV=False,
         HAS_CU_SEQLENS_Q=True,
         HAS_CU_SEQLENS_K=True,
         HAS_SEQUSED_Q=seqused_q is not None,

--- a/flash_sparse_attn/ops/triton/interface.py
+++ b/flash_sparse_attn/ops/triton/interface.py
@@ -341,6 +341,8 @@ class FlashSparseAttnFunc(torch.autograd.Function):
         is_split_qo: bool = False,
         pack_gqa: bool = False,
         num_splits: Optional[int] = None,
+        page_table: Optional[torch.Tensor] = None,
+        seqused_k: Optional[torch.Tensor] = None,
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         is_autotune: bool = True,
@@ -380,6 +382,8 @@ class FlashSparseAttnFunc(torch.autograd.Function):
             is_split_kv=is_split_kv,
             pack_gqa=pack_gqa,
             num_splits=num_splits,
+            page_table=page_table,
+            seqused_k=seqused_k,
             out=out,
             lse=lse,
             is_autotune=is_autotune,
@@ -626,6 +630,8 @@ class FlashGatedAttnFunc(torch.autograd.Function):
         is_split_qo: bool = False,
         pack_gqa: bool = False,
         num_splits: Optional[int] = None,
+        page_table: Optional[torch.Tensor] = None,
+        seqused_k: Optional[torch.Tensor] = None,
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         is_autotune: bool = True,
@@ -675,6 +681,8 @@ class FlashGatedAttnFunc(torch.autograd.Function):
                 is_split_kv=is_split_kv,
                 pack_gqa=pack_gqa,
                 num_splits=num_splits,
+                page_table=page_table,
+                seqused_k=seqused_k,
                 out=out,
                 lse=lse,
                 is_autotune=is_autotune,
@@ -1013,7 +1021,7 @@ def flash_dense_attn_func(
     :param is_split_qo: Whether to enable split-QO for backward occupancy.
     :param pack_gqa: Whether to pack grouped-query attention.
     :param num_splits: Optional split count for split-KV and split-QO. If provided, enables split-KV and split-QO, if omitted with split-KV and split-QO enabled, a heuristic is used.
-    :param page_table: Optional paged KV table with shape [batch_size, max_pages]. If provided, key/value must have shape [num_pages, page_size, num_kv_heads, head_dim].
+    :param page_table: Optional paged KV table with shape [batch_size, max_pages_per_seq]. If provided, key/value must have shape [num_pages, page_size, num_kv_heads, head_dim].
     :param seqused_k: Optional tensor of shape [batch_size] indicating the actual sequence lengths for keys/values.
     :param out: Optional preallocated output tensor with shape [batch_size, seqlen_q, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads, seqlen_q].
@@ -1087,7 +1095,7 @@ def flash_dense_attn_with_kvcache_func(
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param num_splits: Optional split count for decode. If omitted, gather decode uses 1 split and regular decode uses a heuristic.
-    :param page_table: Optional paged KV table with shape [batch_size, max_pages]. If provided, key/value must have shape [num_pages, page_size, num_kv_heads, head_dim].
+    :param page_table: Optional paged KV table with shape [batch_size, max_pages_per_seq]. If provided, key/value must have shape [num_pages, page_size, num_kv_heads, head_dim].
     :param gather_kv_indices: Optional TopK gather indices with shape [batch_size, topk_seqlen_k]. Each non-negative entry is an original KV sequence position to gather for decode, negative entries are masked out.
     :param seqused_k: Optional tensor of shape [batch_size] indicating the actual sequence lengths for keys/values.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
@@ -1332,6 +1340,8 @@ def flash_sparse_attn_func(
     is_split_qo: bool = False,
     pack_gqa: bool = False,
     num_splits: Optional[int] = None,
+    page_table: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = True,
@@ -1358,6 +1368,8 @@ def flash_sparse_attn_func(
     :param is_split_qo: Whether to enable split-QO for backward occupancy.
     :param pack_gqa: Whether to pack grouped-query attention.
     :param num_splits: Optional split count for split-KV and split-QO. If provided, enables split-KV and split-QO, if omitted with split-KV and split-QO enabled, a heuristic is used.
+    :param page_table: Optional paged KV table with shape [batch_size, max_pages_per_seq]. If provided, key/value must have shape [num_pages, page_size, num_kv_heads, head_dim].
+    :param seqused_k: Optional tensor of shape [batch_size] indicating the actual sequence lengths for keys/values.
     :param out: Optional preallocated output tensor with shape [batch_size, seqlen_q, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads, seqlen_q].
     :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
@@ -1384,6 +1396,8 @@ def flash_sparse_attn_func(
         is_split_qo,
         pack_gqa,
         num_splits,
+        page_table,
+        seqused_k,
         out,
         lse,
         is_autotune,
@@ -1405,8 +1419,10 @@ def flash_sparse_attn_with_kvcache_func(
     window_sizes: Optional[torch.Tensor] = None,
     is_local: bool = False,
     is_quant: bool = False,
-    gather_kv_indices: Optional[torch.Tensor] = None,
     num_splits: Optional[int] = None,
+    page_table: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = True,
@@ -1428,8 +1444,10 @@ def flash_sparse_attn_with_kvcache_func(
     :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
-    :param gather_kv_indices: Optional TopK gather indices with shape [batch_size, topk_seqlen_k]. Each non-negative entry is an original KV sequence position to gather for decode, negative entries are masked out.
     :param num_splits: Optional split count for decode. If omitted, gather decode uses 1 split and regular decode uses a heuristic.
+    :param page_table: Optional paged KV table with shape [batch_size, max_pages_per_seq]. If provided, key/value must be shaped [num_pages, page_size, num_kv_heads, head_dim].
+    :param gather_kv_indices: Optional TopK gather indices with shape [batch_size, topk_seqlen_k]. Each non-negative entry is an original KV sequence position to gather for decode, negative entries are masked out.
+    :param seqused_k: Optional tensor of shape [batch_size] indicating the actual sequence lengths for keys/values.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads].
     :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
@@ -1460,8 +1478,10 @@ def flash_sparse_attn_with_kvcache_func(
         window_sizes=window_sizes,
         is_local=is_local,
         is_quant=is_quant,
-        gather_kv_indices=gather_kv_indices,
         num_splits=num_splits,
+        page_table=page_table,
+        gather_kv_indices=gather_kv_indices,
+        seqused_k=seqused_k,
         out=out,
         lse=lse,
         is_autotune=is_autotune,
@@ -1682,6 +1702,8 @@ def flash_gated_attn_func(
     is_split_qo: bool = False,
     pack_gqa: bool = False,
     num_splits: Optional[int] = None,
+    page_table: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = True,
@@ -1713,6 +1735,8 @@ def flash_gated_attn_func(
     :param is_split_qo: Whether to enable split-QO for backward occupancy.
     :param pack_gqa: Whether to pack grouped-query attention.
     :param num_splits: Optional split count for split-KV and split-QO. If provided, enables split-KV and split-QO, if omitted with split-KV and split-QO enabled, a heuristic is used.
+    :param page_table: Optional paged KV table with shape [batch_size, max_pages_per_seq]. If provided, key/value must have shape [num_pages, page_size, num_kv_heads, head_dim], delta must have shape [num_pages, page_size, num_kv_heads].
+    :param seqused_k: Optional tensor of shape [batch_size] indicating the actual sequence lengths for keys/values/delta.
     :param out: Optional preallocated output tensor with shape [batch_size, seqlen_q, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads, seqlen_q].
     :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
@@ -1744,6 +1768,8 @@ def flash_gated_attn_func(
         is_split_qo,
         pack_gqa,
         num_splits,
+        page_table,
+        seqused_k,
         out,
         lse,
         is_autotune,
@@ -1769,8 +1795,10 @@ def flash_gated_attn_with_kvcache_func(
     window_sizes: Optional[torch.Tensor] = None,
     is_local: bool = False,
     is_quant: bool = False,
-    gather_kv_indices: Optional[torch.Tensor] = None,
     num_splits: Optional[int] = None,
+    page_table: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = True,
@@ -1796,8 +1824,10 @@ def flash_gated_attn_with_kvcache_func(
     :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
-    :param gather_kv_indices: Optional TopK gather indices with shape [batch_size, topk_seqlen_k]. Each non-negative entry is an original KV sequence position to gather for decode, negative entries are masked out.
     :param num_splits: Optional split count for decode. If omitted, gather decode uses 1 split and regular decode uses a heuristic.
+    :param page_table: Optional paged KV table with shape [batch_size, max_pages_per_seq]. If provided, key/value must have shape [num_pages, page_size, num_kv_heads, head_dim], delta must have shape [num_pages, page_size, num_kv_heads].
+    :param gather_kv_indices: Optional TopK gather indices with shape [batch_size, topk_seqlen_k]. Each non-negative entry is an original KV sequence position to gather for decode, negative entries are masked out.
+    :param seqused_k: Optional tensor of shape [batch_size] indicating the actual sequence lengths for keys/values/delta.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads].
     :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
@@ -1835,8 +1865,10 @@ def flash_gated_attn_with_kvcache_func(
         window_sizes=window_sizes,
         is_local=is_local,
         is_quant=is_quant,
-        gather_kv_indices=gather_kv_indices,
         num_splits=num_splits,
+        page_table=page_table,
+        gather_kv_indices=gather_kv_indices,
+        seqused_k=seqused_k,
         out=out,
         lse=lse,
         is_autotune=is_autotune,

--- a/flash_sparse_attn/ops/triton/interface.py
+++ b/flash_sparse_attn/ops/triton/interface.py
@@ -64,6 +64,8 @@ class FlashDenseAttnFunc(torch.autograd.Function):
         is_split_qo: bool = False,
         pack_gqa: bool = False,
         num_splits: Optional[int] = None,
+        page_table: Optional[torch.Tensor] = None,
+        seqused_k: Optional[torch.Tensor] = None,
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         is_autotune: bool = True,
@@ -102,6 +104,8 @@ class FlashDenseAttnFunc(torch.autograd.Function):
             is_split_kv=is_split_kv,
             pack_gqa=pack_gqa,
             num_splits=num_splits,
+            page_table=page_table,
+            seqused_k=seqused_k,
             out=out,
             lse=lse,
             is_autotune=is_autotune,
@@ -982,6 +986,8 @@ def flash_dense_attn_func(
     is_split_qo: bool = False,
     pack_gqa: bool = False,
     num_splits: Optional[int] = None,
+    page_table: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = True,
@@ -1007,6 +1013,8 @@ def flash_dense_attn_func(
     :param is_split_qo: Whether to enable split-QO for backward occupancy.
     :param pack_gqa: Whether to pack grouped-query attention.
     :param num_splits: Optional split count for split-KV and split-QO. If provided, enables split-KV and split-QO, if omitted with split-KV and split-QO enabled, a heuristic is used.
+    :param page_table: Optional paged KV table with shape [batch_size, max_pages]. If provided, key/value must have shape [num_pages, page_size, num_kv_heads, head_dim].
+    :param seqused_k: Optional tensor of shape [batch_size] indicating the actual sequence lengths for keys/values.
     :param out: Optional preallocated output tensor with shape [batch_size, seqlen_q, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads, seqlen_q].
     :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
@@ -1032,6 +1040,8 @@ def flash_dense_attn_func(
         is_split_qo,
         pack_gqa,
         num_splits,
+        page_table,
+        seqused_k,
         out,
         lse,
         is_autotune,
@@ -1052,8 +1062,10 @@ def flash_dense_attn_with_kvcache_func(
     window_sizes: Optional[torch.Tensor] = None,
     is_local: bool = False,
     is_quant: bool = False,
-    gather_kv_indices: Optional[torch.Tensor] = None,
     num_splits: Optional[int] = None,
+    page_table: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_autotune: bool = True,
@@ -1074,8 +1086,10 @@ def flash_dense_attn_with_kvcache_func(
     :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
-    :param gather_kv_indices: Optional TopK gather indices with shape [batch_size, topk_seqlen_k]. Each non-negative entry is an original KV sequence position to gather for decode, negative entries are masked out.
     :param num_splits: Optional split count for decode. If omitted, gather decode uses 1 split and regular decode uses a heuristic.
+    :param page_table: Optional paged KV table with shape [batch_size, max_pages]. If provided, key/value must have shape [num_pages, page_size, num_kv_heads, head_dim].
+    :param gather_kv_indices: Optional TopK gather indices with shape [batch_size, topk_seqlen_k]. Each non-negative entry is an original KV sequence position to gather for decode, negative entries are masked out.
+    :param seqused_k: Optional tensor of shape [batch_size] indicating the actual sequence lengths for keys/values.
     :param out: Optional preallocated output tensor with shape [batch_size, num_heads, head_dim].
     :param lse: Optional preallocated logsumexp tensor with shape [batch_size, num_heads].
     :param is_autotune: If True, use the cached launch config when present, on cache miss, run autotune and store the selected config. If False, tile_mn is used directly.
@@ -1105,8 +1119,10 @@ def flash_dense_attn_with_kvcache_func(
         window_sizes=window_sizes,
         is_local=is_local,
         is_quant=is_quant,
-        gather_kv_indices=gather_kv_indices,
         num_splits=num_splits,
+        page_table=page_table,
+        gather_kv_indices=gather_kv_indices,
+        seqused_k=seqused_k,
         out=out,
         lse=lse,
         is_autotune=is_autotune,

--- a/flash_sparse_attn/ops/triton/kernel_repr.py
+++ b/flash_sparse_attn/ops/triton/kernel_repr.py
@@ -14,7 +14,10 @@ def fwd_dense_repr(specialization):
     )
     varlen = "_varlen" if _get(c, "HAS_CU_SEQLENS_Q") else ""
     split = "_splitkv" if _get(c, "IS_SPLIT_KV") else ""
-    return f"flash_dense_fwd_{mask}_{c['TILE_M']}x{c['TILE_N']}{split}{varlen}"
+    is_paged = "_paged" if _get(c, "IS_PAGED_KV") else ""
+    return (
+        f"flash_dense_fwd_{mask}_{c['TILE_M']}x{c['TILE_N']}{split}{is_paged}{varlen}"
+    )
 
 
 def fwd_sparse_repr(specialization):
@@ -26,7 +29,10 @@ def fwd_sparse_repr(specialization):
     )
     varlen = "_varlen" if _get(c, "HAS_CU_SEQLENS_Q") else ""
     split = "_splitkv" if _get(c, "IS_SPLIT_KV") else ""
-    return f"flash_sparse_fwd_{mask}_{c['TILE_M']}x{c['TILE_N']}{split}{varlen}"
+    is_paged = "_paged" if _get(c, "IS_PAGED_KV") else ""
+    return (
+        f"flash_sparse_fwd_{mask}_{c['TILE_M']}x{c['TILE_N']}{split}{is_paged}{varlen}"
+    )
 
 
 def fwd_gated_repr(specialization):
@@ -38,7 +44,10 @@ def fwd_gated_repr(specialization):
     )
     varlen = "_varlen" if _get(c, "HAS_CU_SEQLENS_Q") else ""
     split = "_splitkv" if _get(c, "IS_SPLIT_KV") else ""
-    return f"flash_gated_fwd_{mask}_{c['TILE_M']}x{c['TILE_N']}{split}{varlen}"
+    is_paged = "_paged" if _get(c, "IS_PAGED_KV") else ""
+    return (
+        f"flash_gated_fwd_{mask}_{c['TILE_M']}x{c['TILE_N']}{split}{is_paged}{varlen}"
+    )
 
 
 def bwd_dense_repr(specialization):
@@ -78,24 +87,27 @@ def dec_dense_repr(specialization):
     c = specialization.constants
     mask = "local" if _get(c, "IS_LOCAL") else "full"
     varlen = "_varlen" if _get(c, "HAS_CU_SEQLENS_Q") else ""
-    gather = "_topk" if _get(c, "HAS_GATHER_KV") else ""
-    return f"flash_dense_dec_{mask}_{c['TILE_M']}x{c['TILE_N']}{gather}{varlen}"
+    paged = "_paged" if _get(c, "IS_PAGED_KV") else ""
+    gather = "_topk" if _get(c, "IS_GATHER_KV") else ""
+    return f"flash_dense_dec_{mask}_{c['TILE_M']}x{c['TILE_N']}{paged}{gather}{varlen}"
 
 
 def dec_sparse_repr(specialization):
     c = specialization.constants
     mask = "local" if _get(c, "IS_LOCAL") else "full"
     varlen = "_varlen" if _get(c, "HAS_CU_SEQLENS_Q") else ""
-    gather = "_topk" if _get(c, "HAS_GATHER_KV") else ""
-    return f"flash_sparse_dec_{mask}_{c['TILE_M']}x{c['TILE_N']}{gather}{varlen}"
+    paged = "_paged" if _get(c, "IS_PAGED_KV") else ""
+    gather = "_topk" if _get(c, "IS_GATHER_KV") else ""
+    return f"flash_sparse_dec_{mask}_{c['TILE_M']}x{c['TILE_N']}{paged}{gather}{varlen}"
 
 
 def dec_gated_repr(specialization):
     c = specialization.constants
     mask = "local" if _get(c, "IS_LOCAL") else "full"
     varlen = "_varlen" if _get(c, "HAS_CU_SEQLENS_Q") else ""
-    gather = "_topk" if _get(c, "HAS_GATHER_KV") else ""
-    return f"flash_gated_dec_{mask}_{c['TILE_M']}x{c['TILE_N']}{gather}{varlen}"
+    paged = "_paged" if _get(c, "IS_PAGED_KV") else ""
+    gather = "_topk" if _get(c, "IS_GATHER_KV") else ""
+    return f"flash_gated_dec_{mask}_{c['TILE_M']}x{c['TILE_N']}{paged}{gather}{varlen}"
 
 
 def fwd_combine_repr(specialization):

--- a/flash_sparse_attn/ops/triton/launch_template.py
+++ b/flash_sparse_attn/ops/triton/launch_template.py
@@ -69,6 +69,7 @@ class LaunchConfigCache:
                     entry["seqlen_q_bucket"],
                     entry["seqlen_k_bucket"],
                     entry["tile_k"],
+                    entry.get("tile_n", None),
                     entry["is_local"],
                     entry["qhead_per_kvhead"],
                     entry.get("is_causal", False),
@@ -83,8 +84,8 @@ class LaunchConfigCache:
     def _write_unlocked(self, device_name: str, cache: dict[tuple, tuple]) -> None:
         json_path = self._json_path(device_name)
         data = []
-        for (k_name, sq, sk, tk, local, qpk, causal, pgqa, quant), config in sorted(
-            cache.items(), key=lambda x: x[0]
+        for (k_name, sq, sk, tk, tn, local, qpk, causal, pgqa, quant), config in sorted(
+            cache.items(), key=lambda x: repr(x[0])
         ):
             data.append(
                 {
@@ -92,6 +93,7 @@ class LaunchConfigCache:
                     "seqlen_q_bucket": sq,
                     "seqlen_k_bucket": sk,
                     "tile_k": tk,
+                    "tile_n": tn,
                     "is_local": local,
                     "qhead_per_kvhead": qpk,
                     "is_causal": causal,
@@ -130,6 +132,7 @@ class LaunchConfigCache:
         seqlen_q: int,
         seqlen_k: int,
         tile_k: int,
+        tile_n: int | None = None,
         is_local: bool = False,
         qhead_per_kvhead: int = 1,
         is_causal: bool = False,
@@ -144,6 +147,7 @@ class LaunchConfigCache:
         :param seqlen_q: Sequence length of queries
         :param seqlen_k: Sequence length of keys
         :param tile_k: Tile size along the K dimension
+        :param tile_n: Optional required tile size along the N dimension
         :param is_local: Whether local mask is applied
         :param qhead_per_kvhead: Ratio of query heads to key/value heads
         :param is_causal: Whether causal mask is applied
@@ -159,13 +163,17 @@ class LaunchConfigCache:
             _seqlen_bucket(seqlen_q),
             _seqlen_bucket(seqlen_k),
             tile_k,
+            tile_n,
             is_local,
             qhead_per_kvhead,
             is_causal,
             pack_gqa,
             is_quant,
         )
-        return cache.get(key)
+        config = cache.get(key)
+        if config is not None and tile_n is not None and config[1] != tile_n:
+            return None
+        return config
 
     def put(
         self,
@@ -174,6 +182,7 @@ class LaunchConfigCache:
         seqlen_q: int,
         seqlen_k: int,
         tile_k: int,
+        tile_n: int | None = None,
         is_local: bool = False,
         qhead_per_kvhead: int = 1,
         is_causal: bool = False,
@@ -190,6 +199,7 @@ class LaunchConfigCache:
         :param seqlen_q: Sequence length of queries
         :param seqlen_k: Sequence length of keys
         :param tile_k: Tile size along the K dimension
+        :param tile_n: Optional tile size along the N dimension
         :param is_local: Whether local mask is applied
         :param qhead_per_kvhead: Ratio of query heads to key/value heads
         :param is_causal: Whether causal mask is applied
@@ -203,12 +213,15 @@ class LaunchConfigCache:
             _seqlen_bucket(seqlen_q),
             _seqlen_bucket(seqlen_k),
             tile_k,
+            tile_n,
             is_local,
             qhead_per_kvhead,
             is_causal,
             pack_gqa,
             is_quant,
         )
+        if tile_n is not None and config[1] != tile_n:
+            return
         # Skip disk write if memory cache already has the same config
         mem = self._memory.get(device_name)
         if mem is not None and mem.get(key) == config:
@@ -246,6 +259,7 @@ def load_launch_config(
     seqlen_q: int,
     seqlen_k: int,
     tile_k: int,
+    tile_n: int | None = None,
     is_local: bool = False,
     qhead_per_kvhead: int = 1,
     is_causal: bool = False,
@@ -260,6 +274,7 @@ def load_launch_config(
     :param seqlen_q: Sequence length of queries
     :param seqlen_k: Sequence length of keys
     :param tile_k: Tile size along the K dimension
+    :param tile_n: Optional required tile size along the N dimension
     :param is_local: Whether local mask is applied
     :param qhead_per_kvhead: Ratio of query heads to key/value heads
     :param is_causal: Whether causal mask is applied
@@ -274,6 +289,7 @@ def load_launch_config(
         seqlen_q,
         seqlen_k,
         tile_k,
+        tile_n,
         is_local,
         qhead_per_kvhead,
         is_causal,
@@ -288,6 +304,7 @@ def store_launch_config(
     seqlen_q: int,
     seqlen_k: int,
     tile_k: int,
+    tile_n: int | None = None,
     *,
     config: tuple[int, int, int, int, int],
     is_local: bool = False,
@@ -304,6 +321,7 @@ def store_launch_config(
     :param seqlen_q: Sequence length of queries
     :param seqlen_k: Sequence length of keys
     :param tile_k: Tile size along the K dimension
+    :param tile_n: Optional tile size along the N dimension
     :param config: Tuple of (TILE_M, TILE_N, num_warps, num_stages, num_ctas)
     :param is_local: Whether local mask is applied
     :param qhead_per_kvhead: Ratio of query heads to key/value heads
@@ -317,6 +335,7 @@ def store_launch_config(
         seqlen_q,
         seqlen_k,
         tile_k,
+        tile_n,
         is_local,
         qhead_per_kvhead,
         is_causal,

--- a/flash_sparse_attn/ops/triton/paged_kv.py
+++ b/flash_sparse_attn/ops/triton/paged_kv.py
@@ -1,0 +1,75 @@
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def load_page(page_table_base, n_block):
+    return tl.load(page_table_base + n_block)
+
+
+@triton.jit
+def load_paged_k(
+    k_base,
+    page_table_base,
+    stride_kb,
+    stride_kn,
+    n_block,
+    actual_seqlen_k,
+    head_dim,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+):
+    page = load_page(page_table_base, n_block)
+    offs_n = tl.arange(0, TILE_N)
+    offs_k = tl.arange(0, TILE_K)
+    return tl.load(
+        k_base + page * stride_kb + offs_n[:, None] * stride_kn + offs_k[None, :],
+        mask=(n_block * TILE_N + offs_n < actual_seqlen_k)[:, None]
+        & (offs_k[None, :] < head_dim),
+        other=0.0,
+        cache_modifier=".ca",
+    )
+
+
+@triton.jit
+def load_paged_v(
+    v_base,
+    page_table_base,
+    stride_vb,
+    stride_vn,
+    n_block,
+    actual_seqlen_k,
+    head_dim,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+):
+    page = load_page(page_table_base, n_block)
+    offs_n = tl.arange(0, TILE_N)
+    offs_k = tl.arange(0, TILE_K)
+    return tl.load(
+        v_base + page * stride_vb + offs_n[:, None] * stride_vn + offs_k[None, :],
+        mask=(n_block * TILE_N + offs_n < actual_seqlen_k)[:, None]
+        & (offs_k[None, :] < head_dim),
+        other=0.0,
+        cache_modifier=".ca",
+    )
+
+
+@triton.jit
+def load_paged_d(
+    d_base,
+    page_table_base,
+    stride_db,
+    stride_dn,
+    n_block,
+    actual_seqlen_k,
+    TILE_N: tl.constexpr,
+):
+    page = load_page(page_table_base, n_block)
+    offs_n = tl.arange(0, TILE_N)
+    return tl.load(
+        d_base + page * stride_db + offs_n * stride_dn,
+        mask=n_block * TILE_N + offs_n < actual_seqlen_k,
+        other=0.0,
+        cache_modifier=".ca",
+    ).to(tl.float32)

--- a/flash_sparse_attn/ops/triton/scheduler.py
+++ b/flash_sparse_attn/ops/triton/scheduler.py
@@ -1397,8 +1397,8 @@ class AttnFwdPointerScheduler:
         stride_ls=0,
         stride_pb=0,
         IS_SPLIT_KV: tl.constexpr = False,
-        IS_GATED: tl.constexpr = False,
         IS_PAGED_KV: tl.constexpr = False,
+        IS_GATED: tl.constexpr = False,
         HAS_CU_SEQLENS_Q: tl.constexpr = False,
         HAS_CU_SEQLENS_K: tl.constexpr = False,
     ):
@@ -2356,8 +2356,8 @@ class AttnDecPointerScheduler:
         stride_pb=0,
         stride_gb=0,
         stride_gn=0,
-        IS_GATED: tl.constexpr = False,
         IS_PAGED_KV: tl.constexpr = False,
+        IS_GATED: tl.constexpr = False,
         HAS_CU_SEQLENS_Q: tl.constexpr = False,
         HAS_CU_SEQLENS_K: tl.constexpr = False,
     ):

--- a/flash_sparse_attn/ops/triton/scheduler.py
+++ b/flash_sparse_attn/ops/triton/scheduler.py
@@ -355,6 +355,10 @@ class AttnFwdConfig:
         return self.m_block * self.TILE_M + tl.arange(0, self.TILE_M)
 
     @triton.jit
+    def get_offs_n(self, n_block):
+        return n_block * self.TILE_N + tl.arange(0, self.TILE_N)
+
+    @triton.jit
     def get_offs_k(self):
         return tl.arange(0, self.TILE_K)
 
@@ -571,6 +575,18 @@ class AttnBwdConfig:
             IS_ADAPT_GATE=self.IS_ADAPT_GATE,
         )
 
+    @triton.jit
+    def get_offs_m(self, m_block):
+        return m_block * self.TILE_M + tl.arange(0, self.TILE_M)
+
+    @triton.jit
+    def get_offs_n(self):
+        return self.n_block * self.TILE_N + tl.arange(0, self.TILE_N)
+
+    @triton.jit
+    def get_offs_k(self):
+        return tl.arange(0, self.TILE_K)
+
 
 @aggregate
 class AttnDecConfig:
@@ -760,6 +776,18 @@ class AttnDecConfig:
             IS_GATHER_KV,
             IS_LOGSIGMOID_GATE,
         )
+
+    @triton.jit
+    def get_offs_m(self):
+        return tl.arange(0, self.TILE_M)
+
+    @triton.jit
+    def get_offs_n(self, n_block):
+        return n_block * self.TILE_N + tl.arange(0, self.TILE_N)
+
+    @triton.jit
+    def get_offs_k(self):
+        return tl.arange(0, self.TILE_K)
 
 
 @aggregate
@@ -1550,21 +1578,11 @@ class AttnFwdPointerScheduler:
                 QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
             )
         else:
-            return tl.make_tensor_descriptor(
-                self.a_base,
-                shape=[config.actual_seqlen_q],
-                strides=[1],
-                block_shape=[config.TILE_M],
-            )
+            return self.a_base + config.get_offs_m()
 
     @triton.jit
     def make_d_ptrs(self, config: AttnFwdConfig):
-        return tl.make_tensor_descriptor(
-            self.d_base,
-            shape=[config.actual_seqlen_k],
-            strides=[1],
-            block_shape=[config.TILE_N],
-        )
+        return self.d_base
 
     @triton.jit
     def make_out_ptrs(self, config: AttnFwdConfig):
@@ -1601,12 +1619,7 @@ class AttnFwdPointerScheduler:
                 QHEAD_PER_KVHEAD_PACKGQA=config.QHEAD_PER_KVHEAD_PACKGQA,
             )
         else:
-            return tl.make_tensor_descriptor(
-                self.lse_base,
-                shape=[config.actual_seqlen_q],
-                strides=[1],
-                block_shape=[config.TILE_M],
-            )
+            return self.lse_base + config.get_offs_m()
 
     @triton.jit
     def load_q(self, config: AttnFwdConfig, q_ptrs):
@@ -1661,8 +1674,8 @@ class AttnFwdPointerScheduler:
 
     @triton.jit
     def load_a(self, config: AttnFwdConfig, a_ptrs):
+        offs_m = config.get_offs_m()
         if config.PACK_GQA:
-            offs_m = config.get_offs_m()
             return tl.load(
                 a_ptrs,
                 mask=(offs_m // config.QHEAD_PER_KVHEAD_PACKGQA)
@@ -1670,7 +1683,11 @@ class AttnFwdPointerScheduler:
                 other=0.0,
             ).to(tl.float32)
         else:
-            return a_ptrs.load([config.m_block * config.TILE_M]).to(tl.float32)
+            return tl.load(
+                a_ptrs,
+                mask=offs_m < config.actual_seqlen_q,
+                other=0.0,
+            ).to(tl.float32)
 
     @triton.jit
     def load_d(self, config: AttnFwdConfig, d_ptrs, n_block):
@@ -1685,7 +1702,12 @@ class AttnFwdPointerScheduler:
                 config.TILE_N,
             )
         else:
-            return d_ptrs.load([n_block * config.TILE_N]).to(tl.float32)
+            offs_n = config.get_offs_n(n_block)
+            return tl.load(
+                d_ptrs + offs_n,
+                mask=offs_n < config.actual_seqlen_k,
+                other=0.0,
+            ).to(tl.float32)
 
     @triton.jit
     def store_out(
@@ -1713,8 +1735,8 @@ class AttnFwdPointerScheduler:
 
     @triton.jit
     def store_lse(self, config: AttnFwdConfig, lse_ptrs, lse_tile):
+        offs_m = config.get_offs_m()
         if config.PACK_GQA:
-            offs_m = config.get_offs_m()
             tl.store(
                 lse_ptrs,
                 lse_tile,
@@ -1724,7 +1746,12 @@ class AttnFwdPointerScheduler:
                 cache_modifier=".wb",
             )
         else:
-            lse_ptrs.store([config.m_block * config.TILE_M], lse_tile)
+            tl.store(
+                lse_ptrs,
+                lse_tile,
+                mask=offs_m < config.actual_seqlen_q,
+                cache_modifier=".wb",
+            )
 
     @triton.jit
     def store_empty(
@@ -2069,21 +2096,11 @@ class AttnBwdPointerScheduler:
 
     @triton.jit
     def make_a_ptrs(self, config: AttnBwdConfig):
-        return tl.make_tensor_descriptor(
-            self.a_base,
-            shape=[config.actual_seqlen_q],
-            strides=[1],
-            block_shape=[config.TILE_M],
-        )
+        return self.a_base
 
     @triton.jit
     def make_d_ptrs(self, config: AttnBwdConfig):
-        return tl.make_tensor_descriptor(
-            self.d_base,
-            shape=[config.actual_seqlen_k],
-            strides=[1],
-            block_shape=[config.TILE_N],
-        )
+        return self.d_base + config.get_offs_n()
 
     @triton.jit
     def make_do_ptrs(self, config: AttnBwdConfig):
@@ -2096,21 +2113,11 @@ class AttnBwdPointerScheduler:
 
     @triton.jit
     def make_lse_ptrs(self, config: AttnBwdConfig):
-        return tl.make_tensor_descriptor(
-            self.lse_base,
-            shape=[config.actual_seqlen_q],
-            strides=[1],
-            block_shape=[config.TILE_M],
-        )
+        return self.lse_base
 
     @triton.jit
     def make_dpsum_ptrs(self, config: AttnBwdConfig):
-        return tl.make_tensor_descriptor(
-            self.dpsum_base,
-            shape=[config.actual_seqlen_q],
-            strides=[1],
-            block_shape=[config.TILE_M],
-        )
+        return self.dpsum_base
 
     @triton.jit
     def make_dq_accum_ptrs(self, config: AttnBwdConfig):
@@ -2141,21 +2148,11 @@ class AttnBwdPointerScheduler:
 
     @triton.jit
     def make_da_ptrs(self, config: AttnBwdConfig):
-        return tl.make_tensor_descriptor(
-            self.da_base,
-            shape=[config.actual_seqlen_q],
-            strides=[1],
-            block_shape=[config.TILE_M],
-        )
+        return self.da_base
 
     @triton.jit
     def make_dd_ptrs(self, config: AttnBwdConfig):
-        return tl.make_tensor_descriptor(
-            self.dd_base,
-            shape=[config.actual_seqlen_k],
-            strides=[1],
-            block_shape=[config.TILE_N],
-        )
+        return self.dd_base + config.get_offs_n()
 
     @triton.jit
     def load_q(self, config: AttnBwdConfig, q_ptrs, m_block):
@@ -2177,11 +2174,21 @@ class AttnBwdPointerScheduler:
 
     @triton.jit
     def load_a(self, config: AttnBwdConfig, a_ptrs, m_block):
-        return a_ptrs.load([m_block * config.TILE_M]).to(tl.float32)
+        offs_m = config.get_offs_m(m_block)
+        return tl.load(
+            a_ptrs + offs_m,
+            mask=offs_m < config.actual_seqlen_q,
+            other=0.0,
+        ).to(tl.float32)
 
     @triton.jit
     def load_d(self, config: AttnBwdConfig, d_ptrs):
-        return d_ptrs.load([config.n_block * config.TILE_N]).to(tl.float32)
+        offs_n = config.get_offs_n()
+        return tl.load(
+            d_ptrs,
+            mask=offs_n < config.actual_seqlen_k,
+            other=0.0,
+        ).to(tl.float32)
 
     @triton.jit
     def load_do(self, config: AttnBwdConfig, do_ptrs, m_block):
@@ -2189,11 +2196,21 @@ class AttnBwdPointerScheduler:
 
     @triton.jit
     def load_lse(self, config: AttnBwdConfig, lse_ptrs, m_block):
-        return lse_ptrs.load([m_block * config.TILE_M])
+        offs_m = config.get_offs_m(m_block)
+        return tl.load(
+            lse_ptrs + offs_m,
+            mask=offs_m < config.actual_seqlen_q,
+            other=0.0,
+        )
 
     @triton.jit
     def load_dpsum(self, config: AttnBwdConfig, dpsum_ptrs, m_block):
-        return dpsum_ptrs.load([m_block * config.TILE_M])
+        offs_m = config.get_offs_m(m_block)
+        return tl.load(
+            dpsum_ptrs + offs_m,
+            mask=offs_m < config.actual_seqlen_q,
+            other=0.0,
+        )
 
     @triton.jit
     def store_dq(self, config: AttnBwdConfig, dq_ptrs, m_block, dq_tile):
@@ -2215,14 +2232,28 @@ class AttnBwdPointerScheduler:
 
     @triton.jit
     def store_da(self, config: AttnBwdConfig, da_ptrs, m_block, da_tile):
-        da_ptrs.atomic_add([m_block * config.TILE_M], da_tile)
+        offs_m = config.get_offs_m(m_block)
+        tl.atomic_add(
+            da_ptrs + offs_m,
+            da_tile,
+            mask=offs_m < config.actual_seqlen_q,
+        )
 
     @triton.jit
     def store_dd(self, config: AttnBwdConfig, dd_ptrs, dd_tile):
+        offs_n = config.get_offs_n()
         if config.QHEAD_PER_KVHEAD > 1:
-            dd_ptrs.atomic_add([config.n_block * config.TILE_N], dd_tile)
+            tl.atomic_add(
+                dd_ptrs,
+                dd_tile,
+                mask=offs_n < config.actual_seqlen_k,
+            )
         else:
-            dd_ptrs.store([config.n_block * config.TILE_N], dd_tile)
+            tl.store(
+                dd_ptrs,
+                dd_tile,
+                mask=offs_n < config.actual_seqlen_k,
+            )
 
 
 @aggregate
@@ -2480,21 +2511,11 @@ class AttnDecPointerScheduler:
 
     @triton.jit
     def make_a_ptrs(self, config: AttnDecConfig):
-        return tl.make_tensor_descriptor(
-            self.a_base,
-            shape=[config.QHEAD_PER_KVHEAD_PACKGQA],
-            strides=[1],
-            block_shape=[config.TILE_M],
-        )
+        return self.a_base + config.get_offs_m()
 
     @triton.jit
     def make_d_ptrs(self, config: AttnDecConfig):
-        return tl.make_tensor_descriptor(
-            self.d_base,
-            shape=[config.actual_seqlen_k],
-            strides=[1],
-            block_shape=[config.TILE_N],
-        )
+        return self.d_base
 
     @triton.jit
     def make_out_ptrs(self, config: AttnDecConfig):
@@ -2507,12 +2528,7 @@ class AttnDecPointerScheduler:
 
     @triton.jit
     def make_lse_ptrs(self, config: AttnDecConfig):
-        return tl.make_tensor_descriptor(
-            self.lse_base,
-            shape=[config.QHEAD_PER_KVHEAD_PACKGQA],
-            strides=[1],
-            block_shape=[config.TILE_M],
-        )
+        return self.lse_base + config.get_offs_m()
 
     @triton.jit
     def load_q(self, config: AttnDecConfig, q_ptrs):
@@ -2570,7 +2586,12 @@ class AttnDecPointerScheduler:
 
     @triton.jit
     def load_a(self, config: AttnDecConfig, a_ptrs):
-        return a_ptrs.load([0]).to(tl.float32)
+        offs_m = config.get_offs_m()
+        return tl.load(
+            a_ptrs,
+            mask=offs_m < config.QHEAD_PER_KVHEAD_PACKGQA,
+            other=0.0,
+        ).to(tl.float32)
 
     @triton.jit
     def load_d(self, config: AttnDecConfig, d_ptrs, n_block, topk_indices=None):
@@ -2590,7 +2611,12 @@ class AttnDecPointerScheduler:
                 topk_indices,
             )
         else:
-            return d_ptrs.load([n_block * config.TILE_N]).to(tl.float32)
+            offs_n = config.get_offs_n(n_block)
+            return tl.load(
+                d_ptrs + offs_n,
+                mask=offs_n < config.actual_seqlen_k,
+                other=0.0,
+            ).to(tl.float32)
 
     @triton.jit
     def load_topk_indices(
@@ -2611,7 +2637,13 @@ class AttnDecPointerScheduler:
 
     @triton.jit
     def store_lse(self, config: AttnDecConfig, lse_ptrs, lse_tile):
-        lse_ptrs.store([0], lse_tile)
+        offs_m = config.get_offs_m()
+        tl.store(
+            lse_ptrs,
+            lse_tile,
+            mask=offs_m < config.QHEAD_PER_KVHEAD_PACKGQA,
+            cache_modifier=".wb",
+        )
 
     @triton.jit
     def store_empty(self, config: AttnDecConfig, out_ptrs, lse_ptrs, Out):

--- a/flash_sparse_attn/ops/triton/scheduler.py
+++ b/flash_sparse_attn/ops/triton/scheduler.py
@@ -8,6 +8,7 @@ from flash_sparse_attn.ops.triton import (
     block_info,
     mask,
     activations,
+    paged_kv,
     topk_gather_kv,
 )
 
@@ -180,6 +181,7 @@ class AttnFwdConfig:
     TILE_M: tl.constexpr
     TILE_N: tl.constexpr
     TILE_K: tl.constexpr
+    IS_PAGED_KV: tl.constexpr
     IS_LOGSIGMOID_GATE: tl.constexpr
 
     @constexpr_function
@@ -206,6 +208,7 @@ class AttnFwdConfig:
         TILE_M,
         TILE_N,
         TILE_K,
+        IS_PAGED_KV,
         IS_LOGSIGMOID_GATE,
     ):
         self.softmax_scale_log2 = softmax_scale_log2
@@ -229,6 +232,7 @@ class AttnFwdConfig:
         self.TILE_M = tl.constexpr(TILE_M)
         self.TILE_N = tl.constexpr(TILE_N)
         self.TILE_K = tl.constexpr(TILE_K)
+        self.IS_PAGED_KV = tl.constexpr(IS_PAGED_KV)
         self.IS_LOGSIGMOID_GATE = tl.constexpr(IS_LOGSIGMOID_GATE)
 
     @staticmethod
@@ -260,6 +264,7 @@ class AttnFwdConfig:
         TILE_K: tl.constexpr = 64,
         IS_CAUSAL: tl.constexpr = False,
         IS_QUANT: tl.constexpr = False,
+        IS_PAGED_KV: tl.constexpr = False,
         IS_LOGSIGMOID_GATE: tl.constexpr = False,
         IS_ADAPT_GATE: tl.constexpr = False,
         HAS_CU_SEQLENS_Q: tl.constexpr = False,
@@ -341,6 +346,7 @@ class AttnFwdConfig:
             TILE_M,
             TILE_N,
             TILE_K,
+            IS_PAGED_KV,
             IS_LOGSIGMOID_GATE,
         )
 
@@ -588,6 +594,8 @@ class AttnDecConfig:
     TILE_M: tl.constexpr
     TILE_N: tl.constexpr
     TILE_K: tl.constexpr
+    IS_PAGED_KV: tl.constexpr
+    IS_GATHER_KV: tl.constexpr
     IS_LOGSIGMOID_GATE: tl.constexpr
 
     @constexpr_function
@@ -613,6 +621,8 @@ class AttnDecConfig:
         TILE_M,
         TILE_N,
         TILE_K,
+        IS_PAGED_KV,
+        IS_GATHER_KV,
         IS_LOGSIGMOID_GATE,
     ):
         self.softmax_scale_log2 = softmax_scale_log2
@@ -635,6 +645,8 @@ class AttnDecConfig:
         self.TILE_M = tl.constexpr(TILE_M)
         self.TILE_N = tl.constexpr(TILE_N)
         self.TILE_K = tl.constexpr(TILE_K)
+        self.IS_PAGED_KV = tl.constexpr(IS_PAGED_KV)
+        self.IS_GATHER_KV = tl.constexpr(IS_GATHER_KV)
         self.IS_LOGSIGMOID_GATE = tl.constexpr(IS_LOGSIGMOID_GATE)
 
     @staticmethod
@@ -663,6 +675,8 @@ class AttnDecConfig:
         TILE_N: tl.constexpr = 64,
         TILE_K: tl.constexpr = 64,
         IS_QUANT: tl.constexpr = False,
+        IS_PAGED_KV: tl.constexpr = False,
+        IS_GATHER_KV: tl.constexpr = False,
         IS_LOGSIGMOID_GATE: tl.constexpr = False,
         HAS_CU_SEQLENS_Q: tl.constexpr = False,
         HAS_CU_SEQLENS_K: tl.constexpr = False,
@@ -742,6 +756,8 @@ class AttnDecConfig:
             TILE_M,
             TILE_N,
             TILE_K,
+            IS_PAGED_KV,
+            IS_GATHER_KV,
             IS_LOGSIGMOID_GATE,
         )
 
@@ -1118,9 +1134,9 @@ class AttnDecBlockScheduler:
         num_splits,
         topk_seqlen_k,
         IS_LOCAL: tl.constexpr,
-        HAS_GATHER_KV: tl.constexpr = False,
+        IS_GATHER_KV: tl.constexpr = False,
     ):
-        if HAS_GATHER_KV:
+        if IS_GATHER_KV:
             (
                 n_block_min,
                 n_block_max,
@@ -1179,7 +1195,7 @@ class AttnDecBlockScheduler:
             # Clamp to split's range so the no-mask loop stays within bounds
             n_block_max_no_mask = tl.minimum(n_block_max_no_mask, n_block_max)
 
-        if IS_LOCAL and not HAS_GATHER_KV:
+        if IS_LOCAL and not IS_GATHER_KV:
             # Compute local n_block range for this m_block
             n_block_max_no_mask = tl.where(
                 split_idx >= num_splits - 1,
@@ -1226,7 +1242,7 @@ class AttnDecBlockScheduler:
                 tl.minimum(n_block_window_min_no_mask, n_block_window_max),
                 n_block_window_min,
             )
-        elif not HAS_GATHER_KV:
+        elif not IS_GATHER_KV:
             n_block_window_min = 0
             n_block_window_max = 0
             n_block_window_min_no_mask = 0
@@ -1254,12 +1270,16 @@ class AttnFwdPointerScheduler:
     d_base: tl.tensor
     out_base: tl.tensor
     lse_base: tl.tensor
+    page_table_base: tl.tensor
     head_idx: tl.tensor
     stride_qh: tl.tensor
     stride_qm: tl.tensor
+    stride_kb: tl.tensor
     stride_kn: tl.tensor
+    stride_vb: tl.tensor
     stride_vn: tl.tensor
     stride_ah: tl.tensor
+    stride_db: tl.tensor
     stride_oh: tl.tensor
     stride_om: tl.tensor
     stride_lh: tl.tensor
@@ -1274,12 +1294,16 @@ class AttnFwdPointerScheduler:
         d_base,
         out_base,
         lse_base,
+        page_table_base,
         head_idx,
         stride_qh,
         stride_qm,
+        stride_kb,
         stride_kn,
+        stride_vb,
         stride_vn,
         stride_ah,
+        stride_db,
         stride_oh,
         stride_om,
         stride_lh,
@@ -1291,12 +1315,16 @@ class AttnFwdPointerScheduler:
         self.d_base = d_base
         self.out_base = out_base
         self.lse_base = lse_base
+        self.page_table_base = page_table_base
         self.head_idx = head_idx
         self.stride_qh = stride_qh
         self.stride_qm = stride_qm
+        self.stride_kb = stride_kb
         self.stride_kn = stride_kn
+        self.stride_vb = stride_vb
         self.stride_vn = stride_vn
         self.stride_ah = stride_ah
+        self.stride_db = stride_db
         self.stride_oh = stride_oh
         self.stride_om = stride_om
         self.stride_lh = stride_lh
@@ -1310,6 +1338,7 @@ class AttnFwdPointerScheduler:
         V=None,
         A=None,
         D=None,
+        PageTable=None,
         Out=None,
         Lse=None,
         batch_idx=0,
@@ -1338,8 +1367,10 @@ class AttnFwdPointerScheduler:
         stride_lb=0,
         stride_lh=0,
         stride_ls=0,
+        stride_pb=0,
         IS_SPLIT_KV: tl.constexpr = False,
         IS_GATED: tl.constexpr = False,
+        IS_PAGED_KV: tl.constexpr = False,
         HAS_CU_SEQLENS_Q: tl.constexpr = False,
         HAS_CU_SEQLENS_K: tl.constexpr = False,
     ):
@@ -1354,26 +1385,32 @@ class AttnFwdPointerScheduler:
             HAS_CU_SEQLENS_Q,
             USE_PADDED=False,
         )
-        k_base = seqlen_info.offset_batch_K(
-            K + head_kv_idx * stride_kh,
-            batch_idx,
-            config.offset_k,
-            config.padded_offset_k,
-            stride_kb,
-            stride_kn,
-            HAS_CU_SEQLENS_K,
-            USE_PADDED=False,
-        )
-        v_base = seqlen_info.offset_batch_K(
-            V + head_kv_idx * stride_vh,
-            batch_idx,
-            config.offset_k,
-            config.padded_offset_k,
-            stride_vb,
-            stride_vn,
-            HAS_CU_SEQLENS_K,
-            USE_PADDED=False,
-        )
+        if IS_PAGED_KV:
+            k_base = K + head_kv_idx * stride_kh
+            v_base = V + head_kv_idx * stride_vh
+            page_table_base = PageTable + batch_idx * stride_pb
+        else:
+            k_base = seqlen_info.offset_batch_K(
+                K + head_kv_idx * stride_kh,
+                batch_idx,
+                config.offset_k,
+                config.padded_offset_k,
+                stride_kb,
+                stride_kn,
+                HAS_CU_SEQLENS_K,
+                USE_PADDED=False,
+            )
+            v_base = seqlen_info.offset_batch_K(
+                V + head_kv_idx * stride_vh,
+                batch_idx,
+                config.offset_k,
+                config.padded_offset_k,
+                stride_vb,
+                stride_vn,
+                HAS_CU_SEQLENS_K,
+                USE_PADDED=False,
+            )
+            page_table_base = tl.full((), 0, tl.int64)
         out_base = seqlen_info.offset_batch_Q(
             Out + head_idx * stride_oh if not config.PACK_GQA else Out,
             batch_idx,
@@ -1406,20 +1443,24 @@ class AttnFwdPointerScheduler:
                 HAS_CU_SEQLENS_Q,
                 USE_PADDED=False,
             )
-            d_base = seqlen_info.offset_batch_K(
-                D + head_kv_idx * stride_dh,
-                batch_idx,
-                config.offset_k,
-                config.padded_offset_k,
-                stride_db,
-                stride_dn,
-                HAS_CU_SEQLENS_K,
-                USE_PADDED=False,
-            )
+            if IS_PAGED_KV:
+                d_base = D + head_kv_idx * stride_dh
+            else:
+                d_base = seqlen_info.offset_batch_K(
+                    D + head_kv_idx * stride_dh,
+                    batch_idx,
+                    config.offset_k,
+                    config.padded_offset_k,
+                    stride_db,
+                    stride_dn,
+                    HAS_CU_SEQLENS_K,
+                    USE_PADDED=False,
+                )
         else:
             a_base = tl.full((), 0, tl.int64)
             d_base = tl.full((), 0, tl.int64)
             stride_ah = tl.full((), 0, tl.int64)
+            stride_db = tl.full((), 0, tl.int64)
 
         # For split KV, offset output and LSE base pointers by split_idx
         if IS_SPLIT_KV:
@@ -1435,12 +1476,16 @@ class AttnFwdPointerScheduler:
             d_base,
             out_base,
             lse_base,
+            page_table_base,
             head_idx,
             stride_qh + tl.full((), 0, tl.int64),
             stride_qm + tl.full((), 0, tl.int64),
+            stride_kb + tl.full((), 0, tl.int64),
             stride_kn + tl.full((), 0, tl.int64),
+            stride_vb + tl.full((), 0, tl.int64),
             stride_vn + tl.full((), 0, tl.int64),
             stride_ah + tl.full((), 0, tl.int64),
+            stride_db + tl.full((), 0, tl.int64),
             stride_oh + tl.full((), 0, tl.int64),
             stride_om + tl.full((), 0, tl.int64),
             stride_lh + tl.full((), 0, tl.int64),
@@ -1469,21 +1514,27 @@ class AttnFwdPointerScheduler:
 
     @triton.jit
     def make_k_ptrs(self, config: AttnFwdConfig):
-        return tl.make_tensor_descriptor(
-            self.k_base,
-            shape=[config.actual_seqlen_k, config.head_dim],
-            strides=[self.stride_kn, 1],
-            block_shape=[config.TILE_N, config.TILE_K],
-        )
+        if config.IS_PAGED_KV:
+            return tl.full((), 0, tl.int64)
+        else:
+            return tl.make_tensor_descriptor(
+                self.k_base,
+                shape=[config.actual_seqlen_k, config.head_dim],
+                strides=[self.stride_kn, 1],
+                block_shape=[config.TILE_N, config.TILE_K],
+            )
 
     @triton.jit
     def make_v_ptrs(self, config: AttnFwdConfig):
-        return tl.make_tensor_descriptor(
-            self.v_base,
-            shape=[config.actual_seqlen_k, config.head_dim],
-            strides=[self.stride_vn, 1],
-            block_shape=[config.TILE_N, config.TILE_K],
-        )
+        if config.IS_PAGED_KV:
+            return tl.full((), 0, tl.int64)
+        else:
+            return tl.make_tensor_descriptor(
+                self.v_base,
+                shape=[config.actual_seqlen_k, config.head_dim],
+                strides=[self.stride_vn, 1],
+                block_shape=[config.TILE_N, config.TILE_K],
+            )
 
     @triton.jit
     def make_a_ptrs(self, config: AttnFwdConfig):
@@ -1576,11 +1627,37 @@ class AttnFwdPointerScheduler:
 
     @triton.jit
     def load_k(self, config: AttnFwdConfig, k_ptrs, n_block):
-        return k_ptrs.load([n_block * config.TILE_N, 0])
+        if config.IS_PAGED_KV:
+            return paged_kv.load_paged_k(
+                self.k_base,
+                self.page_table_base,
+                self.stride_kb,
+                self.stride_kn,
+                n_block,
+                config.actual_seqlen_k,
+                config.head_dim,
+                config.TILE_N,
+                config.TILE_K,
+            )
+        else:
+            return k_ptrs.load([n_block * config.TILE_N, 0])
 
     @triton.jit
     def load_v(self, config: AttnFwdConfig, v_ptrs, n_block):
-        return v_ptrs.load([n_block * config.TILE_N, 0])
+        if config.IS_PAGED_KV:
+            return paged_kv.load_paged_v(
+                self.v_base,
+                self.page_table_base,
+                self.stride_vb,
+                self.stride_vn,
+                n_block,
+                config.actual_seqlen_k,
+                config.head_dim,
+                config.TILE_N,
+                config.TILE_K,
+            )
+        else:
+            return v_ptrs.load([n_block * config.TILE_N, 0])
 
     @triton.jit
     def load_a(self, config: AttnFwdConfig, a_ptrs):
@@ -1597,7 +1674,18 @@ class AttnFwdPointerScheduler:
 
     @triton.jit
     def load_d(self, config: AttnFwdConfig, d_ptrs, n_block):
-        return d_ptrs.load([n_block * config.TILE_N]).to(tl.float32)
+        if config.IS_PAGED_KV:
+            return paged_kv.load_paged_d(
+                self.d_base,
+                self.page_table_base,
+                self.stride_db,
+                1,
+                n_block,
+                config.actual_seqlen_k,
+                config.TILE_N,
+            )
+        else:
+            return d_ptrs.load([n_block * config.TILE_N]).to(tl.float32)
 
     @triton.jit
     def store_out(
@@ -2146,10 +2234,14 @@ class AttnDecPointerScheduler:
     d_base: tl.tensor
     out_base: tl.tensor
     lse_base: tl.tensor
+    page_table_base: tl.tensor
     gather_kv_base: tl.tensor
     stride_qh: tl.tensor
+    stride_kb: tl.tensor
     stride_kn: tl.tensor
+    stride_vb: tl.tensor
     stride_vn: tl.tensor
+    stride_db: tl.tensor
     stride_oh: tl.tensor
     stride_gn: tl.tensor
 
@@ -2163,10 +2255,14 @@ class AttnDecPointerScheduler:
         d_base,
         out_base,
         lse_base,
+        page_table_base,
         gather_kv_base,
         stride_qh,
+        stride_kb,
         stride_kn,
+        stride_vb,
         stride_vn,
+        stride_db,
         stride_oh,
         stride_gn,
     ):
@@ -2177,10 +2273,14 @@ class AttnDecPointerScheduler:
         self.d_base = d_base
         self.out_base = out_base
         self.lse_base = lse_base
+        self.page_table_base = page_table_base
         self.gather_kv_base = gather_kv_base
         self.stride_qh = stride_qh
+        self.stride_kb = stride_kb
         self.stride_kn = stride_kn
+        self.stride_vb = stride_vb
         self.stride_vn = stride_vn
+        self.stride_db = stride_db
         self.stride_oh = stride_oh
         self.stride_gn = stride_gn
 
@@ -2193,6 +2293,7 @@ class AttnDecPointerScheduler:
         V=None,
         A=None,
         D=None,
+        PageTable=None,
         GatherKVIndices=None,
         Out=None,
         Lse=None,
@@ -2221,10 +2322,11 @@ class AttnDecPointerScheduler:
         stride_lh=0,
         stride_lm=0,
         stride_ls=0,
+        stride_pb=0,
         stride_gb=0,
         stride_gn=0,
         IS_GATED: tl.constexpr = False,
-        HAS_GATHER_KV: tl.constexpr = False,
+        IS_PAGED_KV: tl.constexpr = False,
         HAS_CU_SEQLENS_Q: tl.constexpr = False,
         HAS_CU_SEQLENS_K: tl.constexpr = False,
     ):
@@ -2239,26 +2341,32 @@ class AttnDecPointerScheduler:
             HAS_CU_SEQLENS_Q,
             USE_PADDED=False,
         )
-        k_base = seqlen_info.offset_batch_K(
-            K + head_kv_idx * stride_kh,
-            batch_idx,
-            config.offset_k,
-            config.padded_offset_k,
-            stride_kb,
-            stride_kn,
-            HAS_CU_SEQLENS_K,
-            USE_PADDED=False,
-        )
-        v_base = seqlen_info.offset_batch_K(
-            V + head_kv_idx * stride_vh,
-            batch_idx,
-            config.offset_k,
-            config.padded_offset_k,
-            stride_vb,
-            stride_vn,
-            HAS_CU_SEQLENS_K,
-            USE_PADDED=False,
-        )
+        if IS_PAGED_KV:
+            k_base = K + head_kv_idx * stride_kh
+            v_base = V + head_kv_idx * stride_vh
+            page_table_base = PageTable + batch_idx * stride_pb
+        else:
+            k_base = seqlen_info.offset_batch_K(
+                K + head_kv_idx * stride_kh,
+                batch_idx,
+                config.offset_k,
+                config.padded_offset_k,
+                stride_kb,
+                stride_kn,
+                HAS_CU_SEQLENS_K,
+                USE_PADDED=False,
+            )
+            v_base = seqlen_info.offset_batch_K(
+                V + head_kv_idx * stride_vh,
+                batch_idx,
+                config.offset_k,
+                config.padded_offset_k,
+                stride_vb,
+                stride_vn,
+                HAS_CU_SEQLENS_K,
+                USE_PADDED=False,
+            )
+            page_table_base = tl.full((), 0, tl.int64)
         out_base = seqlen_info.offset_batch_Q(
             Out + head_idx * config.QHEAD_PER_KVHEAD_PACKGQA * stride_oh,
             batch_idx,
@@ -2279,7 +2387,7 @@ class AttnDecPointerScheduler:
             HAS_CU_SEQLENS_Q,
             USE_PADDED=False,
         )
-        if HAS_GATHER_KV:
+        if config.IS_GATHER_KV:
             gather_kv_base = GatherKVIndices + batch_idx * stride_gb
         else:
             gather_kv_base = tl.full((), 0, tl.int64)
@@ -2295,16 +2403,19 @@ class AttnDecPointerScheduler:
                 HAS_CU_SEQLENS_Q,
                 USE_PADDED=False,
             )
-            d_base = seqlen_info.offset_batch_K(
-                D + head_kv_idx * stride_dh,
-                batch_idx,
-                config.offset_k,
-                config.padded_offset_k,
-                stride_db,
-                1,
-                HAS_CU_SEQLENS_K,
-                USE_PADDED=False,
-            )
+            if IS_PAGED_KV:
+                d_base = D + head_kv_idx * stride_dh
+            else:
+                d_base = seqlen_info.offset_batch_K(
+                    D + head_kv_idx * stride_dh,
+                    batch_idx,
+                    config.offset_k,
+                    config.padded_offset_k,
+                    stride_db,
+                    1,
+                    HAS_CU_SEQLENS_K,
+                    USE_PADDED=False,
+                )
         else:
             a_base = tl.full((), 0, tl.int64)
             d_base = tl.full((), 0, tl.int64)
@@ -2322,10 +2433,14 @@ class AttnDecPointerScheduler:
             d_base,
             out_base,
             lse_base,
+            page_table_base,
             gather_kv_base,
             stride_qh + tl.full((), 0, tl.int64),
+            stride_kb + tl.full((), 0, tl.int64),
             stride_kn + tl.full((), 0, tl.int64),
+            stride_vb + tl.full((), 0, tl.int64),
             stride_vn + tl.full((), 0, tl.int64),
+            stride_db + tl.full((), 0, tl.int64),
             stride_oh + tl.full((), 0, tl.int64),
             stride_gn + tl.full((), 0, tl.int64),
         )
@@ -2341,21 +2456,27 @@ class AttnDecPointerScheduler:
 
     @triton.jit
     def make_k_ptrs(self, config: AttnDecConfig):
-        return tl.make_tensor_descriptor(
-            self.k_base,
-            shape=[config.actual_seqlen_k, config.head_dim],
-            strides=[self.stride_kn, 1],
-            block_shape=[config.TILE_N, config.TILE_K],
-        )
+        if config.IS_PAGED_KV:
+            return tl.full((), 0, tl.int64)
+        else:
+            return tl.make_tensor_descriptor(
+                self.k_base,
+                shape=[config.actual_seqlen_k, config.head_dim],
+                strides=[self.stride_kn, 1],
+                block_shape=[config.TILE_N, config.TILE_K],
+            )
 
     @triton.jit
     def make_v_ptrs(self, config: AttnDecConfig):
-        return tl.make_tensor_descriptor(
-            self.v_base,
-            shape=[config.actual_seqlen_k, config.head_dim],
-            strides=[self.stride_vn, 1],
-            block_shape=[config.TILE_N, config.TILE_K],
-        )
+        if config.IS_PAGED_KV:
+            return tl.full((), 0, tl.int64)
+        else:
+            return tl.make_tensor_descriptor(
+                self.v_base,
+                shape=[config.actual_seqlen_k, config.head_dim],
+                strides=[self.stride_vn, 1],
+                block_shape=[config.TILE_N, config.TILE_K],
+            )
 
     @triton.jit
     def make_a_ptrs(self, config: AttnDecConfig):
@@ -2398,15 +2519,20 @@ class AttnDecPointerScheduler:
         return q_ptrs.load([0, 0])
 
     @triton.jit
-    def load_k(
-        self,
-        config: AttnDecConfig,
-        k_ptrs,
-        n_block,
-        topk_indices=None,
-        HAS_GATHER_KV: tl.constexpr = False,
-    ):
-        if HAS_GATHER_KV:
+    def load_k(self, config: AttnDecConfig, k_ptrs, n_block, topk_indices=None):
+        if config.IS_PAGED_KV:
+            return paged_kv.load_paged_k(
+                self.k_base,
+                self.page_table_base,
+                self.stride_kb,
+                self.stride_kn,
+                n_block,
+                config.actual_seqlen_k,
+                config.head_dim,
+                config.TILE_N,
+                config.TILE_K,
+            )
+        elif config.IS_GATHER_KV:
             return topk_gather_kv.load_gathered_k(
                 self.k_base,
                 topk_indices,
@@ -2418,15 +2544,20 @@ class AttnDecPointerScheduler:
             return k_ptrs.load([n_block * config.TILE_N, 0])
 
     @triton.jit
-    def load_v(
-        self,
-        config: AttnDecConfig,
-        v_ptrs,
-        n_block,
-        topk_indices=None,
-        HAS_GATHER_KV: tl.constexpr = False,
-    ):
-        if HAS_GATHER_KV:
+    def load_v(self, config: AttnDecConfig, v_ptrs, n_block, topk_indices=None):
+        if config.IS_PAGED_KV:
+            return paged_kv.load_paged_v(
+                self.v_base,
+                self.page_table_base,
+                self.stride_vb,
+                self.stride_vn,
+                n_block,
+                config.actual_seqlen_k,
+                config.head_dim,
+                config.TILE_N,
+                config.TILE_K,
+            )
+        elif config.IS_GATHER_KV:
             return topk_gather_kv.load_gathered_v(
                 self.v_base,
                 topk_indices,
@@ -2442,15 +2573,18 @@ class AttnDecPointerScheduler:
         return a_ptrs.load([0]).to(tl.float32)
 
     @triton.jit
-    def load_d(
-        self,
-        config: AttnDecConfig,
-        d_ptrs,
-        n_block,
-        topk_indices=None,
-        HAS_GATHER_KV: tl.constexpr = False,
-    ):
-        if HAS_GATHER_KV:
+    def load_d(self, config: AttnDecConfig, d_ptrs, n_block, topk_indices=None):
+        if config.IS_PAGED_KV:
+            return paged_kv.load_paged_d(
+                self.d_base,
+                self.page_table_base,
+                self.stride_db,
+                1,
+                n_block,
+                config.actual_seqlen_k,
+                config.TILE_N,
+            )
+        elif config.IS_GATHER_KV:
             return topk_gather_kv.load_gathered_d(
                 self.d_base,
                 topk_indices,


### PR DESCRIPTION
## Summary
- add Triton paged K/V/D loading through `page_table` and `seqused_k`
- support paged KV in dense, sparse, and gated forward/decode paths
- force paged KV launch/autotune candidates to use `TILE_N = page_size`
- keep decode gather-KV disabled when paged KV is active
- fix raw LSE addressing for partial Q tiles and split combine paths

## Validation
- `pytest ./tests` on H20: 697 passed in 651.68s

Closes #338
