### PR TITLE
Use running LSE for sparse forward skip predicate

### DIFF
--- a/flash_sparse_attn/ops/triton/activations.py
+++ b/flash_sparse_attn/ops/triton/activations.py
@@ -129,8 +129,13 @@ def online_sparse_softmax(
     # Compute current row max
     row_max_curr = tl.max(acc_s, axis=1)
 
-    # Update skip condition based on threshold
+    # Compute scaled differences to new row max
     row_max_diff_log2 = (row_max_curr - row_max) * scale_log2
+
+    # Compute approximate final probability with current row max diff and row sum
+    row_max_diff_log2 -= tl.log2(row_sum)
+
+    # Update skip condition based on threshold
     skip_softmax = tl.max(row_max_diff_log2 - softmax_threshold_log2) < 0.0
 
     # Return zero attention weights


### PR DESCRIPTION
## Summary

- update sparse online softmax skip to account for the online row normalizer
- make the forward skip predicate approximate normalized probability rather than only score gap from the running max
- keep the change in the shared sparse softmax helper so sparse/gated forward and decode paths use consistent skip semantics

## Motivation

The previous forward predicate was much more conservative than backward because it did not divide by the online softmax row sum. In long-sequence synthetic LLM-style measurements, `threshold ~= 1 / seqlen` skipped about 1.6% of forward tiles at `seqlen=32768`, while backward skipped about 79%.

With the running-LSE predicate, forward skip at the same setting is about 77.9%, close to backward's 79.0%.

Closes #343
