### PR TITLE
refactor: define softmax_threshold as a uniform-attention multiplier

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ value = torch.randn(batch_size, seqlen, num_kv_heads, head_dim, dtype=dtype, dev
 output = flash_sparse_attn_func(
     query, key, value,
     is_causal=True,
-    softmax_threshold=128.0 / seqlen,
+    softmax_threshold=1.0,
     is_local=True,
     is_quant=True,
     is_split_kv=True,
@@ -144,7 +144,7 @@ value = torch.randn(batch_size, seqlen, num_kv_heads, head_dim, dtype=dtype, dev
 output = flash_sparse_attn_func(
     query, key, value,
     is_causal=True,
-    softmax_threshold=1.0 / seqlen,
+    softmax_threshold=1.0,
     is_local=True,
     is_quant=True,
     is_split_kv=True,
@@ -166,7 +166,7 @@ value = torch.randn(batch_size, seqlen, num_kv_heads, head_dim, dtype=dtype, dev
 def fsa_decode_fn():
     return flash_sparse_attn_with_kvcache_func(
         query, key, value,
-        softmax_threshold=128.0 / seqlen,
+        softmax_threshold=1.0,
         is_local=True,
         is_quant=True,
     )

--- a/README_zh.md
+++ b/README_zh.md
@@ -127,7 +127,7 @@ value = torch.randn(batch_size, seqlen, num_kv_heads, head_dim, dtype=dtype, dev
 output = flash_sparse_attn_func(
     query, key, value,
     is_causal=True,
-    softmax_threshold=128.0 / seqlen,
+    softmax_threshold=1.0,
     is_local=True,
     is_quant=True,
     is_split_kv=True,
@@ -146,7 +146,7 @@ value = torch.randn(batch_size, seqlen, num_kv_heads, head_dim, dtype=dtype, dev
 output = flash_sparse_attn_func(
     query, key, value,
     is_causal=True,
-    softmax_threshold=1.0 / seqlen,
+    softmax_threshold=1.0,
     is_local=True,
     is_quant=True,
     is_split_kv=True,
@@ -168,7 +168,7 @@ value = torch.randn(batch_size, seqlen, num_kv_heads, head_dim, dtype=dtype, dev
 def fsa_decode_fn():
     return flash_sparse_attn_with_kvcache_func(
         query, key, value,
-        softmax_threshold=128.0 / seqlen,
+        softmax_threshold=1.0,
         is_local=True,
         is_quant=True,
     )

--- a/flash_sparse_attn/ops/triton/flash_gated_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_bwd.py
@@ -720,9 +720,7 @@ def _flash_gated_attn_backward(
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
-    softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else 1.0 / seqlen_k
-    )
+    softmax_threshold = softmax_threshold if softmax_threshold is not None else 1.0
     gate_threshold = gate_threshold if gate_threshold is not None else 1.0 / seqlen_k
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
@@ -1035,9 +1033,7 @@ def _flash_gated_attn_varlen_backward(
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
-    softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else 1.0 / seqlen_k
-    )
+    softmax_threshold = softmax_threshold if softmax_threshold is not None else 1.0
     gate_threshold = gate_threshold if gate_threshold is not None else 1.0 / seqlen_k
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:

--- a/flash_sparse_attn/ops/triton/flash_gated_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_dec.py
@@ -883,9 +883,7 @@ def _flash_gated_attn_decode(
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
-    softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else 1.0 / seqlen_k
-    )
+    softmax_threshold = softmax_threshold if softmax_threshold is not None else 1.0
     gate_threshold = gate_threshold if gate_threshold is not None else 1.0 / seqlen_k
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
@@ -1133,9 +1131,7 @@ def _flash_gated_attn_varlen_decode(
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
-    softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else 1.0 / seqlen_k
-    )
+    softmax_threshold = softmax_threshold if softmax_threshold is not None else 1.0
     gate_threshold = gate_threshold if gate_threshold is not None else 1.0 / seqlen_k
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:

--- a/flash_sparse_attn/ops/triton/flash_gated_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_gated_fwd.py
@@ -889,9 +889,7 @@ def _flash_gated_attn_forward(
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
-    softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else 1.0 / seqlen_k
-    )
+    softmax_threshold = softmax_threshold if softmax_threshold is not None else 1.0
     gate_threshold = gate_threshold if gate_threshold is not None else 1.0 / seqlen_k
     qhead_per_kvhead = num_heads_q // num_heads_kv
     qhead_per_kvhead_packgqa = num_heads_q // num_heads_kv if pack_gqa else 1
@@ -1157,9 +1155,7 @@ def _flash_gated_attn_varlen_forward(
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
-    softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else 1.0 / seqlen_k
-    )
+    softmax_threshold = softmax_threshold if softmax_threshold is not None else 1.0
     gate_threshold = gate_threshold if gate_threshold is not None else 1.0 / seqlen_k
     qhead_per_kvhead = num_heads_q // num_heads_kv
     qhead_per_kvhead_packgqa = num_heads_q // num_heads_kv if pack_gqa else 1

--- a/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
@@ -524,9 +524,7 @@ def _flash_sparse_attn_backward(
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
-    softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else 1.0 / seqlen_k
-    )
+    softmax_threshold = softmax_threshold if softmax_threshold is not None else 1.0
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
@@ -797,9 +795,7 @@ def _flash_sparse_attn_varlen_backward(
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
-    softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else 1.0 / seqlen_k
-    )
+    softmax_threshold = softmax_threshold if softmax_threshold is not None else 1.0
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)

--- a/flash_sparse_attn/ops/triton/flash_sparse_dec.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_dec.py
@@ -578,9 +578,7 @@ def _flash_sparse_attn_decode(
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
-    softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else 1.0 / seqlen_k
-    )
+    softmax_threshold = softmax_threshold if softmax_threshold is not None else 1.0
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)
@@ -813,9 +811,7 @@ def _flash_sparse_attn_varlen_decode(
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
-    softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else 1.0 / seqlen_k
-    )
+    softmax_threshold = softmax_threshold if softmax_threshold is not None else 1.0
     qhead_per_kvhead = num_heads_q // num_heads_kv
     if is_local and window_sizes is None:
         window_sizes = utils.window_sizes_heuristic(seqlen_k, num_heads_kv, device)

--- a/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
+++ b/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
@@ -566,9 +566,7 @@ def _flash_sparse_attn_forward(
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
-    softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else 1.0 / seqlen_k
-    )
+    softmax_threshold = softmax_threshold if softmax_threshold is not None else 1.0
     qhead_per_kvhead = num_heads_q // num_heads_kv
     qhead_per_kvhead_packgqa = num_heads_q // num_heads_kv if pack_gqa else 1
     if is_local and window_sizes is None:
@@ -815,9 +813,7 @@ def _flash_sparse_attn_varlen_forward(
     softmax_scale = (
         softmax_scale if softmax_scale is not None else 1.0 / (head_dim**0.5)
     )
-    softmax_threshold = (
-        softmax_threshold if softmax_threshold is not None else 1.0 / seqlen_k
-    )
+    softmax_threshold = softmax_threshold if softmax_threshold is not None else 1.0
     qhead_per_kvhead = num_heads_q // num_heads_kv
     qhead_per_kvhead_packgqa = num_heads_q // num_heads_kv if pack_gqa else 1
     if is_local and window_sizes is None:

--- a/flash_sparse_attn/ops/triton/interface.py
+++ b/flash_sparse_attn/ops/triton/interface.py
@@ -1361,7 +1361,7 @@ def flash_sparse_attn_func(
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
     :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
-    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1 / seqlen_k.
+    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided or will be computed from the input tensors.
     :param is_split_kv: Whether to enable split-KV for forward occupancy.
@@ -1441,7 +1441,7 @@ def flash_sparse_attn_with_kvcache_func(
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
     :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
-    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1 / seqlen_k.
+    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param num_splits: Optional split count for decode. If omitted, gather decode uses 1 split and regular decode uses a heuristic.
@@ -1540,7 +1540,7 @@ def flash_sparse_attn_varlen_func(
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
     :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
-    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1 / max_seqlen_k.
+    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided or will be computed from the input tensors.
     :param is_split_kv: Whether to enable split-KV for forward occupancy.
@@ -1628,7 +1628,7 @@ def flash_sparse_attn_varlen_with_kvcache_func(
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
     :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
-    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1 / max_seqlen_k.
+    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1.
     :param is_local: Whether to apply a local mask.
     :param is_quant: Whether the inputs are quantized. If True, query_scale, key_scale, and value_scale must be provided for dequantization.
     :param seqused_k: Optional tensor indicating the actual sequence lengths for keys/values.
@@ -1726,7 +1726,7 @@ def flash_gated_attn_func(
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
     :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
-    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1 / seqlen_k.
+    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1.
     :param gate_threshold: Optional threshold for the sparsity gate. If None, defaults to 1 / seqlen_k.
     :param is_logsigmoid_gate: Whether to use a log-sigmoid function for the sparsity gate. If False, uses a linear function.
     :param is_adapt_gate: Whether to adapt the gate threshold based on sequence length.
@@ -1820,7 +1820,7 @@ def flash_gated_attn_with_kvcache_func(
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
     :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
-    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1 / seqlen_k.
+    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1.
     :param gate_threshold: Optional threshold for the sparsity gate. If None, defaults to 1 / seqlen_k.
     :param is_logsigmoid_gate: Whether to use a log-sigmoid function for the sparsity gate. If False, uses a linear function.
     :param is_local: Whether to apply a local mask.
@@ -1935,7 +1935,7 @@ def flash_gated_attn_varlen_func(
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
     :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
-    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1 / max_seqlen_k.
+    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1.
     :param gate_threshold: Optional threshold for the sparsity gate. If None, defaults to 1 / max_seqlen_k.
     :param is_logsigmoid_gate: Whether to use a log-sigmoid function for the sparsity gate. If False, uses a linear function.
     :param is_adapt_gate: Whether to adapt the gate threshold based on sequence length.
@@ -2036,7 +2036,7 @@ def flash_gated_attn_varlen_with_kvcache_func(
     :param key_scale: Optional per-tensor scale for key dequantization.
     :param value_scale: Optional per-tensor scale for value dequantization.
     :param window_sizes: Optional window sizes tensor for flexible local attention. Must be shape [num_kv_heads, 4] with dtype int32, with columns [window_sink, window_left, window_right, window_dist]. If provided, is_local is automatically set to True.
-    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1 / max_seqlen_k.
+    :param softmax_threshold: Optional threshold for the sparse softmax. If None, defaults to 1.
     :param gate_threshold: Optional threshold for the sparsity gate. If None, defaults to 1 / max_seqlen_k.
     :param is_logsigmoid_gate: Whether to use a log-sigmoid function for the sparsity gate. If False, uses a linear function.
     :param is_local: Whether to apply a local mask.

--- a/flash_sparse_attn/ops/triton/seqlen_info.py
+++ b/flash_sparse_attn/ops/triton/seqlen_info.py
@@ -128,7 +128,7 @@ def get_softmax_threshold(
     """
     Compute the softmax threshold for a given block.
 
-    :param softmax_threshold: Threshold value normalized by full key length.
+    :param softmax_threshold: Dimensionless multiple of uniform attention.
     :param m_block: Current block index along the M dimension.
     :param seqlen_q: Sequence length of the query.
     :param seqlen_k: Sequence length of the key.
@@ -144,10 +144,12 @@ def get_softmax_threshold(
         if QHEAD_PER_KVHEAD_PACKGQA > 1:
             q_idx = q_idx // QHEAD_PER_KVHEAD_PACKGQA
         causal_offset = seqlen_k - seqlen_q
-        s_thr = softmax_threshold * (q_idx + causal_offset + 1.0) / seqlen_k
+        visible_len = (q_idx + causal_offset + 1).to(tl.float32)
     else:
-        s_thr = tl.full((TILE_M,), softmax_threshold, dtype=tl.float32)
-    softmax_threshold_log2 = tl.log2(s_thr)
+        visible_len = tl.full((TILE_M,), seqlen_k, dtype=tl.float32)
+    softmax_threshold_log2 = tl.log2(
+        tl.maximum(tl.minimum(softmax_threshold / visible_len, 1.0), 0.0)
+    )
     return softmax_threshold_log2
 
 

--- a/tests/benchmark_backward.py
+++ b/tests/benchmark_backward.py
@@ -297,7 +297,7 @@ def benchmark_fsa_skip_backward(
     k = k.requires_grad_(True)
     v = v.requires_grad_(True)
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = cfg.head_dim / cfg.seqlen_k
+    softmax_threshold = 1.0
     try:
         out = flash_sparse_attn_func(
             q,
@@ -344,7 +344,7 @@ def benchmark_fsa_all_backward(
     k = k.requires_grad_(True)
     v = v.requires_grad_(True)
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = cfg.head_dim / cfg.seqlen_k
+    softmax_threshold = 1.0
     window_sizes = window_sizes_heuristic(
         cfg.seqlen_k, cfg.num_kv_heads, device=torch.device(device)
     )

--- a/tests/benchmark_decode.py
+++ b/tests/benchmark_decode.py
@@ -320,7 +320,7 @@ def benchmark_fsa_skip_decode(
     )
     q = q.squeeze(1)
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = cfg.head_dim / cfg.seqlen_k
+    softmax_threshold = 1.0
     try:
 
         def fn():
@@ -361,7 +361,7 @@ def benchmark_fsa_all_decode(
     k_quant, k_scale = quant.quantize_fp8(k)
     v_quant, v_scale = quant.quantize_fp8(v)
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = cfg.head_dim / cfg.seqlen_k
+    softmax_threshold = 1.0
     window_sizes = window_sizes_heuristic(
         cfg.seqlen_k, cfg.num_kv_heads, device=torch.device(device)
     )

--- a/tests/benchmark_forward.py
+++ b/tests/benchmark_forward.py
@@ -244,7 +244,7 @@ def benchmark_fsa_skip_forward(
         layout="bshd",
     )
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = cfg.head_dim / cfg.seqlen_k
+    softmax_threshold = 1.0
     try:
 
         def fn():
@@ -285,7 +285,7 @@ def benchmark_fsa_all_forward(
     k_quant, k_scale = quant.quantize_fp8(k)
     v_quant, v_scale = quant.quantize_fp8(v)
     softmax_scale = cfg.head_dim**-0.5
-    softmax_threshold = cfg.head_dim / cfg.seqlen_k
+    softmax_threshold = 1.0
     window_sizes = window_sizes_heuristic(
         cfg.seqlen_k, cfg.num_kv_heads, device=torch.device(device)
     )


### PR DESCRIPTION
## Summary

Define `softmax_threshold` as a dimensionless multiplier of uniform attention and derive the effective per-row probability threshold from the number of visible keys.

Closes #345

## Design

Given `softmax_threshold = alpha`, the kernels use:

```text
effective_threshold = clamp(alpha / visible_len, 0, 1)
```

For non-causal attention:

```text
visible_len = seqlen_k
```

For bottom-right causal attention:

```text
visible_len = q_position + (seqlen_k - seqlen_q) + 1
```

This makes `alpha = 1` correspond to the uniform-attention probability for each query row, independent of the full sequence length.

The effective threshold remains clamped to `[0, 1]` because it represents a softmax probability. `visible_len` itself is not clamped: valid scheduled rows and the supported `seqlen_q <= actual_seqlen_k` invariant already guarantee a valid visible-key count.

## Changes

- Update `get_softmax_threshold` to normalize by the per-row visible key count.
- Handle bottom-right causal positions, including packed-GQA query indexing.
- Change the default `softmax_threshold` from `1 / seqlen_k` to `1.0`.
- Apply the default consistently across sparse/gated attention, forward/backward/decode, and fixed/varlen/KV-cache paths.
- Update public API documentation for the new semantics and default.
- Update forward, backward, and decode benchmark configurations.
- Leave `gate_threshold` semantics unchanged.

## Compatibility

This intentionally changes the meaning of explicitly supplied `softmax_threshold` values. Callers should now pass a multiplier relative to uniform attention instead of a probability pre-normalized by the full key length.

## Validation

- `git diff --check`
- `python -m compileall -q flash_sparse_attn`
- Reviewed threshold propagation across sparse/gated forward, backward, and decode paths.
- GPU tests were not run in the current environment because PyTorch/CUDA is unavailable.

## Checklist

- [x] Linked issue provided
- [x] API semantics and documentation updated
- [x] Benchmark configurations updated
- [x] Sparse and gated kernel paths kept consistent
- [x] `gate_threshold` semantics unchanged
