### PR TITLE
Add CuTe softmax-threshold sparse forward and backward kernels

### DIFF
--- a/flash_sparse_attn/ops/cute/ampere_helpers.py
+++ b/flash_sparse_attn/ops/cute/ampere_helpers.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026, Jingze Shi.
 # Copyright (c) 2025, Tri Dao.
 from typing import Type, Callable, Optional
 
@@ -42,6 +43,7 @@ def gemm(
     smem_thr_copy_A: cute.TiledCopy,
     smem_thr_copy_B: cute.TiledCopy,
     hook_fn: Optional[Callable] = None,
+    hook_args: tuple = (),
     A_in_regs: cutlass.Constexpr[bool] = False,
     B_in_regs: cutlass.Constexpr[bool] = False,
     swap_AB: cutlass.Constexpr[bool] = False,
@@ -57,6 +59,7 @@ def gemm(
             smem_thr_copy_B,
             smem_thr_copy_A,
             hook_fn,
+            hook_args=hook_args,
             A_in_regs=B_in_regs,
             B_in_regs=A_in_regs,
             swap_AB=False,
@@ -80,7 +83,7 @@ def gemm(
                     )
             cute.gemm(tiled_mma, acc, tCrA[None, None, k], tCrB[None, None, k], acc)
             if cutlass.const_expr(k == 0 and hook_fn is not None):
-                hook_fn()
+                hook_fn(*hook_args)
 
 
 @cute.jit

--- a/flash_sparse_attn/ops/cute/flash_bwd.py
+++ b/flash_sparse_attn/ops/cute/flash_bwd.py
@@ -1,4 +1,8 @@
+# Copyright (c) 2026, Jingze Shi.
 # Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+# A reimplementation of
+# https://github.com/HKUSTDial/flash-sparse-attention/blob/main/flash_sparse_attn/ops/triton/flash_sparse_bwd.py
+# from Triton to Cute-DSL.
 # A reimplementation of https://github.com/Dao-AILab/flash-attention/blob/main/hopper/mainloop_bwd_sm80.hpp
 # from Cutlass C++ to Cute-DSL.
 import math
@@ -41,7 +45,7 @@ class FlashAttentionBackwardSm80:
         m_block_size: int = 64,
         n_block_size: int = 128,
         num_stages_Q: int = 2,
-        num_stages_dO: int = 2,
+        num_stages_dO: int = 1,
         num_threads: int = 256,
         pack_gqa: bool = False,
         is_causal: bool = False,
@@ -49,9 +53,9 @@ class FlashAttentionBackwardSm80:
         SdP_swapAB: bool = False,
         dKV_swapAB: bool = False,
         dQ_swapAB: bool = False,
-        AtomLayoutMSdP: int = 1,
-        AtomLayoutNdKV: int = 8,
-        AtomLayoutMdQ: int = 1,
+        AtomLayoutMSdP: int = 2,
+        AtomLayoutNdKV: int = 2,
+        AtomLayoutMdQ: int = 2,
         V_in_regs: bool = False,
         score_mod: cutlass.Constexpr | None = None,
         score_mod_bwd: cutlass.Constexpr | None = None,
@@ -980,6 +984,7 @@ class FlashAttentionBackwardSm80:
                     mask_seqlen=True,
                     mask_causal=self.is_causal,
                     mask_local=self.is_local,
+                    use_r2p=False,
                 )
                 smem_pipe_read_q = cutlass.Int32(0)
                 smem_pipe_read_do = cutlass.Int32(0)
@@ -1616,3 +1621,1623 @@ class FlashAttentionBackwardSm80:
                         smem_pipe_write_q if cutlass.const_expr(self.num_stages_dO > 1) else 0,
                     ],
                 )
+
+
+class FlashSparseAttentionBackwardSm80:
+    def __init__(
+        self,
+        dtype: Type[cutlass.Numeric],
+        head_dim: int,
+        qhead_per_kvhead: int = 1,
+        m_block_size: int = 64,
+        n_block_size: int = 128,
+        num_stages_Q: int = 2,
+        num_threads: int = 256,
+        pack_gqa: bool = False,
+        is_causal: bool = False,
+        is_local: bool = False,
+        SdP_swapAB: bool = False,
+        dKV_swapAB: bool = False,
+        dQ_swapAB: bool = False,
+        AtomLayoutMSdP: int = 2,
+        AtomLayoutNdKV: int = 2,
+        AtomLayoutMdQ: int = 2,
+        V_in_regs: bool = False,
+        score_mod: cutlass.Constexpr | None = None,
+        score_mod_bwd: cutlass.Constexpr | None = None,
+    ):
+        """Initializes the configuration for a flash sparse attention kernel.
+
+        All contiguous dimensions must be at least 16 bytes aligned which indicates the head dimension
+        should be a multiple of 8.
+
+        :param head_dim: head dimension
+        :type head_dim: int
+        :param m_block_size: m block size
+        :type m_block_size: int
+        :param n_block_size: n block size
+        :type n_block_size: int
+        :param num_threads: number of threads
+        :type num_threads: int
+        :param is_causal: is causal
+        :type is_causal: bool
+        """
+        self.dtype = dtype
+        # padding head_dim to a multiple of 32 (stricter than fwd's 16) due to
+        # backward kernel register layout requirements for dQ/dK/dV accumulation
+        hdim_multiple_of = 32
+        self.head_dim_padded = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
+        # Can save registers (and hence be faster) if we don't have to check hdim predication
+        self.check_hdim_oob = head_dim != self.head_dim_padded
+        self.qhead_per_kvhead = qhead_per_kvhead
+        self.m_block_size = m_block_size
+        self.n_block_size = n_block_size
+        self.num_threads = num_threads
+        self.num_warps = num_threads // cute.arch.WARP_SIZE
+        self.pack_gqa = pack_gqa
+        self.is_causal = is_causal
+        self.is_local = is_local
+        self.num_stages_Q = num_stages_Q
+        self.SdP_swapAB = SdP_swapAB
+        self.dKV_swapAB = dKV_swapAB
+        self.dQ_swapAB = dQ_swapAB
+        self.AtomLayoutMSdP = AtomLayoutMSdP
+        self.AtomLayoutNdKV = AtomLayoutNdKV
+        self.AtomLayoutMdQ = AtomLayoutMdQ
+        num_mma_warps = self.num_threads // cute.arch.WARP_SIZE
+        self.Mma_dKV_is_RS = (
+            AtomLayoutMSdP == 1
+            and AtomLayoutNdKV == num_mma_warps
+            and SdP_swapAB
+            and not dKV_swapAB
+        )
+        self.V_in_regs = V_in_regs
+        self.share_QV_smem = V_in_regs
+        self.score_mod = score_mod
+        self.score_mod_bwd = score_mod_bwd
+
+    @staticmethod
+    def can_implement(
+        dtype,
+        head_dim,
+        m_block_size,
+        n_block_size,
+        num_stages_Q,
+        num_threads,
+        is_causal,
+        V_in_regs=False,
+    ) -> bool:
+        """Check if the kernel can be implemented with the given parameters.
+
+        :param dtype: data type
+        :type dtype: cutlass.Numeric
+        :param head_dim: head dimension
+        :type head_dim: int
+        :param m_block_size: m block size
+        :type m_block_size: int
+        :param n_block_size: n block size
+        :type n_block_size: int
+        :param num_threads: number of threads
+        :type num_threads: int
+        :param is_causal: is causal
+        :type is_causal: bool
+
+        :return: True if the kernel can be implemented, False otherwise
+        :rtype: bool
+        """
+        if dtype not in [cutlass.Float16, cutlass.BFloat16]:
+            return False
+        if head_dim % 8 != 0:
+            return False
+        if n_block_size % 16 != 0:
+            return False
+        if num_threads % 32 != 0:
+            return False
+        # Check if block size setting is out of shared memory capacity
+        # Shared memory usage: Q tile + (K tile + V tile) where K and V use the same tile size
+        smem_usage_Q = m_block_size * head_dim * num_stages_Q * 2
+        smem_usage_dO = m_block_size * head_dim * 2
+        smem_usage_K = n_block_size * head_dim * 2
+        smem_usage_V = n_block_size * head_dim * 2
+        smem_usage_QV = (
+            (smem_usage_Q + smem_usage_V) if not V_in_regs else max(smem_usage_Q, smem_usage_V)
+        )
+        smem_usage = smem_usage_QV + smem_usage_dO + smem_usage_K
+        smem_capacity = utils_basic.get_smem_capacity_in_bytes("sm_80")
+        if smem_usage > smem_capacity:
+            return False
+        return True
+
+    def _check_type(
+        self,
+        mQ_type: Type[cutlass.Numeric],
+        mK_type: Type[cutlass.Numeric],
+        mV_type: Type[cutlass.Numeric],
+        mdO_type: Type[cutlass.Numeric],
+        mLSE_type: Type[cutlass.Numeric],
+        mdPsum_type: Type[cutlass.Numeric],
+        mdQaccum_type: Type[cutlass.Numeric],
+        mdK_type: Type[cutlass.Numeric],
+        mdV_type: Type[cutlass.Numeric],
+        mCuSeqlensQ_type: Type[cutlass.Numeric] | None,
+        mCuSeqlensK_type: Type[cutlass.Numeric] | None,
+        mSeqUsedQ_type: Type[cutlass.Numeric] | None,
+        mSeqUsedK_type: Type[cutlass.Numeric] | None,
+    ):
+        if cutlass.const_expr(not (mQ_type == mK_type == mV_type == mdO_type)):
+            raise TypeError("All tensors must have the same data type")
+        if cutlass.const_expr(self.qhead_per_kvhead == 1):
+            if cutlass.const_expr(not (mdK_type == mdV_type == mQ_type)):
+                raise TypeError("mdK and mdV tensors must have the same data type as mQ")
+        else:
+            if cutlass.const_expr(not (mdK_type == mdV_type == cutlass.Float32)):
+                raise TypeError("mdKaccum and mdVaccum tensors must have the data type Float32")
+        if cutlass.const_expr(mQ_type not in [cutlass.Float16, cutlass.BFloat16]):
+            raise TypeError("Only Float16 or BFloat16 is supported")
+        if cutlass.const_expr(mLSE_type not in [cutlass.Float32]):
+            raise TypeError("LSE tensor must be Float32")
+        if cutlass.const_expr(mdPsum_type not in [cutlass.Float32]):
+            raise TypeError("dPsum tensor must be Float32")
+        if cutlass.const_expr(mdQaccum_type not in [cutlass.Float32]):
+            raise TypeError("dQaccum tensor must be Float32")
+        if cutlass.const_expr(mCuSeqlensQ_type not in [None, cutlass.Int32]):
+            raise TypeError("cuSeqlensQ tensor must be Int32")
+        if cutlass.const_expr(mCuSeqlensK_type not in [None, cutlass.Int32]):
+            raise TypeError("cuSeqlensK tensor must be Int32")
+        if cutlass.const_expr(mSeqUsedQ_type not in [None, cutlass.Int32]):
+            raise TypeError("SeqUsedQ tensor must be Int32")
+        if cutlass.const_expr(mSeqUsedK_type not in [None, cutlass.Int32]):
+            raise TypeError("SeqUsedK tensor must be Int32")
+        assert mQ_type == self.dtype
+
+    def _setup_attributes(self):
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Shared memory layout: Q/K/V
+        # ///////////////////////////////////////////////////////////////////////////////
+        sQ_layout_atom = sm80_utils.get_smem_layout_atom(self.dtype, self.head_dim_padded)
+        self.sQ_layout = cute.tile_to_shape(
+            sQ_layout_atom,
+            (self.m_block_size, self.head_dim_padded, self.num_stages_Q),
+            (0, 1, 2),
+        )
+        sK_layout_atom = sQ_layout_atom
+        self.sK_layout = cute.tile_to_shape(
+            sK_layout_atom,
+            (self.n_block_size, self.head_dim_padded),
+            (0, 1),
+        )
+        sV_layout_atom = sm80_utils.get_smem_layout_atom(self.dtype, self.head_dim_padded)
+        self.sV_layout = cute.tile_to_shape(
+            sV_layout_atom,
+            (self.n_block_size, self.head_dim_padded),
+            (0, 1),
+        )
+        sdO_layout_atom = sV_layout_atom
+        self.sdO_layout = cute.tile_to_shape(
+            sdO_layout_atom,
+            (self.m_block_size, self.head_dim_padded, 1),
+            (0, 1, 2),
+        )
+        # TODO: do we set swizzle to be 3 here explicitly?
+        sPdS_layout_atom = sm80_utils.get_smem_layout_atom(self.dtype, self.n_block_size)
+        self.sPdS_layout = cute.tile_to_shape(
+            sPdS_layout_atom,
+            (self.m_block_size, self.n_block_size),
+            (0, 1),
+        )
+        # We set stride to be multiple of 64 so that if ShuffleLSE, even if threads read from sLSE but out of bounds,
+        # it's still a valid smem address.
+        self.sLSE_layout = cute.make_layout(
+            (self.m_block_size, self.num_stages_Q),
+            stride=(1, cute.round_up(self.m_block_size, 64)),
+        )
+        sLSEMma_layout = cute.make_layout(
+            (self.m_block_size, self.n_block_size, self.num_stages_Q),
+            stride=(1, 0, cute.round_up(self.m_block_size, 64)),
+        )
+        sLSEMma_layout_transposed = cute.make_layout(
+            (self.n_block_size, self.m_block_size, self.num_stages_Q),
+            stride=(0, 1, cute.round_up(self.m_block_size, 64)),
+        )
+        self.sLSEMma_layout = sLSEMma_layout if not self.SdP_swapAB else sLSEMma_layout_transposed
+        self.sSkip_layout = cute.make_layout((self.num_warps,))
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # GMEM Tiled copy:
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Thread layouts for copies
+        universal_copy_bits = 128
+        async_copy_elems = universal_copy_bits // self.dtype.width
+        # atom_async_copy: async copy atom for QKV load
+        atom_async_copy = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            self.dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        # atom_universal_copy: universal copy atom for O store
+        atom_universal_copy = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        # tQK_layout: thread layout for QK load
+        tQK_shape_dim_1 = sQ_layout_atom.outer.shape[1] // async_copy_elems
+        assert self.num_threads % tQK_shape_dim_1 == 0, (
+            "num_threads must be divisible by tQK_shape_dim_1"
+        )
+        tQK_layout = cute.make_ordered_layout(
+            (self.num_threads // tQK_shape_dim_1, tQK_shape_dim_1),
+            order=(1, 0),
+        )
+        # Do we need to check if we overshot kBlockM when we load Q?
+        self.is_even_m_smem_q = self.m_block_size % tQK_layout.shape[0] == 0
+        # Do we need to check if we overshot kBlockN when we load K?
+        self.is_even_n_smem_k = self.n_block_size % tQK_layout.shape[0] == 0
+        tVdO_shape_dim_1 = sV_layout_atom.outer.shape[1] // async_copy_elems
+        assert self.num_threads % tVdO_shape_dim_1 == 0, (
+            "num_threads must be divisible by tVdO_shape_dim_1"
+        )
+        tVdO_layout = cute.make_ordered_layout(
+            (self.num_threads // tVdO_shape_dim_1, tVdO_shape_dim_1),
+            order=(1, 0),
+        )
+        # Do we need to check if we overshot kBlockN when we load V?
+        self.is_even_n_smem_v = self.n_block_size % tVdO_layout.shape[0] == 0
+        self.is_even_m_smem_do = self.m_block_size % tVdO_layout.shape[0] == 0
+
+        # Value layouts for copies
+        vQKVdO_layout = cute.make_layout((1, async_copy_elems))
+
+        # gmem_tiled_copy_QK: tiled copy for QK load
+        self.gmem_tiled_copy_QK = cute.make_tiled_copy_tv(
+            atom_async_copy, tQK_layout, vQKVdO_layout
+        )
+        self.gmem_tiled_copy_VdO = cute.make_tiled_copy_tv(
+            atom_async_copy, tVdO_layout, vQKVdO_layout
+        )
+        self.gmem_tiled_copy_dK = cute.make_tiled_copy_tv(
+            atom_universal_copy, tQK_layout, vQKVdO_layout
+        )
+        self.gmem_tiled_copy_dV = cute.make_tiled_copy_tv(
+            atom_universal_copy, tVdO_layout, vQKVdO_layout
+        )
+        async_copy_elems_accum = universal_copy_bits // cutlass.Float32.width
+
+        # I think we wouldn't require this with smarter padding
+        if cutlass.const_expr(not self.varlen_q):
+            async_copy_elems_accum = universal_copy_bits // cutlass.Float32.width
+            atom_async_copy_accum = cute.make_copy_atom(
+                cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+                cutlass.Float32,
+                num_bits_per_copy=universal_copy_bits,
+            )
+        else:
+            async_copy_elems_accum = 1
+            atom_async_copy_accum = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                cutlass.Float32,
+                num_bits_per_copy=cutlass.Float32.width,
+            )
+        self.gmem_tiled_copy_LSE = cute.make_tiled_copy_tv(
+            atom_async_copy_accum,
+            cute.make_layout(self.num_threads),
+            cute.make_layout(async_copy_elems_accum),
+        )
+        self.gmem_tiled_copy_dQaccum = cute.make_tiled_copy_tv(
+            cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                cutlass.Float32,
+                num_bits_per_copy=cutlass.Float32.width,
+            ),
+            cute.make_layout(self.num_threads),
+            cute.make_layout(1),
+        )
+        if cutlass.const_expr(self.qhead_per_kvhead > 1):
+            self.gmem_tiled_copy_dK = self.gmem_tiled_copy_dQaccum
+            self.gmem_tiled_copy_dV = self.gmem_tiled_copy_dQaccum
+
+    def _get_tiled_mma(self):
+        num_mma_warps = self.num_threads // 32
+        AtomLayoutSdP = (
+            (self.AtomLayoutMSdP, num_mma_warps // self.AtomLayoutMSdP, 1)
+            if cutlass.const_expr(not self.SdP_swapAB)
+            else (num_mma_warps // self.AtomLayoutMSdP, self.AtomLayoutMSdP, 1)
+        )
+        tiled_mma_sdp = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self.dtype, cutlass.Float32, (16, 8, 16)),
+            AtomLayoutSdP,
+            permutation_mnk=(AtomLayoutSdP[0] * 16, AtomLayoutSdP[1] * 16, 16),
+        )
+        AtomLayoutdKV = (
+            (self.AtomLayoutNdKV, num_mma_warps // self.AtomLayoutNdKV, 1)
+            if cutlass.const_expr(not self.dKV_swapAB)
+            else (num_mma_warps // self.AtomLayoutNdKV, self.AtomLayoutNdKV, 1)
+        )
+        tiled_mma_dkv = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self.dtype, cutlass.Float32, (16, 8, 16)),
+            AtomLayoutdKV,
+            permutation_mnk=(AtomLayoutdKV[0] * 16, AtomLayoutdKV[1] * 16, 16),
+        )
+        AtomLayoutdQ = (
+            (self.AtomLayoutMdQ, num_mma_warps // self.AtomLayoutMdQ, 1)
+            if cutlass.const_expr(not self.dQ_swapAB)
+            else (num_mma_warps // self.AtomLayoutMdQ, self.AtomLayoutMdQ, 1)
+        )
+        tiled_mma_dq = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self.dtype, cutlass.Float32, (16, 8, 16)),
+            AtomLayoutdQ,
+            permutation_mnk=(AtomLayoutdQ[0] * 16, AtomLayoutdQ[1] * 16, 16),
+        )
+        return tiled_mma_sdp, tiled_mma_dkv, tiled_mma_dq
+
+    def _get_shared_storage_cls(self):
+        sQ_struct, sK_struct, sV_struct, sdO_struct = [
+            cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(layout)], 1024]
+            for layout in (self.sQ_layout, self.sK_layout, self.sV_layout, self.sdO_layout)
+        ]
+        cosize_sQV = max(cute.cosize(self.sQ_layout), cute.cosize(self.sV_layout))
+        sQV_struct = cute.struct.Align[cute.struct.MemRange[self.dtype, cosize_sQV], 1024]
+        sLSE_struct, sdPsum_struct = [
+            cute.struct.Align[cute.struct.MemRange[cutlass.Float32, cute.cosize(layout)], 128]
+            for layout in (self.sLSE_layout, self.sLSE_layout)
+        ]
+        sP_struct, sdS_struct = [
+            cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(layout)], 128]
+            for layout in (self.sPdS_layout, self.sPdS_layout)
+        ]
+
+        @cute.struct
+        class SharedStorageSeparateQV:
+            sK: sK_struct
+            sV: sV_struct
+            sQ: sQ_struct
+            sdO: sdO_struct
+            sLSE: sLSE_struct
+            sdPsum: sdPsum_struct
+            sP: sP_struct
+            sdS: sdS_struct
+            # TODO: the case where there's no sP
+
+        @cute.struct
+        class SharedStorageSharedQV:
+            sK: sK_struct
+            sV: sV_struct
+            sQ: sQV_struct
+            sdO: sdO_struct
+            sLSE: sLSE_struct
+            sdPsum: sdPsum_struct
+            sP: sP_struct
+            sdS: sdS_struct
+
+        return (
+            SharedStorageSeparateQV
+            if cutlass.const_expr(not self.share_QV_smem)
+            else SharedStorageSharedQV
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mdO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mdPsum: cute.Tensor,
+        mdQaccum: cute.Tensor,
+        mdK: cute.Tensor,
+        mdV: cute.Tensor,
+        softmax_scale: cutlass.Float32,
+        softmax_threshold: cutlass.Float32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        mSeqUsedQ: Optional[cute.Tensor] = None,
+        mSeqUsedK: Optional[cute.Tensor] = None,
+        window_size_left: Int32 | int | None = None,
+        window_size_right: Int32 | int | None = None,
+        mdQ_semaphore: Optional[cute.Tensor] = None,
+        mdK_semaphore: Optional[cute.Tensor] = None,
+        mdV_semaphore: Optional[cute.Tensor] = None,
+        aux_data: AuxData = AuxData(),
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
+        stream: cuda.CUstream = None,
+    ):
+        assert mdQ_semaphore is None and mdK_semaphore is None and mdV_semaphore is None, (
+            "determinism not supported yet for Sm80"
+        )
+        # Get the data type and check if it is fp16 or bf16
+        self._check_type(
+            *(
+                t.element_type if t is not None else None
+                for t in (
+                    mQ,
+                    mK,
+                    mV,
+                    mdO,
+                    mLSE,
+                    mdPsum,
+                    mdQaccum,
+                    mdK,
+                    mdV,
+                    mCuSeqlensQ,
+                    mCuSeqlensK,
+                    mSeqUsedQ,
+                    mSeqUsedK,
+                )
+            )
+        )
+        mQ, mK, mV, mdO, mLSE, mdPsum, mdQaccum, mdK, mdV = [
+            assume_tensor_aligned(t) for t in (mQ, mK, mV, mdO, mLSE, mdPsum, mdQaccum, mdK, mdV)
+        ]
+        self.varlen_q = mCuSeqlensQ is not None
+        self._setup_attributes()
+        SharedStorage = self._get_shared_storage_cls()
+        tiled_mma_sdp, tiled_mma_dkv, tiled_mma_dq = self._get_tiled_mma()
+
+        num_head = mQ.shape[1] if cutlass.const_expr(mCuSeqlensQ is not None) else mQ.shape[2]
+
+        if cutlass.const_expr(mCuSeqlensK is not None):
+            TileScheduler = SingleTileVarlenScheduler
+            num_batch = mCuSeqlensK.shape[0] - 1
+        else:
+            TileScheduler = SingleTileScheduler
+            num_batch = mK.shape[0]
+
+        # Uses seqlen k, etc. since main bwd kernel's blocks are over n
+        tile_sched_args = TileSchedulerArguments(
+            num_block=cute.ceil_div(mK.shape[1], self.n_block_size),
+            num_head=num_head,
+            num_batch=num_batch,
+            num_splits=1,
+            seqlen_k=0,
+            headdim=mK.shape[2],
+            total_q=mK.shape[0],
+            tile_shape_mn=(self.n_block_size, self.m_block_size),
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead
+            if cutlass.const_expr(self.pack_gqa)
+            else 1,
+            mCuSeqlensQ=mCuSeqlensK,
+            mSeqUsedQ=mSeqUsedK,
+        )
+
+        tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
+        grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
+
+        softmax_scale_log2, _ = utils.compute_softmax_scale_log2(softmax_scale, self.score_mod)
+        self.kernel(
+            mQ,
+            mK,
+            mV,
+            mdO,
+            mLSE,
+            mdPsum,
+            mdQaccum,
+            mdK,
+            mdV,
+            mCuSeqlensQ,
+            mCuSeqlensK,
+            mSeqUsedQ,
+            mSeqUsedK,
+            softmax_scale,
+            softmax_scale_log2,
+            softmax_threshold,
+            window_size_left,
+            window_size_right,
+            self.sQ_layout,
+            self.sK_layout,
+            self.sV_layout,
+            self.sdO_layout,
+            self.sPdS_layout,
+            self.sLSE_layout,
+            self.sLSEMma_layout,
+            self.sSkip_layout,
+            self.gmem_tiled_copy_QK,
+            self.gmem_tiled_copy_VdO,
+            self.gmem_tiled_copy_dK,
+            self.gmem_tiled_copy_dV,
+            self.gmem_tiled_copy_LSE,
+            self.gmem_tiled_copy_dQaccum,
+            tiled_mma_sdp,
+            tiled_mma_dkv,
+            tiled_mma_dq,
+            SharedStorage,
+            tile_sched_params,
+            TileScheduler,
+            aux_data,
+        ).launch(
+            grid=grid_dim,
+            block=[self.num_threads, 1, 1],
+            smem=SharedStorage.size_in_bytes(),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mdO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mdPsum: cute.Tensor,
+        mdQaccum: cute.Tensor,
+        mdK: cute.Tensor,
+        mdV: cute.Tensor,
+        mCuSeqlensQ: Optional[cute.Tensor],
+        mCuSeqlensK: Optional[cute.Tensor],
+        mSeqUsedQ: Optional[cute.Tensor],
+        mSeqUsedK: Optional[cute.Tensor],
+        softmax_scale: cutlass.Float32,
+        softmax_scale_log2: cutlass.Float32,
+        softmax_threshold: cutlass.Float32,
+        window_size_left: Optional[Int32],
+        window_size_right: Optional[Int32],
+        sQ_layout: cute.ComposedLayout,
+        sK_layout: cute.ComposedLayout,
+        sV_layout: cute.ComposedLayout,
+        sdO_layout: cute.ComposedLayout,
+        sPdS_layout: cute.ComposedLayout,
+        sLSE_layout: cute.Layout,
+        sLSEMma_layout: cute.Layout,
+        sSkip_layout: cute.Layout,
+        gmem_tiled_copy_QK: cute.TiledCopy,
+        gmem_tiled_copy_VdO: cute.TiledCopy,
+        gmem_tiled_copy_dK: cute.TiledCopy,
+        gmem_tiled_copy_dV: cute.TiledCopy,
+        gmem_tiled_copy_LSE: cute.TiledCopy,
+        gmem_tiled_copy_dQaccum: cute.TiledCopy,
+        tiled_mma_sdp: cute.TiledMma,
+        tiled_mma_dkv: cute.TiledMma,
+        tiled_mma_dq: cute.TiledMma,
+        SharedStorage: cutlass.Constexpr,
+        tile_sched_params: ParamsBase,
+        TileScheduler: cutlass.Constexpr[Callable],
+        aux_data: AuxData = AuxData(),
+    ):
+        # Thread index, block index
+        tidx, _, _ = cute.arch.thread_idx()
+
+        tile_scheduler = TileScheduler.create(tile_sched_params)
+        work_tile = tile_scheduler.initial_work_tile_info()
+
+        n_block, head_idx, batch_idx, _ = work_tile.tile_idx
+
+        if work_tile.is_valid_tile:
+            seqlen = SeqlenInfoQK.create(
+                batch_idx,
+                mQ.shape[1],
+                mK.shape[1],
+                mCuSeqlensQ=mCuSeqlensQ,
+                mCuSeqlensK=mCuSeqlensK,
+                mSeqUsedQ=mSeqUsedQ,
+                mSeqUsedK=mSeqUsedK,
+                tile_m=self.m_block_size,
+                tile_n=self.n_block_size,
+            )
+
+            block_info = BlockInfo(
+                self.m_block_size,
+                self.n_block_size,
+                self.is_causal,
+                self.is_local,
+                False,
+                window_size_left,
+                window_size_right,
+            )
+            m_block_min, m_block_max = block_info.get_m_block_min_max(seqlen, n_block)
+            # TODO: return early if m_block_max == 0
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Get the appropriate tiles for this thread block.
+            # ///////////////////////////////////////////////////////////////////////////////
+            blkQ_shape = (self.m_block_size, self.head_dim_padded)
+            blkK_shape = (self.n_block_size, self.head_dim_padded)
+            blkV_shape = (self.n_block_size, self.head_dim_padded)
+            blkdO_shape = (self.m_block_size, self.head_dim_padded)
+
+            if cutlass.const_expr(not seqlen.has_cu_seqlens_q):
+                mQ_cur = mQ[batch_idx, None, head_idx, None]
+                mLSE_cur = mLSE[batch_idx, head_idx, None]
+                mdO_cur = mdO[batch_idx, None, head_idx, None]
+                mdPsum_cur = mdPsum[batch_idx, head_idx, None]
+                mdQaccum_cur = mdQaccum[batch_idx, head_idx, None]
+            else:
+                padded_offset_q = seqlen.padded_offset_q
+                mQ_cur = cute.domain_offset((seqlen.offset_q, 0), mQ[None, head_idx, None])
+                mLSE_cur = cute.domain_offset((padded_offset_q,), mLSE[head_idx, None])
+                mdO_cur = cute.domain_offset((seqlen.offset_q, 0), mdO[None, head_idx, None])
+                mdPsum_cur = cute.domain_offset((padded_offset_q,), mdPsum[head_idx, None])
+                mdQaccum_cur = cute.domain_offset(
+                    (padded_offset_q * self.head_dim_padded,), mdQaccum[head_idx, None]
+                )
+            head_idx_kv = (
+                head_idx // self.qhead_per_kvhead
+                if cutlass.const_expr(not self.pack_gqa)
+                else head_idx
+            )
+
+            if cutlass.const_expr(not seqlen.has_cu_seqlens_k):
+                mK_cur, mV_cur = [t[batch_idx, None, head_idx_kv, None] for t in (mK, mV)]
+            else:
+                mK_cur, mV_cur = [
+                    cute.domain_offset((seqlen.offset_k, 0), t[None, head_idx_kv, None])
+                    for t in (mK, mV)
+                ]
+
+            # (m_block_size, head_dim, m_block)
+            gQ = cute.local_tile(mQ_cur, blkQ_shape, (None, 0))
+            # (n_block_size, head_dim)
+            gK = cute.local_tile(mK_cur, blkK_shape, (n_block, 0))
+            # (n_block_size, head_dim)
+            gV = cute.local_tile(mV_cur, blkV_shape, (n_block, 0))
+            # (m_block_size, head_dim, m_block)
+            gdO = cute.local_tile(mdO_cur, blkdO_shape, (None, 0))
+            gLSE = cute.local_tile(mLSE_cur, (self.m_block_size,), (None,))
+            gdPsum = cute.local_tile(mdPsum_cur, (self.m_block_size,), (None,))
+            gdQaccum = cute.local_tile(
+                mdQaccum_cur, (self.m_block_size * self.head_dim_padded,), (None,)
+            )
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Get shared memory buffer
+            # ///////////////////////////////////////////////////////////////////////////////
+            smem = cutlass.utils.SmemAllocator()
+            storage = smem.allocate(SharedStorage)
+            sQ = storage.sQ.get_tensor(sQ_layout)
+            sK = storage.sK.get_tensor(sK_layout)
+            if cutlass.const_expr(not self.share_QV_smem):
+                sV = storage.sV.get_tensor(sV_layout)
+            else:
+                sV = cute.make_tensor(cute.recast_ptr(sQ.iterator, dtype=self.dtype), sV_layout)
+            sdO = storage.sdO.get_tensor(sdO_layout)
+            sP = storage.sP.get_tensor(sPdS_layout)
+            # The skip reduction is complete before sP is populated, so the two
+            # buffers can safely share storage.
+            sSkip = storage.sP.get_tensor(sSkip_layout, dtype=cutlass.Float32)
+            sdS = storage.sdS.get_tensor(sPdS_layout)
+            sLSE = storage.sLSE.get_tensor(sLSE_layout)
+            sdPsum = storage.sdPsum.get_tensor(sLSE_layout)
+            sLSEMma = storage.sLSE.get_tensor(sLSEMma_layout)
+            sdPsumMma = storage.sdPsum.get_tensor(sLSEMma_layout)
+
+            # Transpose view of tensors for tiled mma
+            sQt, sdOt, sKt, sPt, sdSt = [
+                layout_utils.transpose_view(t) for t in (sQ, sdO, sK, sP, sdS)
+            ]
+
+            gmem_thr_copy_QK = gmem_tiled_copy_QK.get_slice(tidx)
+            gmem_thr_copy_VdO = gmem_tiled_copy_VdO.get_slice(tidx)
+            gmem_thr_copy_lse = gmem_tiled_copy_LSE.get_slice(tidx)
+            gmem_thr_copy_dQaccum = gmem_tiled_copy_dQaccum.get_slice(tidx)
+            # (CPY_Atom, CPY_M, CPY_K, m_block)
+            tQgQ = gmem_thr_copy_QK.partition_S(gQ)
+            tQsQ = gmem_thr_copy_QK.partition_D(sQ)
+            # (CPY_Atom, CPY_N, CPY_K)
+            tKgK = gmem_thr_copy_QK.partition_S(gK)
+            tKsK = gmem_thr_copy_QK.partition_D(sK)
+            # (CPY_Atom, CPY_N, CPY_K)
+            tVgV = gmem_thr_copy_VdO.partition_S(gV)
+            tVsV = gmem_thr_copy_VdO.partition_D(sV)
+            # (CPY_Atom, CPY_M, CPY_K, m_block)
+            tdOgdO = gmem_thr_copy_VdO.partition_S(gdO)
+            tdOsdO = gmem_thr_copy_VdO.partition_D(sdO)
+            tLSEgLSE = gmem_thr_copy_lse.partition_S(gLSE)
+            tLSEsLSE = gmem_thr_copy_lse.partition_D(sLSE)
+            tLSEgdPsum = gmem_thr_copy_lse.partition_S(gdPsum)
+            tLSEsdPsum = gmem_thr_copy_lse.partition_D(sdPsum)
+            tdQgdQaccum = gmem_thr_copy_dQaccum.partition_S(gdQaccum)
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Tile MMA compute thread partitions and allocate accumulators
+            # ///////////////////////////////////////////////////////////////////////////////
+            thr_mma_sdp = tiled_mma_sdp.get_slice(tidx)
+            thr_mma_dkv = tiled_mma_dkv.get_slice(tidx)
+            thr_mma_dq = tiled_mma_dq.get_slice(tidx)
+            acc_shape_dK = thr_mma_dkv.partition_shape_C((self.n_block_size, self.head_dim_padded))
+            acc_shape_dV = thr_mma_dkv.partition_shape_C((self.n_block_size, self.head_dim_padded))
+            acc_dK = cute.make_rmem_tensor(acc_shape_dK, cutlass.Float32)
+            acc_dV = cute.make_rmem_tensor(acc_shape_dV, cutlass.Float32)
+            acc_dK.fill(0.0)
+            acc_dV.fill(0.0)
+
+            tSrQ = utils.mma_make_fragment_A(sQ[None, None, 0], thr_mma_sdp, swapAB=self.SdP_swapAB)
+            tSrK = utils.mma_make_fragment_B(sK, thr_mma_sdp, swapAB=self.SdP_swapAB)
+            tdPrdO = utils.mma_make_fragment_A(
+                sdO[None, None, 0], thr_mma_sdp, swapAB=self.SdP_swapAB
+            )
+            tdPrV = utils.mma_make_fragment_B(sV, thr_mma_sdp, swapAB=self.SdP_swapAB)
+            tdVrP = utils.mma_make_fragment_A(sPt, thr_mma_dkv, swapAB=self.dKV_swapAB)
+            tdVrdO = utils.mma_make_fragment_B(
+                sdOt[None, None, 0], thr_mma_dkv, swapAB=self.dKV_swapAB
+            )
+            tdKrdS = utils.mma_make_fragment_A(sdSt, thr_mma_dkv, swapAB=self.dKV_swapAB)
+            tdKrQ = utils.mma_make_fragment_B(
+                sQt[None, None, 0], thr_mma_dkv, swapAB=self.dKV_swapAB
+            )
+            tdQrdS = utils.mma_make_fragment_A(sdS, thr_mma_dq, swapAB=self.dQ_swapAB)
+            tdQrK = utils.mma_make_fragment_B(sKt, thr_mma_dq, swapAB=self.dQ_swapAB)
+
+            LSEslice = (
+                (None, 0, None) if cutlass.const_expr(not self.SdP_swapAB) else (0, None, None)
+            )
+            tSsLSEMma = layout_utils.reshape_acc_to_mn(thr_mma_sdp.partition_C(sLSEMma))[LSEslice]
+            tSsdPsumMma = layout_utils.reshape_acc_to_mn(thr_mma_sdp.partition_C(sdPsumMma))[
+                LSEslice
+            ]
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Smem copy atom tiling
+            # ///////////////////////////////////////////////////////////////////////////////
+            smem_copy_atom = cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+                self.dtype,
+            )
+            smem_copy_atom_transposed = cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4),
+                self.dtype,
+            )
+            smem_thr_copy_QdO = utils.make_tiled_copy_A(
+                smem_copy_atom, tiled_mma_sdp, swapAB=self.SdP_swapAB
+            ).get_slice(tidx)
+            smem_thr_copy_KV = utils.make_tiled_copy_B(
+                smem_copy_atom, tiled_mma_sdp, swapAB=self.SdP_swapAB
+            ).get_slice(tidx)
+            # TODO: should this be smem_copy_atom_transposed?
+            smem_thr_copy_PdSt = utils.make_tiled_copy_A(
+                smem_copy_atom_transposed, tiled_mma_dkv, swapAB=self.dKV_swapAB
+            ).get_slice(tidx)
+            smem_thr_copy_QdOt = utils.make_tiled_copy_B(
+                smem_copy_atom_transposed, tiled_mma_dkv, swapAB=self.dKV_swapAB
+            ).get_slice(tidx)
+            smem_thr_copy_dS = utils.make_tiled_copy_A(
+                smem_copy_atom, tiled_mma_dq, swapAB=self.dQ_swapAB
+            ).get_slice(tidx)
+            smem_thr_copy_Kt = utils.make_tiled_copy_B(
+                smem_copy_atom_transposed, tiled_mma_dq, swapAB=self.dQ_swapAB
+            ).get_slice(tidx)
+            # TODO: what's the number of bits? What if SdP_swapAB
+            r2s_thr_copy_PdS = cute.make_tiled_copy_C(
+                cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(), self.dtype, num_bits_per_copy=2 * self.dtype.width
+                ),
+                tiled_mma_sdp,
+            ).get_slice(tidx)
+
+            tSsQ = smem_thr_copy_QdO.partition_S(sQ)
+            tdPsdO = smem_thr_copy_QdO.partition_S(sdO)
+            tSsK = smem_thr_copy_KV.partition_S(sK)
+            tdPsV = smem_thr_copy_KV.partition_S(sV)
+            tdVsPt = smem_thr_copy_PdSt.partition_S(sPt)
+            tdKsdSt = smem_thr_copy_PdSt.partition_S(sdSt)
+            tdVsdOt = smem_thr_copy_QdOt.partition_S(sdOt)
+            tdKsQt = smem_thr_copy_QdOt.partition_S(sQt)
+            tdQsdS = smem_thr_copy_dS.partition_S(sdS)
+            tdQsKt = smem_thr_copy_Kt.partition_S(sKt)
+            tPsP = r2s_thr_copy_PdS.partition_D(sP)
+            tdSsdS = r2s_thr_copy_PdS.partition_D(sdS)
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Predicate: Mark indices that need to copy when problem_shape isn't a multiple
+            # of tile_shape
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Construct identity layout for KV
+            cQ = cute.make_identity_tensor((self.m_block_size, self.head_dim_padded))
+            tQcQ = gmem_thr_copy_QK.partition_S(cQ)
+            t0QcQ = gmem_thr_copy_QK.get_slice(0).partition_S(cQ)
+            tdOcdO = tQcQ
+            t0dOcdO = t0QcQ
+            cLSE = cute.make_identity_tensor((self.m_block_size,))
+            tLSEcLSE = gmem_thr_copy_lse.partition_S(cLSE)
+
+            # Allocate predicate tensors for m and n, here we only allocate the tile of k, and
+            # use "if" on the mn dimension.
+            # This is to reduce register pressure and gets 2-3% performance gain.
+
+            d_head = mQ.shape[cute.rank(mQ) - 1]
+
+            tQpQ = utils.predicate_k(tQcQ, limit=d_head)
+            tdOpdO = tQpQ
+
+            # group parameters for compute_one_m_block
+            mma_params = SimpleNamespace(
+                thr_mma_sdp=thr_mma_sdp,
+                thr_mma_dkv=thr_mma_dkv,
+                thr_mma_dq=thr_mma_dq,
+                tSrQ=tSrQ,
+                tSrK=tSrK,
+                tdPrdO=tdPrdO,
+                tdPrV=tdPrV,
+                tdVrP=tdVrP,
+                tdVrdO=tdVrdO,
+                tdKrdS=tdKrdS,
+                tdKrQ=tdKrQ,
+                tdQrdS=tdQrdS,
+                tdQrK=tdQrK,
+                acc_dK=acc_dK,
+                acc_dV=acc_dV,
+            )
+            smem_copy_params = SimpleNamespace(
+                smem_thr_copy_QdO=smem_thr_copy_QdO,
+                smem_thr_copy_KV=smem_thr_copy_KV,
+                smem_thr_copy_PdSt=smem_thr_copy_PdSt,
+                smem_thr_copy_QdOt=smem_thr_copy_QdOt,
+                smem_thr_copy_dS=smem_thr_copy_dS,
+                smem_thr_copy_Kt=smem_thr_copy_Kt,
+                r2s_thr_copy_PdS=r2s_thr_copy_PdS,
+                tSsQ=tSsQ,
+                tSsK=tSsK,
+                tdPsdO=tdPsdO,
+                tdPsV=tdPsV,
+                tSsLSEMma=tSsLSEMma,
+                tSsdPsumMma=tSsdPsumMma,
+                tPsP=tPsP,
+                tdSsdS=tdSsdS,
+                tdVsPt=tdVsPt,
+                tdVsdOt=tdVsdOt,
+                tdKsdSt=tdKsdSt,
+                tdKsQt=tdKsQt,
+                tdQsdS=tdQsdS,
+                tdQsKt=tdQsKt,
+            )
+            gmem_copy_params = SimpleNamespace(
+                gmem_thr_copy_dQaccum=gmem_thr_copy_dQaccum, tdQgdQaccum=tdQgdQaccum
+            )
+            load_Q_LSE = partial(
+                self.load_Q_LSE,
+                gmem_tiled_copy_QK,
+                gmem_tiled_copy_LSE,
+                tQgQ,
+                tQsQ,
+                tQcQ,
+                t0QcQ,
+                tQpQ,
+                tLSEgLSE,
+                tLSEsLSE,
+                tLSEcLSE,
+                seqlen=seqlen.seqlen_q,
+            )
+            load_dO_dPsum = partial(
+                self.load_dO_dPsum,
+                gmem_tiled_copy_VdO,
+                gmem_tiled_copy_LSE,
+                tdOgdO,
+                tdOsdO,
+                tdOcdO,
+                t0dOcdO,
+                tdOpdO,
+                tLSEgdPsum,
+                tLSEsdPsum,
+                tLSEcLSE,
+                seqlen=seqlen.seqlen_q,
+            )
+            skip_fn = partial(
+                self.skip_softmax,
+                softmax_scale_log2=softmax_scale_log2,
+                softmax_threshold=softmax_threshold,
+                seqlen=seqlen,
+                thr_mma=thr_mma_sdp,
+                sSkip=sSkip,
+            )
+            compute_one_m_block = partial(
+                self.compute_one_m_block,
+                mma_params=mma_params,
+                smem_copy_params=smem_copy_params,
+                gmem_copy_params=gmem_copy_params,
+                load_Q_LSE=load_Q_LSE,
+                load_dO_dPsum=load_dO_dPsum,
+                m_block_max=m_block_max,
+                softmax_scale=softmax_scale,
+                softmax_scale_log2=softmax_scale_log2,
+                aux_data=aux_data,
+                skip_fn=skip_fn,
+            )
+
+            if m_block_min < m_block_max:
+                # ///////////////////////////////////////////////////////////////////////////////
+                # Prologue
+                # ///////////////////////////////////////////////////////////////////////////////
+                # Start async loads of the last mn-tile, where we take care of the mn residue
+                self.load_V(
+                    gmem_thr_copy_VdO, tVgV, tVsV, n_block, seqlen=seqlen.seqlen_k, headdim=d_head
+                )
+                if cutlass.const_expr(self.V_in_regs):
+                    cute.arch.cp_async_commit_group()
+                self.load_K(
+                    gmem_thr_copy_QK, tKgK, tKsK, n_block, seqlen=seqlen.seqlen_k, headdim=d_head
+                )
+                cute.arch.cp_async_commit_group()
+
+                if cutlass.const_expr(self.V_in_regs):
+                    cute.arch.cp_async_wait_group(1)
+                    cute.arch.barrier()
+                    tdPrV_copy_view = smem_thr_copy_KV.retile(tdPrV)
+                    cute.copy(smem_thr_copy_KV, tdPsV, tdPrV_copy_view)
+                    # Sync to avoid loading Q to smem_q, which overlaps with smem_v
+                    cute.arch.barrier()
+
+                m_block = m_block_min
+                for stage in cutlass.range_constexpr(self.num_stages_Q):
+                    if cutlass.const_expr(self.num_stages_Q == 1 or stage < self.num_stages_Q - 1):
+                        if stage == 0 or m_block + stage < m_block_max:
+                            load_Q_LSE(m_block + stage, smem_pipe_write_q=stage)
+                        cute.arch.cp_async_commit_group()
+
+                # ///////////////////////////////////////////////////////////////////////////////
+                # Mainloop
+                # ///////////////////////////////////////////////////////////////////////////////
+                # Start processing of the first n-block.
+                mask = AttentionMask(
+                    self.m_block_size,
+                    self.n_block_size,
+                    seqlen,
+                    window_size_left,
+                    window_size_right,
+                )
+                mask_fn = partial(
+                    mask.apply_mask,
+                    n_block=n_block,
+                    thr_mma=thr_mma_sdp,
+                    batch_idx=batch_idx,
+                    head_idx=head_idx,
+                    mask_seqlen=True,
+                    mask_causal=self.is_causal,
+                    mask_local=self.is_local,
+                    use_r2p=False,
+                )
+                smem_pipe_read_q = cutlass.Int32(0)
+                smem_pipe_write_q = cutlass.Int32(self.num_stages_Q - 1)
+                for m_tile in cutlass.range(m_block_min, m_block_max, unroll=1):
+                    compute_one_m_block(
+                        m_tile,
+                        smem_pipe_read_q,
+                        smem_pipe_write_q,
+                        mask_fn=mask_fn,
+                    )
+                    smem_pipe_read_q = self.advance_pipeline(smem_pipe_read_q, self.num_stages_Q)
+                    smem_pipe_write_q = self.advance_pipeline(smem_pipe_write_q, self.num_stages_Q)
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Epilogue
+            # ///////////////////////////////////////////////////////////////////////////////
+            # If GQA, we scale dK in the postprocessing kernel instead
+            if cutlass.const_expr(self.qhead_per_kvhead == 1):
+                acc_dK.store(acc_dK.load() * softmax_scale)
+            # reuse sK and sV data iterator
+            sdK = cute.make_tensor(sK.iterator, sK_layout)
+            sdV = cute.make_tensor(sV.iterator, sV_layout)
+            self.epilogue(
+                acc_dK,
+                acc_dV,
+                mdK,
+                mdV,
+                sdK,
+                sdV,
+                gmem_tiled_copy_dK,
+                gmem_tiled_copy_dV,
+                tiled_mma_dkv,
+                tidx,
+                n_block,
+                head_idx,
+                batch_idx,
+                seqlen,
+                d_head,
+            )
+
+    @cute.jit
+    def compute_one_m_block(
+        self,
+        m_block: cutlass.Int32,
+        smem_pipe_read_q: cutlass.Int32,
+        smem_pipe_write_q: cutlass.Int32,
+        mma_params: SimpleNamespace,
+        smem_copy_params: SimpleNamespace,
+        gmem_copy_params: SimpleNamespace,
+        load_Q_LSE: Callable,
+        load_dO_dPsum: Callable,
+        m_block_max: cutlass.Int32,
+        softmax_scale: cutlass.Float32,
+        softmax_scale_log2: cutlass.Float32,
+        aux_data: AuxData = AuxData(),
+        mask_fn: Optional[Callable] = None,
+        skip_fn: Optional[Callable] = None,
+    ):
+        def load_Q_next(
+            self,
+            load_Q_LSE: Callable,
+            m_block: cutlass.Int32,
+            smem_pipe_write_q: cutlass.Int32,
+            m_block_max: cutlass.Int32,
+        ):
+            m_block_next = m_block + (
+                self.num_stages_Q - 1 if cutlass.const_expr(self.num_stages_Q > 1) else 1
+            )
+            if m_block_next < m_block_max:
+                load_Q_LSE(m_block_next, smem_pipe_write_q)
+            cute.arch.cp_async_commit_group()
+
+        # MMA S
+        acc_shape_SdP = mma_params.thr_mma_sdp.partition_shape_C(
+            (self.m_block_size, self.n_block_size)
+            if cutlass.const_expr(not self.SdP_swapAB)
+            else (self.n_block_size, self.m_block_size)
+        )
+        acc_S = cute.make_rmem_tensor(acc_shape_SdP, cutlass.Float32)
+        acc_S.fill(0.0)
+        cute.arch.cp_async_wait_group(0)
+        cute.arch.barrier()
+        sm80_utils.gemm(
+            mma_params.thr_mma_sdp,
+            acc_S,
+            mma_params.tSrQ,
+            mma_params.tSrK,
+            smem_copy_params.tSsQ[
+                None,
+                None,
+                None,
+                smem_pipe_read_q if cutlass.const_expr(self.num_stages_Q > 1) else 0,
+            ],
+            smem_copy_params.tSsK,
+            smem_copy_params.smem_thr_copy_QdO,
+            smem_copy_params.smem_thr_copy_KV,
+            swap_AB=self.SdP_swapAB,
+        )
+        acc_S_pre = cute.make_fragment_like(acc_S)
+        acc_S_pre.store(acc_S.load())
+        tLSErLSE = cute.make_fragment_like(smem_copy_params.tSsLSEMma[None, 0])
+        cute.autovec_copy(
+            smem_copy_params.tSsLSEMma[
+                None, smem_pipe_read_q if cutlass.const_expr(self.num_stages_Q > 1) else 0
+            ],
+            tLSErLSE,
+        )
+        acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S)
+        acc_S_pre_mn = layout_utils.reshape_acc_to_mn(acc_S_pre)
+        if cutlass.const_expr(self.score_mod is not None):
+            for r in cutlass.range(cute.size(acc_S_mn, mode=[0]), unroll_full=True):
+                acc_S_mn[r, None].store(
+                    call_score_mod(
+                        self.score_mod,
+                        acc_S_mn[r, None].load() * softmax_scale,
+                        0,
+                        0,
+                        0,
+                        0,
+                        None,
+                        aux_data,
+                    )
+                )
+        if cutlass.const_expr(mask_fn is not None):
+            mask_fn(acc_S, m_block=m_block)
+        if cutlass.const_expr(skip_fn is not None):
+            is_skip = skip_fn(acc_S, tLSErLSE, m_block)
+        else:
+            is_skip = cutlass.Boolean(False)
+
+        if is_skip:
+            load_Q_next(self, load_Q_LSE, m_block, smem_pipe_write_q, m_block_max)
+        else:
+            bidx = 0
+            # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_S_mn)
+            # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == 1: cute.print_tensor(tLSErLSE)
+            load_dO_dPsum(m_block)
+            cute.arch.cp_async_commit_group()
+            assert cute.size(acc_S_mn, mode=[0]) == cute.size(tLSErLSE)
+            for r in cutlass.range(cute.size(acc_S_mn, mode=[0]), unroll_full=True):
+                acc_S_mn[r, None].store(
+                    cute.math.exp2(
+                        acc_S_mn[r, None].load() * softmax_scale_log2 - tLSErLSE[r], fastmath=True
+                    )
+                )
+            # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_S_mn)
+
+            # MMA dP
+            acc_dP = cute.make_rmem_tensor(acc_shape_SdP, cutlass.Float32)
+            acc_dP.fill(0.0)
+            cute.arch.cp_async_wait_group(0)
+            cute.arch.barrier()
+            sm80_utils.gemm(
+                mma_params.thr_mma_sdp,
+                acc_dP,
+                mma_params.tdPrdO,
+                mma_params.tdPrV,
+                smem_copy_params.tdPsdO[None, None, None, 0],
+                smem_copy_params.tdPsV,
+                smem_copy_params.smem_thr_copy_QdO,
+                smem_copy_params.smem_thr_copy_KV,
+                hook_fn=load_Q_next if cutlass.const_expr(self.num_stages_Q > 1) else None,
+                hook_args=(self, load_Q_LSE, m_block, smem_pipe_write_q, m_block_max),
+                swap_AB=self.SdP_swapAB,
+            )
+            tLSErdPsum = cute.make_fragment_like(smem_copy_params.tSsdPsumMma[None, 0])
+            cute.autovec_copy(smem_copy_params.tSsdPsumMma[None, 0], tLSErdPsum)
+            acc_dP_mn = layout_utils.reshape_acc_to_mn(acc_dP)
+            # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_dP_mn)
+            assert cute.size(acc_dP_mn, mode=[0]) == cute.size(tLSErdPsum)
+            for r in cutlass.range(cute.size(acc_dP_mn, mode=[0]), unroll_full=True):
+                grad_val = acc_S_mn[r, None].load() * (acc_dP_mn[r, None].load() - tLSErdPsum[r])
+                if cutlass.const_expr(self.score_mod_bwd is not None):
+                    grad_val = call_score_mod_bwd(
+                        self.score_mod_bwd,
+                        grad_val,
+                        acc_S_pre_mn[r, None].load() * softmax_scale,
+                        0,
+                        0,
+                        0,
+                        0,
+                        None,
+                        aux_data,
+                    )
+                acc_dP_mn[r, None].store(grad_val)
+            # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_dP_mn)
+            rP = cute.make_fragment_like(acc_S, self.dtype)
+            rP.store(acc_S.load().to(self.dtype))
+            if cutlass.const_expr(not self.Mma_dKV_is_RS):
+                tPrP = smem_copy_params.r2s_thr_copy_PdS.retile(
+                    rP
+                )  # ((Atom,AtomNum), MMA_N, MMA_N)
+                cute.copy(smem_copy_params.r2s_thr_copy_PdS, tPrP, smem_copy_params.tPsP)
+            rdS = cute.make_fragment_like(acc_dP, self.dtype)
+            rdS.store(acc_dP.load().to(self.dtype))
+            if cutlass.const_expr(not self.Mma_dKV_is_RS):
+                cute.arch.barrier()  # Make sure P is written
+            # For hdim 64, It's faster to write to smem_dS first before the dV gemm
+            if cutlass.const_expr(not self.Mma_dKV_is_RS):
+                tdSrdS = smem_copy_params.r2s_thr_copy_PdS.retile(rdS)
+                cute.copy(smem_copy_params.r2s_thr_copy_PdS, tdSrdS, smem_copy_params.tdSsdS)
+            if cutlass.const_expr(self.Mma_dKV_is_RS):
+                tdVrP = layout_utils.reshape_acc_to_frgA(rP)
+            else:
+                tdVrP = mma_params.tdVrP
+
+            # MMA dK
+            sm80_utils.gemm(
+                mma_params.thr_mma_dkv,
+                mma_params.acc_dV,
+                tdVrP,
+                mma_params.tdVrdO,
+                smem_copy_params.tdVsPt,
+                smem_copy_params.tdVsdOt[None, None, None, 0],
+                smem_copy_params.smem_thr_copy_PdSt,
+                smem_copy_params.smem_thr_copy_QdOt,
+                A_in_regs=self.Mma_dKV_is_RS,
+                swap_AB=self.dKV_swapAB,
+            )
+            # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(mma_params.acc_dV)
+            cute.arch.barrier()  # Make sure dS is written
+
+            # MMA dQ
+            def dQ_mma(hook_fn=None, hook_args=()):
+                acc_shape_dQ = mma_params.thr_mma_dq.partition_shape_C(
+                    (self.m_block_size, self.head_dim_padded)
+                    if cutlass.const_expr(not self.dQ_swapAB)
+                    else (self.head_dim_padded, self.m_block_size)
+                )
+                acc_dQ = cute.make_rmem_tensor(acc_shape_dQ, cutlass.Float32)
+                acc_dQ.fill(0.0)
+                sm80_utils.gemm(
+                    mma_params.thr_mma_dq,
+                    acc_dQ,
+                    mma_params.tdQrdS,
+                    mma_params.tdQrK,
+                    smem_copy_params.tdQsdS,
+                    smem_copy_params.tdQsKt,
+                    smem_copy_params.smem_thr_copy_dS,
+                    smem_copy_params.smem_thr_copy_Kt,
+                    swap_AB=self.dQ_swapAB,
+                    hook_fn=hook_fn,
+                    hook_args=hook_args,
+                )
+                # ((1, 1), num_elements)
+                acc_dQ_atomic = gmem_copy_params.gmem_thr_copy_dQaccum.retile(acc_dQ)
+                tdQgdQaccum_atomic = gmem_copy_params.tdQgdQaccum[None, None, m_block]
+                assert cute.size(acc_dQ_atomic) == cute.size(tdQgdQaccum_atomic)
+                for i in cutlass.range(cute.size(acc_dQ_atomic), unroll_full=True):
+                    utils.atomic_add_fp32(
+                        acc_dQ_atomic[i], utils.elem_pointer(tdQgdQaccum_atomic, i)
+                    )
+                    # utils.atomic_add_fp32(acc_dQ[i], tdQgdQaccum_atomic.iterator + i * tdQgdQaccum_atomic.stride[1])
+                # if cute.arch.thread_idx()[0] == 64 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_dQ)
+
+            # If num_stages_Q == 1, we want to do Mma_dK first so we can start loading Q for the next iteration
+            if cutlass.const_expr(self.num_stages_Q > 1):
+                dQ_mma()
+
+            # MMA dK
+            if cutlass.const_expr(self.Mma_dKV_is_RS):
+                tdKrdS = layout_utils.reshape_acc_to_frgA(rdS)
+            else:
+                tdKrdS = mma_params.tdKrdS
+            sm80_utils.gemm(
+                mma_params.thr_mma_dkv,
+                mma_params.acc_dK,
+                tdKrdS,
+                mma_params.tdKrQ,
+                smem_copy_params.tdKsdSt,
+                smem_copy_params.tdKsQt[
+                    None,
+                    None,
+                    None,
+                    smem_pipe_read_q if cutlass.const_expr(self.num_stages_Q > 1) else 0,
+                ],
+                smem_copy_params.smem_thr_copy_PdSt,
+                smem_copy_params.smem_thr_copy_QdOt,
+                A_in_regs=self.Mma_dKV_is_RS,
+                swap_AB=self.dKV_swapAB,
+            )
+            # if cute.arch.thread_idx()[0] == 0: cute.print_tensor(mma_params.acc_dK)
+            if cutlass.const_expr(self.num_stages_Q == 1):
+                cute.arch.barrier()
+                dQ_mma(
+                    load_Q_next,
+                    (self, load_Q_LSE, m_block, smem_pipe_write_q, m_block_max),
+                )
+
+    @cute.jit
+    def epilogue(
+        self,
+        acc_dK: cute.Tensor,
+        acc_dV: cute.Tensor,
+        mdK: cute.Tensor,
+        mdV: cute.Tensor,
+        sdK: cute.Tensor,
+        sdV: cute.Tensor,
+        gmem_tiled_copy_dK: cute.TiledCopy,
+        gmem_tiled_copy_dV: cute.TiledCopy,
+        tiled_mma: cute.TiledMma,
+        tidx: cutlass.Int32,
+        n_block: cutlass.Int32,
+        num_head: cutlass.Int32,
+        batch_size: cutlass.Int32,
+        seqlen: SeqlenInfoQK,
+        d_head: cutlass.Int32,
+    ):
+        rdV = cute.make_fragment_like(acc_dV, self.dtype)
+        rdV.store(acc_dV.load().to(self.dtype))
+        rdK = cute.make_fragment_like(acc_dK, self.dtype)
+        rdK.store(acc_dK.load().to(self.dtype))
+        gmem_thr_copy_dK = gmem_tiled_copy_dK.get_slice(tidx)
+        gmem_thr_copy_dV = gmem_tiled_copy_dV.get_slice(tidx)
+
+        batch_idx = batch_size
+        head_idx_kv = (
+            num_head // self.qhead_per_kvhead if cutlass.const_expr(not self.pack_gqa) else num_head
+        )
+
+        if cutlass.const_expr(self.qhead_per_kvhead == 1):
+            # Make sure all threads have finished reading K and V, otherwise we get racy dQ
+            # because smem_q could be changed.
+            cute.arch.barrier()
+            # smem copy atom for dKV
+            smem_copy_atom_dKV = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(), self.dtype, num_bits_per_copy=2 * self.dtype.width
+            )
+            smem_thr_copy_dKV = cute.make_tiled_copy_C(smem_copy_atom_dKV, tiled_mma).get_slice(
+                tidx
+            )
+            taccdVrdV = smem_thr_copy_dKV.retile(rdV)
+            taccdKrdK = smem_thr_copy_dKV.retile(rdK)
+            taccdVsdV = smem_thr_copy_dKV.partition_D(sdV)
+            taccdKsdK = smem_thr_copy_dKV.partition_D(sdK)
+            # copy acc O from rmem to smem with the smem copy atom
+            cute.copy(smem_copy_atom_dKV, taccdVrdV, taccdVsdV)
+            cute.copy(smem_copy_atom_dKV, taccdKrdK, taccdKsdK)
+
+            if cutlass.const_expr(not seqlen.has_cu_seqlens_k):
+                mdK_cur, mdV_cur = [t[batch_idx, None, head_idx_kv, None] for t in (mdK, mdV)]
+            else:
+                mdK_cur, mdV_cur = [
+                    cute.domain_offset((seqlen.offset_k, 0), t[None, head_idx_kv, None])
+                    for t in (mdK, mdV)
+                ]
+
+            blkdK_shape = (self.n_block_size, self.head_dim_padded)
+            blkdV_shape = (self.n_block_size, self.head_dim_padded)
+            gdK = cute.local_tile(mdK_cur, blkdK_shape, (n_block, 0))
+            gdV = cute.local_tile(mdV_cur, blkdV_shape, (n_block, 0))
+            tdKsdK = gmem_thr_copy_dK.partition_S(sdK)
+            tdKgdK = gmem_thr_copy_dK.partition_D(gdK)
+            tdVsdV = gmem_thr_copy_dV.partition_S(sdV)
+            tdVgdV = gmem_thr_copy_dV.partition_D(gdV)
+            tdKrdK = cute.make_fragment_like(tdKgdK, self.dtype)
+            tdVrdV = cute.make_fragment_like(tdVgdV, self.dtype)
+            # sync before all smem stores are done.
+            cute.arch.barrier()
+            # load acc dK and dV from smem to rmem for wider vectorization
+            # Need to check OOB when reading from smem if kBlockN isn't evenly tiled
+            # TODO
+            cute.autovec_copy(tdKsdK, tdKrdK)
+            cute.autovec_copy(tdVsdV, tdVrdV)
+
+            cdK = cute.make_identity_tensor((self.n_block_size, self.head_dim_padded))
+            tdKcdK = gmem_thr_copy_dK.partition_S(cdK)
+            t0dKcdK = gmem_tiled_copy_dK.get_slice(0).partition_S(cdK)
+            tdVcdV = tdKcdK
+            t0dVcdV = t0dKcdK
+            tdKpdK = utils.predicate_k(tdKcdK, limit=d_head)
+            tdVpdV = tdKpdK
+            # copy acc dK and acc_dV from rmem to gmem
+            for rest_m in cutlass.range_constexpr(cute.size(tdKrdK.shape[1])):
+                if (
+                    t0dKcdK[0, rest_m, 0][0]
+                    < seqlen.seqlen_k - n_block * self.n_block_size - tdKcdK[0][0]
+                ):
+                    cute.copy(
+                        gmem_tiled_copy_dK,
+                        tdKrdK[None, rest_m, None],
+                        tdKgdK[None, rest_m, None],
+                        pred=tdKpdK[None, rest_m, None]
+                        if cutlass.const_expr(self.check_hdim_oob)
+                        else None,
+                    )
+            for rest_m in cutlass.range_constexpr(cute.size(tdVrdV.shape[1])):
+                if (
+                    t0dVcdV[0, rest_m, 0][0]
+                    < seqlen.seqlen_k - n_block * self.n_block_size - tdVcdV[0][0]
+                ):
+                    cute.copy(
+                        gmem_tiled_copy_dV,
+                        tdVrdV[None, rest_m, None],
+                        tdVgdV[None, rest_m, None],
+                        pred=tdVpdV[None, rest_m, None]
+                        if cutlass.const_expr(self.check_hdim_oob)
+                        else None,
+                    )
+
+        else:  # qhead_per_kvhead > 1, do atomic add
+            # For Sm90, we need to sync to avoid racy writes to smem_q
+            # For Sm80, we don't need to sync since we're not touching smem
+            head_idx_kv = (
+                num_head // self.qhead_per_kvhead
+                if cutlass.const_expr(not self.pack_gqa)
+                else num_head
+            )
+
+            if cutlass.const_expr(not seqlen.has_cu_seqlens_k):
+                mdK_cur, mdV_cur = [t[batch_idx, head_idx_kv, None] for t in (mdK, mdV)]
+            else:
+                padded_offset_k = seqlen.offset_k + batch_idx * self.n_block_size
+                mdK_cur = cute.domain_offset(
+                    (padded_offset_k * self.head_dim_padded,), mdK[head_idx_kv, None]
+                )
+                mdV_cur = cute.domain_offset(
+                    (padded_offset_k * self.head_dim_padded,), mdV[head_idx_kv, None]
+                )
+
+            gdV = cute.local_tile(mdV_cur, (self.n_block_size * self.head_dim_padded,), (n_block,))
+            gdK = cute.local_tile(mdK_cur, (self.n_block_size * self.head_dim_padded,), (n_block,))
+            tdVgdVaccum = gmem_thr_copy_dV.partition_S(gdV)
+            tdKgdKaccum = gmem_thr_copy_dK.partition_S(gdK)
+            acc_dV_atomic = gmem_thr_copy_dV.retile(acc_dV)
+            acc_dK_atomic = gmem_thr_copy_dK.retile(acc_dK)
+            assert cute.size(acc_dV_atomic) == cute.size(tdVgdVaccum)
+            assert cute.size(acc_dK_atomic) == cute.size(tdKgdKaccum)
+            for i in cutlass.range(cute.size(acc_dV_atomic), unroll_full=True):
+                utils.atomic_add_fp32(acc_dV_atomic[i], utils.elem_pointer(tdVgdVaccum, i))
+            for i in cutlass.range(cute.size(acc_dK_atomic), unroll_full=True):
+                utils.atomic_add_fp32(acc_dK_atomic[i], utils.elem_pointer(tdKgdKaccum, i))
+
+    @cute.jit
+    def advance_pipeline(self, pipeline_index, num_stages: cutlass.Constexpr):
+        return pipeline_index + 1 if pipeline_index < num_stages - 1 else 0
+
+    @cute.jit
+    def load_K(
+        self,
+        gmem_thr_copy: cute.TiledCopy,
+        tKgK: cute.Tensor,
+        tKsK: cute.Tensor,
+        block: cutlass.Int32,
+        seqlen: cutlass.Int32,
+        headdim: cutlass.Int32,
+    ):
+        cK = cute.make_identity_tensor((self.n_block_size, self.head_dim_padded))
+        tKcK = gmem_thr_copy.partition_S(cK)
+        t0KcK = gmem_thr_copy.get_slice(0).partition_S(cK)
+        tKpK = utils.predicate_k(tKcK, limit=headdim)
+        for n in cutlass.range_constexpr(cute.size(tKsK.shape[1])):
+            # If kBlockN doesn't evenly divide the tiled copy, only the last `n` needs to be checked
+            if (
+                self.is_even_n_smem_k
+                or n < cute.size(tKsK.shape[1]) - 1
+                or tKcK[0, n, 0][0] < self.n_block_size
+            ):
+                # Instead of using tKcK, we using t0KcK and subtract the offset from the limit
+                # (seqlen - block * kBlockN). This is because the entries of t0KcK are known at compile time.
+                predicate_n = t0KcK[0, n, 0][0] < seqlen - block * self.n_block_size - tKcK[0][0]
+                predicate = cute.make_fragment_like(tKpK[None, 0, None])
+                for k in cutlass.range_constexpr(cute.size(predicate.shape[1])):
+                    for i in cutlass.range_constexpr(cute.size(predicate.shape[0])):
+                        predicate[i, k] = (
+                            tKpK[i, n, k] if cutlass.const_expr(self.check_hdim_oob) else True
+                        ) and predicate_n
+                cute.copy(
+                    gmem_thr_copy,
+                    tKgK[None, n, None],
+                    tKsK[None, n, None],
+                    pred=predicate,
+                )
+            # We need to clear the sK smem tiles since we'll use sKt for mma_dq
+
+    @cute.jit
+    def load_V(
+        self,
+        gmem_thr_copy: cute.TiledCopy,
+        tVgV: cute.Tensor,
+        tVsV: cute.Tensor,
+        block: cutlass.Int32,
+        seqlen: cutlass.Int32,
+        headdim: cutlass.Int32,
+    ):
+        cV = cute.make_identity_tensor((self.n_block_size, self.head_dim_padded))
+        tVcV = gmem_thr_copy.partition_S(cV)
+        t0VcV = gmem_thr_copy.get_slice(0).partition_S(cV)
+        tVpV = utils.predicate_k(tVcV, limit=headdim)
+        for n in cutlass.range_constexpr(cute.size(tVsV.shape[1])):
+            # If kBlockN doesn't evenly divide the tiled copy, only the last `n` needs to be checked
+            if (
+                self.is_even_n_smem_v
+                or n < cute.size(tVsV.shape[1]) - 1
+                or tVcV[0, n, 0][0] < self.n_block_size
+            ):
+                # Instead of using tVcV, we using t0VcV and subtract the offset from the limit
+                # (seqlen - block * kBlockN). This is because the entries of t0VcV are known at compile time.
+                predicate_n = t0VcV[0, n, 0][0] < seqlen - block * self.n_block_size - tVcV[0][0]
+                predicate = cute.make_fragment_like(tVpV[None, 0, None])
+                for k in cutlass.range_constexpr(cute.size(predicate.shape[1])):
+                    for i in cutlass.range_constexpr(cute.size(predicate.shape[0])):
+                        predicate[i, k] = (
+                            tVpV[i, n, k] if cutlass.const_expr(self.check_hdim_oob) else True
+                        ) and predicate_n
+                cute.copy(
+                    gmem_thr_copy,
+                    tVgV[None, n, None],
+                    tVsV[None, n, None],
+                    pred=predicate,
+                )
+
+    @cute.jit
+    def load_Q_LSE(
+        self,
+        gmem_tiled_copy_Q: cute.TiledCopy,
+        gmem_tiled_copy_LSE: cute.TiledCopy,
+        tQgQ: cute.Tensor,
+        tQsQ: cute.Tensor,
+        tQcQ: cute.Tensor,
+        t0QcQ: cute.Tensor,
+        tQpQ: cute.Tensor,
+        tLSEgLSE: cute.Tensor,
+        tLSEsLSE: cute.Tensor,
+        tLSEcLSE: cute.Tensor,
+        block: cutlass.Int32,
+        smem_pipe_write_q: cutlass.Int32,
+        seqlen: cutlass.Int32,
+    ):
+        for m in cutlass.range_constexpr(cute.size(tQsQ.shape[1])):
+            # If kBlockM doesn't evenly divide the tiled copy, only the last `m` needs to be checked
+            if (
+                self.is_even_m_smem_q
+                or m < cute.size(tQsQ.shape[1]) - 1
+                or tQcQ[0, m, 0][0] < self.m_block_size
+            ):
+                # Instead of using tQcQ, we using t0QcQ and subtract the offset from the limit
+                # (seqlen - block * kBlockM). This is because the entries of t0QcQ are known at compile time.
+                predicate_m = t0QcQ[0, m, 0][0] < seqlen - block * self.m_block_size - tQcQ[0][0]
+                predicate = cute.make_fragment_like(tQpQ[None, 0, None])
+                for k in cutlass.range_constexpr(cute.size(predicate.shape[1])):
+                    for i in cutlass.range_constexpr(cute.size(predicate.shape[0])):
+                        predicate[i, k] = (
+                            tQpQ[i, m, k] if cutlass.const_expr(self.check_hdim_oob) else True
+                        ) and predicate_m
+                cute.copy(
+                    gmem_tiled_copy_Q,
+                    tQgQ[None, m, None, block],
+                    tQsQ[
+                        None,
+                        m,
+                        None,
+                        smem_pipe_write_q if cutlass.const_expr(self.num_stages_Q) > 1 else 0,
+                    ],
+                    pred=predicate,
+                )
+            # We need to clear the sQ smem tiles since we'll use sQt for mma_dK
+        # We made sure LSE length is padded so we read `kBlockM` elements so that all
+        # elements in sLSE are filled. Without this we might have uninitialized sLSE values.
+        for m in cutlass.range_constexpr(cute.size(tLSEsLSE.shape[1])):
+            if tLSEcLSE[0, m][0] < self.m_block_size:
+                cute.copy(
+                    gmem_tiled_copy_LSE,
+                    tLSEgLSE[None, m, block],
+                    tLSEsLSE[
+                        None,
+                        m,
+                        smem_pipe_write_q if cutlass.const_expr(self.num_stages_Q > 1) else 0,
+                    ],
+                )
+
+    @cute.jit
+    def load_dO_dPsum(
+        self,
+        gmem_tiled_copy_dO: cute.TiledCopy,
+        gmem_tiled_copy_dPsum: cute.TiledCopy,
+        tdOgdO: cute.Tensor,
+        tdOsdO: cute.Tensor,
+        tdOcdO: cute.Tensor,
+        t0dOcdO: cute.Tensor,
+        tdOpdO: cute.Tensor,
+        tdPsumgdPsum: cute.Tensor,
+        tdPsumsdPsum: cute.Tensor,
+        tdPsumcdPsum: cute.Tensor,
+        block: cutlass.Int32,
+        seqlen: cutlass.Int32,
+    ):
+        for m in cutlass.range_constexpr(cute.size(tdOsdO.shape[1])):
+            # If kBlockM doesn't evenly divide the tiled copy, only the last `m` needs to be checked
+            if (
+                self.is_even_m_smem_do
+                or m < cute.size(tdOsdO.shape[1]) - 1
+                or tdOcdO[0, m, 0][0] < self.m_block_size
+            ):
+                # Instead of using tdOcdO, we using t0dOcdO and subtract the offset from the limit
+                # (seqlen - block * kBlockM). This is because the entries of t0dOcdO are known at compile time.
+                predicate_m = (
+                    t0dOcdO[0, m, 0][0] < seqlen - block * self.m_block_size - tdOcdO[0][0]
+                )
+                predicate = cute.make_fragment_like(tdOpdO[None, 0, None])
+                for k in cutlass.range_constexpr(cute.size(predicate.shape[1])):
+                    for i in cutlass.range_constexpr(cute.size(predicate.shape[0])):
+                        predicate[i, k] = (
+                            tdOpdO[i, m, k] if cutlass.const_expr(self.check_hdim_oob) else True
+                        ) and predicate_m
+                cute.copy(
+                    gmem_tiled_copy_dO,
+                    tdOgdO[None, m, None, block],
+                    tdOsdO[None, m, None, 0],
+                    pred=predicate,
+                )
+            # We need to clear the sQ smem tiles since we'll use sQt for mma_dK
+        # We made sure LSE length is padded so we read `kBlockM` elements so that all
+        # elements in sLSE are filled. Without this we might have uninitialized sLSE values.
+        for m in cutlass.range_constexpr(cute.size(tdPsumgdPsum.shape[1])):
+            if tdPsumcdPsum[0, m][0] < self.m_block_size:
+                cute.copy(
+                    gmem_tiled_copy_dPsum,
+                    tdPsumgdPsum[None, m, block],
+                    tdPsumsdPsum[None, m, 0],
+                )
+
+    @cute.jit
+    def skip_softmax(
+        self,
+        acc_S: cute.Tensor,
+        tLSErLSE: cute.Tensor,
+        m_block: cutlass.Int32,
+        softmax_scale_log2: cutlass.Float32,
+        softmax_threshold: cutlass.Float32,
+        seqlen: SeqlenInfoQK,
+        thr_mma: cute.TiledMma,
+        sSkip: cute.Tensor,
+    ) -> cutlass.Boolean:
+        acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S)
+        softmax_threshold_log2 = seqlen.get_softmax_threshold(
+            softmax_threshold,
+            m_block,
+            tLSErLSE,
+            thr_mma,
+            self.m_block_size,
+            self.n_block_size,
+            self.is_causal,
+        )
+        thread_max = -cutlass.Float32.inf
+        for r in cutlass.range(cute.size(acc_S_mn, mode=[0]), unroll_full=True):
+            row_max_local = utils.fmax_reduce(acc_S_mn[r, None].load(), arch=80)
+            metric = row_max_local * softmax_scale_log2 - tLSErLSE[r] - softmax_threshold_log2[r]
+            thread_max = cutlass.max(thread_max, metric)
+        cta_max = utils.cta_reduce(
+            thread_max,
+            sSkip,
+            cutlass.max,
+            -cutlass.Float32.inf,
+            self.num_warps,
+        )
+        return cutlass.Boolean(cta_max < 0.0)

--- a/flash_sparse_attn/ops/cute/flash_bwd_sm120.py
+++ b/flash_sparse_attn/ops/cute/flash_bwd_sm120.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026, Jingze Shi.
 # Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 # SM120 (Blackwell GeForce / DGX Spark) backward pass.
 #
@@ -8,7 +9,10 @@
 import cutlass
 import cutlass.utils as utils_basic
 
-from flash_sparse_attn.ops.cute.flash_bwd import FlashAttentionBackwardSm80
+from flash_sparse_attn.ops.cute.flash_bwd import (
+    FlashAttentionBackwardSm80,
+    FlashSparseAttentionBackwardSm80,
+)
 
 
 class FlashAttentionBackwardSm120(FlashAttentionBackwardSm80):
@@ -39,6 +43,46 @@ class FlashAttentionBackwardSm120(FlashAttentionBackwardSm80):
         # Shared memory usage: Q tile + dO tile + K tile + V tile
         smem_usage_Q = m_block_size * head_dim * num_stages_Q * 2
         smem_usage_dO = m_block_size * head_dim * num_stages_dO * 2
+        smem_usage_K = n_block_size * head_dim * 2
+        smem_usage_V = n_block_size * head_dim * 2
+        smem_usage_QV = (
+            (smem_usage_Q + smem_usage_V) if not V_in_regs else max(smem_usage_Q, smem_usage_V)
+        )
+        smem_usage = smem_usage_QV + smem_usage_dO + smem_usage_K
+        # SM120 has 99 KB shared memory (vs 163 KB on SM80)
+        smem_capacity = utils_basic.get_smem_capacity_in_bytes("sm_120")
+        if smem_usage > smem_capacity:
+            return False
+        return True
+
+
+class FlashSparseAttentionBackwardSm120(FlashSparseAttentionBackwardSm80):
+    @staticmethod
+    def can_implement(
+        dtype,
+        head_dim,
+        m_block_size,
+        n_block_size,
+        num_stages_Q,
+        num_threads,
+        is_causal,
+        V_in_regs=False,
+    ) -> bool:
+        """Check if the kernel can be implemented on SM120.
+
+        Same logic as SM80 but uses SM120's shared memory capacity (99 KB).
+        """
+        if dtype not in [cutlass.Float16, cutlass.BFloat16]:
+            return False
+        if head_dim % 8 != 0:
+            return False
+        if n_block_size % 16 != 0:
+            return False
+        if num_threads % 32 != 0:
+            return False
+        # Shared memory usage: Q tile + dO tile + K tile + V tile
+        smem_usage_Q = m_block_size * head_dim * num_stages_Q * 2
+        smem_usage_dO = m_block_size * head_dim * 2
         smem_usage_K = n_block_size * head_dim * 2
         smem_usage_V = n_block_size * head_dim * 2
         smem_usage_QV = (

--- a/flash_sparse_attn/ops/cute/flash_fwd.py
+++ b/flash_sparse_attn/ops/cute/flash_fwd.py
@@ -1,8 +1,12 @@
+# Copyright (c) 2026, Jingze Shi.
 # Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 # A reimplementation of
 # https://github.com/Dao-AILab/flash-attention/blob/main/hopper/flash_fwd_kernel_sm80.h
 # and https://github.com/Dao-AILab/flash-attention/blob/main/hopper/flash_fwd_kernel_sm90.h
 # from Cutlass C++ to Cute-DSL.
+# A reimplementation of
+# https://github.com/HKUSTDial/flash-sparse-attention/blob/main/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
+# from Triton to Cute-DSL.
 # Built on Cute-DSL example: https://github.com/NVIDIA/cutlass/blob/main/examples/python/CuTeDSL/ampere/flash_attention_v2.py
 
 import math
@@ -567,6 +571,536 @@ class FlashAttentionForwardBase:
                 gmem_tiled_copy,
                 tVgV[None, None, None, block],
                 tVsV[None, None, None, smem_pipe_write if const_expr(self.num_stages > 1) else 0],
+                pred=tVpV if const_expr(self.check_hdim_oob) else None,
+            )
+
+
+class FlashSparseAttentionForwardBase:
+    def __init__(
+        self,
+        dtype: Type[cutlass.Numeric],
+        head_dim: int,
+        qhead_per_kvhead: int = 1,
+        is_causal: bool = False,
+        is_local: bool = False,
+        pack_gqa: bool = True,
+        tile_m: int = 128,
+        tile_n: int = 128,
+        num_stages: int = 1,
+        num_threads: int = 128,
+        Q_in_regs: bool = False,
+        score_mod: Optional[cutlass.Constexpr] = None,
+        mask_mod: Optional[cutlass.Constexpr] = None,
+        has_aux_tensors: bool = False,
+        q_subtile_factor: int = 1,
+    ):
+        """Initializes the configuration for a flash attention kernel.
+
+        All contiguous dimensions must be at least 16 bytes aligned, which means that the head dimension
+        should be a multiple of 8.
+
+        :param head_dim: head dimension
+        :type head_dim: int
+        :param tile_m: m block size
+        :type tile_m: int
+        :param tile_n: n block size
+        :type tile_n: int
+        :param num_threads: number of threads
+        :type num_threads: int
+        :param is_causal: is causal
+        :param score_mod: A callable that takes the attention scores and applies a modification.
+            Callable signature: ``score_mod(scores, batch_idx, head_idx, q_idx, kv_idx, aux_tensors) -> Any``
+        :param mask_mod: A callable that takes the attention scores and returns a boolean representing whether that score should be masked.
+            Callable signature: ``mask_mod(batch_idx, head_idx, q_idx, kv_idx, aux_tensors) -> Boolean``
+        """
+        self.dtype = dtype
+        # padding head_dim to a multiple of 16 as k_block_size
+        hdim_multiple_of = 16
+        self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
+        # Can save registers (and hence be faster) if we don't have to check hdim predication
+        self.check_hdim_oob = head_dim != self.tile_hdim
+        self.qhead_per_kvhead = qhead_per_kvhead
+        self.is_causal = is_causal
+        self.is_local = is_local
+        self.pack_gqa = pack_gqa
+        self.tile_m = tile_m
+        self.tile_n = tile_n
+        self.num_threads = num_threads
+        self.num_warps = num_threads // cute.arch.WARP_SIZE
+        self.num_stages = num_stages
+        self.q_subtile_factor = q_subtile_factor
+        self.Q_in_regs = Q_in_regs
+        self.score_mod = score_mod
+        self.mask_mod = mask_mod
+        self.qk_acc_dtype = Float32
+        self.score_vec_size: cutlass.Constexpr = getattr(
+            score_mod, "__vec_size__", 1 if cutlass.const_expr(has_aux_tensors) else 2
+        )
+        if self.score_vec_size > 2:
+            raise ValueError(
+                f"score_mod vec_size {self.score_vec_size} not supported on Sm80/90/120 "
+                "due to accumulator thread ownership pattern."
+            )
+        self.mask_vec_size: cutlass.Constexpr = getattr(mask_mod, "__vec_size__", 1)
+        if self.mask_vec_size > 1:
+            raise ValueError(
+                f"mask_mod vec_size {self.mask_vec_size} not supported on Sm80/90/120 "
+                "due to accumulator thread ownership pattern."
+            )
+        self.arch = BaseDSL._get_dsl().get_arch_enum()
+
+    @staticmethod
+    def can_implement(
+        dtype,
+        head_dim,
+        tile_m,
+        tile_n,
+        num_stages,
+        num_threads,
+        is_causal,
+        Q_in_regs=False,
+    ) -> bool:
+        """Check if the kernel can be implemented with the given parameters.
+
+        :param dtype: data type
+        :type dtype: cutlass.Numeric
+        :param head_dim: head dimension
+        :type head_dim: int
+        :param tile_m: m block size
+        :type tile_m: int
+        :param tile_n: n block size
+        :type tile_n: int
+        :param num_threads: number of threads
+        :type num_threads: int
+        :param is_causal: is causal
+        :type is_causal: bool
+
+        :return: True if the kernel can be implemented, False otherwise
+        :rtype: bool
+        """
+        if dtype not in [cutlass.Float16, cutlass.BFloat16]:
+            return False
+        if head_dim % 8 != 0:
+            return False
+        if tile_n % 16 != 0:
+            return False
+        if num_threads % 32 != 0:
+            return False
+        # Check if block size setting is out of shared memory capacity
+        # Shared memory usage: Q tile + (K tile + V tile) where K and V use the same tile size
+        smem_usage_Q = tile_m * head_dim * 2
+        smem_usage_K = tile_n * head_dim * num_stages * 2
+        smem_usage_V = tile_n * head_dim * 2
+        smem_usage_QV = (
+            (smem_usage_Q + smem_usage_V) if not Q_in_regs else max(smem_usage_Q, smem_usage_V)
+        )
+        smem_usage = smem_usage_QV + smem_usage_K
+        # TODO: sm86 and sm89
+        smem_capacity = utils_basic.get_smem_capacity_in_bytes("sm_80")
+        if smem_usage > smem_capacity:
+            return False
+        # Check if twice the block size is divisible by the number of threads
+        if (tile_m * 2) % num_threads != 0:
+            return False
+        return True
+
+    def _check_type(
+        self,
+        mQ_type: Type[cutlass.Numeric],
+        mK_type: Type[cutlass.Numeric],
+        mV_type: Type[cutlass.Numeric],
+        mO_type: Type[cutlass.Numeric],
+        mLSE_type: Type[cutlass.Numeric] | None,
+        mCuSeqlensQ_type: Type[cutlass.Numeric] | None,
+        mCuSeqlensK_type: Type[cutlass.Numeric] | None,
+        mSeqUsedQ_type: Type[cutlass.Numeric] | None,
+        mSeqUsedK_type: Type[cutlass.Numeric] | None,
+    ):
+        # Get the data type and check if it is fp16 or bf16
+        if const_expr(not (mQ_type == mK_type == mV_type == mO_type)):
+            raise TypeError("All tensors must have the same data type")
+        if const_expr(mQ_type not in [cutlass.Float16, cutlass.BFloat16]):
+            raise TypeError("Only Float16 or BFloat16 is supported")
+        if const_expr(mLSE_type not in [None, Float32]):
+            raise TypeError("LSE tensor must be Float32")
+        if const_expr(mCuSeqlensQ_type not in [None, Int32]):
+            raise TypeError("cu_seqlens_q tensor must be Int32")
+        if const_expr(mCuSeqlensK_type not in [None, Int32]):
+            raise TypeError("cu_seqlens_k tensor must be Int32")
+        if const_expr(mSeqUsedQ_type not in [None, Int32]):
+            raise TypeError("seqused_q tensor must be Int32")
+        if const_expr(mSeqUsedK_type not in [None, Int32]):
+            raise TypeError("seqused_k tensor must be Int32")
+        assert mQ_type == self.dtype
+
+    def _setup_attributes(self):
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Shared memory layout: Q/K/V
+        # ///////////////////////////////////////////////////////////////////////////////
+        sQ_layout_atom, sK_layout_atom, sV_layout_atom, sO_layout_atom, sP_layout_atom = (
+            self._get_smem_layout_atom()
+        )
+        self.sQ_layout = cute.tile_to_shape(
+            sQ_layout_atom,
+            (self.tile_m, self.tile_hdim),
+            (0, 1),
+        )
+        self.sK_layout = cute.tile_to_shape(
+            sK_layout_atom,
+            (self.tile_n, self.tile_hdim, self.num_stages),
+            (0, 1, 2),
+        )
+        self.sV_layout = cute.tile_to_shape(
+            sV_layout_atom,
+            (self.tile_n, self.tile_hdim, 1),
+            (0, 1, 2),
+        )
+        self.sO_layout = cute.tile_to_shape(
+            sO_layout_atom,
+            (self.tile_m, self.tile_hdim),
+            (0, 1),
+        )
+        if const_expr(sP_layout_atom is not None):
+            self.sP_layout = cute.tile_to_shape(
+                sP_layout_atom,
+                (self.tile_m, self.tile_n),
+                (0, 1),
+            )
+        else:
+            self.sP_layout = None
+        self.sSkip_layout = cute.make_layout((self.num_warps,))
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # GMEM Tiled copy:
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Thread layouts for copies
+        universal_copy_bits = 128
+        async_copy_elems = universal_copy_bits // self.dtype.width
+        # atom_async_copy: async copy atom for QKV load
+        atom_async_copy = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            self.dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        # atom_universal_copy: universal copy atom for O store
+        atom_universal_copy = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        # tQ_layout and tK_layout: thread layout for QK load
+        tQK_shape_dim_1 = sQ_layout_atom.outer.shape[1] // async_copy_elems
+        assert self.num_Q_load_threads % tQK_shape_dim_1 == 0, (
+            "num_threads must be divisible by tQK_shape_dim_1"
+        )
+        assert self.num_producer_threads % tQK_shape_dim_1 == 0, (
+            "num_threads must be divisible by tQK_shape_dim_1"
+        )
+        tQ_layout = cute.make_ordered_layout(
+            (self.num_Q_load_threads // tQK_shape_dim_1, tQK_shape_dim_1),
+            order=(1, 0),
+        )
+        tK_layout = cute.make_ordered_layout(
+            (self.num_producer_threads // tQK_shape_dim_1, tQK_shape_dim_1),
+            order=(1, 0),
+        )
+        # So that we don't have to check if we overshoot kBlockM when we load Q
+        assert self.tile_m % tQ_layout.shape[0] == 0
+        tV_shape_dim_1 = sV_layout_atom.outer.shape[1] // async_copy_elems
+        tV_layout = cute.make_ordered_layout(
+            (self.num_producer_threads // tV_shape_dim_1, tV_shape_dim_1),
+            order=(1, 0),
+        )
+        # TODO: need a different layout for O if O dtype is not the same as V dtype
+        # tO_layout: thread layout for O store
+        tO_layout = cute.make_ordered_layout(
+            (self.num_epilogue_threads // tV_shape_dim_1, tV_shape_dim_1),
+            order=(1, 0),
+        )
+        # So that we don't have to check if we overshoot kBlockM when we store O
+        assert self.tile_m % tO_layout.shape[0] == 0
+
+        # Value layouts for copies
+        vQKV_layout = cute.make_layout((1, async_copy_elems))
+        vO_layout = vQKV_layout
+
+        self.gmem_tiled_copy_Q = cute.make_tiled_copy_tv(atom_async_copy, tQ_layout, vQKV_layout)
+        self.gmem_tiled_copy_K = cute.make_tiled_copy_tv(atom_async_copy, tK_layout, vQKV_layout)
+        self.gmem_tiled_copy_V = cute.make_tiled_copy_tv(atom_async_copy, tV_layout, vQKV_layout)
+        # gmem_tiled_copy_O: tiled copy for O store
+        self.gmem_tiled_copy_O = cute.make_tiled_copy_tv(atom_universal_copy, tO_layout, vO_layout)
+
+    def _get_smem_layout_atom(self):
+        raise NotImplementedError()
+
+    def _get_tiled_mma(self):
+        raise NotImplementedError()
+
+    def _get_shared_storage_cls(self):
+        raise NotImplementedError()
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        softmax_scale: Float32,
+        # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
+        stream: cuda.CUstream = None,
+    ):
+        """Configures and launches the flash attention kernel.
+
+        mQ/mK/mV/mO has same data types(supports fp16 and bf16) and same layout:
+        (batch_size, seqlen_q, num_head, head_dim):(_, _, _, 1)
+        """
+        raise NotImplementedError()
+
+    @cute.jit
+    def epilogue(
+        self,
+        acc_O: cute.Tensor,
+        lse: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        sO: cute.Tensor,
+        seqlen: SeqlenInfoQK,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tma_atom_O: Optional[cute.CopyAtom],
+        tiled_mma: cute.TiledMma,
+        tidx: Int32,
+        m_block: Int32,
+        head_idx: Int32,
+        batch_idx: Int32,
+    ):
+        # store acc_O
+        rO = cute.make_fragment_like(acc_O, self.dtype)
+        rO.store(acc_O.load().to(self.dtype))
+        # Make sure all threads have finished reading V
+        cute.arch.barrier(
+            barrier_id=int(NamedBarrierFwd.Epilogue), number_of_threads=self.num_epilogue_threads
+        )
+        smem_copy_atom_O = utils.get_smem_store_atom(
+            self.arch.major * 10 + self.arch.minor, self.dtype
+        )
+        smem_thr_copy_O = cute.make_tiled_copy_C(smem_copy_atom_O, tiled_mma).get_slice(tidx)
+        taccOrO = smem_thr_copy_O.retile(rO)
+        taccOsO = smem_thr_copy_O.partition_D(sO)
+        # taccOsO = copy_utils.partition_D_position_independent(smem_thr_copy_O, sO)
+        # copy acc O from rmem to smem with the smem copy atom
+        cute.copy(smem_copy_atom_O, taccOrO, taccOsO)
+
+        cO = cute.make_identity_tensor((self.tile_m, self.tile_hdim))
+        pack_gqa = PackGQA(self.tile_m, self.tile_hdim, self.check_hdim_oob, self.qhead_per_kvhead)
+
+        # Write LSE from rmem -> gmem
+        if const_expr(mLSE is not None):
+            mLSE_cur = seqlen.offset_batch_Q(mLSE, batch_idx, dim=2)[None, head_idx]
+            if const_expr(not self.pack_gqa):
+                gLSE = cute.local_tile(mLSE_cur, (self.tile_m,), (m_block,))
+                gLSE_expanded_layout = cute.append(
+                    gLSE.layout, cute.make_layout((self.tile_hdim,), stride=(0,))
+                )
+                gLSE_expanded = cute.make_tensor(gLSE.iterator, gLSE_expanded_layout)
+                thr_mma = tiled_mma.get_slice(tidx)
+                taccOgLSE = layout_utils.reshape_acc_to_mn(thr_mma.partition_C(gLSE_expanded))
+                assert cute.size(taccOgLSE, mode=[0]) == cute.size(lse)
+                taccOcO = layout_utils.reshape_acc_to_mn(thr_mma.partition_C(cO))
+                t0accOcO = layout_utils.reshape_acc_to_mn(thr_mma.get_slice(0).partition_C(cO))
+                # Only the thread corresponding to column 0 writes out the lse to gmem
+                if taccOcO[0][1] == 0:
+                    for m in cutlass.range(cute.size(taccOgLSE.shape[1]), unroll_full=True):
+                        if (
+                            t0accOcO[m, 0][0]
+                            < seqlen.seqlen_q - m_block * self.tile_m - taccOcO[0][0]
+                        ):
+                            taccOgLSE[m, 0] = lse[m]
+            else:
+                pack_gqa.store_LSE(mLSE_cur, lse, tiled_mma, tidx, m_block, seqlen.seqlen_q)
+
+        ragged = self.use_tma_O and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
+        mO_cur = seqlen.offset_batch_Q(mO, batch_idx, dim=3, ragged=ragged)[None, None, head_idx]
+        # thr_mma = tiled_mma.get_slice(tidx)
+        # taccOgO = thr_mma.partition_C(gO)
+        # cute.autovec_copy(rO, taccOgO)
+        # sync to make sure all smem stores are done
+        if const_expr(self.use_tma_O):
+            # ensure smem writes are visible to TMA
+            cute.arch.fence_view_async_shared()
+            cute.arch.barrier_arrive(
+                barrier_id=int(NamedBarrierFwd.Epilogue),
+                number_of_threads=self.num_epilogue_threads + cute.arch.WARP_SIZE,
+            )
+            gO = cute.local_tile(mO_cur, (self.tile_m, self.tile_hdim), (m_block, 0))
+            store_O, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_O, 0, cute.make_layout(1), sO, gO, single_stage=True
+            )
+            warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+            if warp_idx == 4:
+                cute.arch.barrier(
+                    barrier_id=int(NamedBarrierFwd.Epilogue),
+                    number_of_threads=self.num_epilogue_threads + cute.arch.WARP_SIZE,
+                )
+                store_O()
+                cute.arch.cp_async_bulk_commit_group()
+                cute.arch.cp_async_bulk_wait_group(0, read=True)
+        else:
+            cute.arch.barrier(
+                barrier_id=int(NamedBarrierFwd.Epilogue),
+                number_of_threads=self.num_epilogue_threads,
+            )
+            gmem_thr_copy_O = gmem_tiled_copy_O.get_slice(tidx)
+            tOsO = gmem_thr_copy_O.partition_S(sO)
+            tOrO = cute.make_fragment_like(tOsO, self.dtype)
+            # load acc O from smem to rmem for wider vectorization
+            cute.autovec_copy(tOsO, tOrO)
+            if const_expr(not self.pack_gqa):
+                gO = cute.local_tile(mO_cur, (self.tile_m, self.tile_hdim), (m_block, 0))
+                tOgO = gmem_thr_copy_O.partition_D(gO)
+                tOcO = gmem_thr_copy_O.partition_S(cO)
+                t0OcO = gmem_tiled_copy_O.get_slice(0).partition_S(cO)
+                tOpO = utils.predicate_k(tOcO, limit=mO.shape[1])
+                # copy acc O from rmem to gmem
+                for rest_m in cutlass.range_constexpr(cute.size(tOrO.shape[1])):
+                    if (
+                        t0OcO[0, rest_m, 0][0]
+                        < seqlen.seqlen_q - m_block * self.tile_m - tOcO[0][0]
+                    ):
+                        cute.copy(
+                            gmem_tiled_copy_O,
+                            tOrO[None, rest_m, None],
+                            tOgO[None, rest_m, None],
+                            pred=tOpO[None, rest_m, None]
+                            if const_expr(self.check_hdim_oob)
+                            else None,
+                        )
+            else:
+                pack_gqa.store_O(mO_cur, tOrO, gmem_tiled_copy_O, tidx, m_block, seqlen.seqlen_q)
+
+    @cute.jit
+    def advance_pipeline(self, pipeline_index):
+        return pipeline_index + 1 if pipeline_index < self.num_stages - 1 else 0
+
+    @cute.jit
+    def load_Q(
+        self,
+        gmem_thr_copy: cute.TiledCopy,
+        gQ: cute.Tensor,
+        sQ: cute.Tensor,
+        block: Int32,
+        seqlen: Int32,
+        headdim: Int32,
+    ):
+        tQsQ, tQgQ = gmem_thr_copy.partition_D(sQ), gmem_thr_copy.partition_S(gQ)
+        cQ = cute.make_identity_tensor((self.tile_m, self.tile_hdim))
+        tQcQ = gmem_thr_copy.partition_S(cQ)
+        t0QcQ = gmem_thr_copy.get_slice(0).partition_S(cQ)
+        tQpQ = utils.predicate_k(tQcQ, limit=headdim)
+        for m in cutlass.range_constexpr(cute.size(tQsQ.shape[1])):
+            # Instead of using tQcQ, we using t0QcQ and subtract the offset from the limit
+            # (seqlen - block * kBlockM). This is because the entries of t0QcQ are known at compile time.
+            if t0QcQ[0, m, 0][0] < seqlen - block * self.tile_m - tQcQ[0][0]:
+                cute.copy(
+                    gmem_thr_copy,
+                    tQgQ[None, m, None],
+                    tQsQ[None, m, None],
+                    pred=tQpQ[None, m, None] if const_expr(self.check_hdim_oob) else None,
+                )
+            # We don't need to clear the sQ smem tiles since we'll only write out the valid outputs
+
+    @cute.jit
+    def load_K(
+        self,
+        gmem_tiled_copy: cute.TiledCopy,
+        tKgK: cute.Tensor,
+        tKsK: cute.Tensor,
+        tKcK: cute.Tensor,
+        t0KcK: cute.Tensor,
+        tKpK: cute.Tensor,
+        block: Int32,
+        smem_pipe_write: Int32,
+        seqlen: Int32,
+        need_predicates: cutlass.Constexpr,
+    ):
+        # Do we need to check if we overshoot kBlockN when we load K?
+        is_even_n_smem_k = self.tile_n % gmem_tiled_copy.tiler_mn[0].shape == 0
+        if const_expr(need_predicates or not is_even_n_smem_k):
+            # Instead of using tKcK, we using t0KcK and subtract the offset from the limit
+            # (seqlen - block * kBlockN). This is because the entries of t0KcK are known at compile time.
+            if const_expr(is_even_n_smem_k):
+                seqlen_limit = seqlen - block * self.tile_n
+            else:
+                if const_expr(not need_predicates):
+                    seqlen_limit = self.tile_n
+                else:
+                    seqlen_limit = cutlass.min(seqlen - block * self.tile_n, self.tile_n)
+            seqlen_limit -= tKcK[0][0]
+            for n in cutlass.range_constexpr(cute.size(tKsK.shape[1])):
+                if t0KcK[0, n, 0][0] < seqlen_limit:
+                    cute.copy(
+                        gmem_tiled_copy,
+                        tKgK[None, n, None, block],
+                        tKsK[
+                            None, n, None, smem_pipe_write if const_expr(self.num_stages > 1) else 0
+                        ],
+                        pred=tKpK[None, n, None] if const_expr(self.check_hdim_oob) else None,
+                    )
+                # We don't need to clear the sK smem tiles since we'll mask out the scores anyway.
+        else:
+            cute.copy(
+                gmem_tiled_copy,
+                tKgK[None, None, None, block],
+                tKsK[None, None, None, smem_pipe_write if const_expr(self.num_stages > 1) else 0],
+                pred=tKpK if const_expr(self.check_hdim_oob) else None,
+            )
+
+    @cute.jit
+    def load_V(
+        self,
+        gmem_tiled_copy: cute.TiledCopy,
+        tVgV: cute.Tensor,
+        tVsV: cute.Tensor,
+        tVcV: cute.Tensor,
+        t0VcV: cute.Tensor,
+        tVpV: cute.Tensor,
+        block: Int32,
+        smem_pipe_write: Int32,
+        seqlen: Int32,
+        need_predicates: cutlass.Constexpr,
+    ):
+        # Do we need to check if we overshoot kBlockN when we load V?
+        is_even_n_smem_v = self.tile_n % gmem_tiled_copy.tiler_mn[0].shape == 0
+        if const_expr(need_predicates or not is_even_n_smem_v):
+            for n in cutlass.range_constexpr(cute.size(tVsV.shape[1])):
+                # If kBlockN doesn't evenly divide the tiled copy, only the last `n` needs to be checked
+                if (
+                    is_even_n_smem_v
+                    or n < cute.size(tVsV.shape[1]) - 1
+                    or tVcV[0, n, 0][0] < self.tile_n
+                ):
+                    predicate = tVpV[None, n, None] if const_expr(self.check_hdim_oob) else None
+                    if const_expr(need_predicates):
+                        seqlen_limit = seqlen - block * self.tile_n - tVcV[0][0]
+                        predicate_n = t0VcV[0, n, 0][0] < seqlen_limit
+                        predicate = cute.make_fragment_like(tVpV[None, 0, None])
+                        for k in cutlass.range_constexpr(cute.size(predicate.shape[1])):
+                            for i in cutlass.range_constexpr(cute.size(predicate.shape[0])):
+                                predicate[i, k] = (
+                                    tVpV[i, n, k] if const_expr(self.check_hdim_oob) else True
+                                ) and predicate_n
+                    cute.copy(
+                        gmem_tiled_copy,
+                        tVgV[None, n, None, block],
+                        tVsV[None, n, None, 0],
+                        pred=predicate,
+                    )
+        else:
+            cute.copy(
+                gmem_tiled_copy,
+                tVgV[None, None, None, block],
+                tVsV[None, None, None, 0],
                 pred=tVpV if const_expr(self.check_hdim_oob) else None,
             )
 
@@ -1201,6 +1735,701 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         )
         # if const_expr(self.num_stages > 1):
         #     load_K_next()
+
+    @cute.jit
+    def apply_score_mod(
+        self,
+        thr_mma_qk,
+        batch_idx,
+        head_idx,
+        m_block,
+        acc_S,
+        n_block,
+        softmax_scale,
+        seqlen,
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=None,
+    ):
+        # Prepare index tensor
+        cS = cute.make_identity_tensor((self.tile_m, self.tile_n))
+        cS = cute.domain_offset((m_block * self.tile_m, n_block * self.tile_n), cS)
+        tScS = thr_mma_qk.partition_C(cS)
+
+        apply_score_mod_inner(
+            acc_S,
+            tScS,
+            self.score_mod,
+            batch_idx,
+            head_idx,
+            softmax_scale,
+            self.score_vec_size,
+            self.qk_acc_dtype,
+            aux_data,
+            fastdiv_mods,
+            seqlen_info=seqlen,
+            constant_q_idx=None,
+            qhead_per_kvhead=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+
+
+class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
+    def _get_smem_layout_atom(self):
+        sQ_layout_atom = sm80_utils.get_smem_layout_atom(self.dtype, self.tile_hdim)
+        sK_layout_atom = sQ_layout_atom
+        sV_layout_atom = sm80_utils.get_smem_layout_atom(self.dtype, self.tile_hdim)
+        sO_layout_atom = sV_layout_atom
+        sP_layout_atom = None
+        return sQ_layout_atom, sK_layout_atom, sV_layout_atom, sO_layout_atom, sP_layout_atom
+
+    def _get_tiled_mma(self):
+        tiled_mma_qk = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self.dtype, Float32, (16, 8, 16)),
+            (self.num_warps, 1, 1),
+            permutation_mnk=(self.num_warps * 16, 16, 16),
+        )
+        tiled_mma_pv = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self.dtype, Float32, (16, 8, 16)),
+            (self.num_warps, 1, 1),
+            permutation_mnk=(self.num_warps * 16, 16, 16),
+        )
+        return tiled_mma_qk, tiled_mma_pv
+
+    def _get_shared_storage_cls(self):
+        sQ_struct, sK_struct, sV_struct = [
+            cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(layout)], 1024]
+            for layout in (self.sQ_layout, self.sK_layout, self.sV_layout)
+        ]
+        cosize_sQV = max(cute.cosize(self.sQ_layout), cute.cosize(self.sV_layout))
+        sQV_struct = cute.struct.Align[cute.struct.MemRange[self.dtype, cosize_sQV], 1024]
+
+        @cute.struct
+        class SharedStorageQKV:
+            sV: sV_struct
+            sQ: sQ_struct
+            sK: sK_struct
+
+            @cute.jit
+            def get_sSkip(self, sSkip_layout: cute.Layout):
+                return self.sV.get_tensor(sSkip_layout, dtype=Int32)
+
+        @cute.struct
+        class SharedStorageSharedQV:
+            sQ: sQV_struct
+            sK: sK_struct
+
+            @cute.jit
+            def get_sSkip(self, sSkip_layout: cute.Layout):
+                return self.sQ.get_tensor(sSkip_layout, dtype=Int32)
+
+        return SharedStorageQKV if const_expr(not self.Q_in_regs) else SharedStorageSharedQV
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        softmax_scale: Float32,
+        softmax_threshold: Float32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        mSeqUsedQ: Optional[cute.Tensor] = None,
+        mSeqUsedK: Optional[cute.Tensor] = None,
+        mPageTable: Optional[cute.Tensor] = None,
+        window_size_left: Int32 | int | None = None,
+        window_size_right: Int32 | int | None = None,
+        learnable_sink: Optional[cute.Tensor] = None,
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        aux_data: AuxData = AuxData(),
+        # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
+        stream: cuda.CUstream = None,
+    ):
+        """Configures and launches the flash attention kernel.
+
+        mQ/mK/mV/mO has same data types(supports fp16 and bf16) and same layout:
+        (batch_size, seqlen_q, num_head, head_dim):(_, _, _, 1)
+        """
+        assert learnable_sink is None, "Learnable sink is not supported in this kernel"
+        self._check_type(
+            *(
+                t.element_type if t is not None else None
+                for t in (mQ, mK, mV, mO, mLSE, mCuSeqlensQ, mCuSeqlensK, mSeqUsedQ, mSeqUsedK)
+            )
+        )
+        tiled_mma_qk, tiled_mma_pv = self._get_tiled_mma()
+        self.num_mma_threads = tiled_mma_pv.size
+        self.num_producer_threads = self.num_threads
+        self.num_Q_load_threads = self.num_threads
+        self.num_epilogue_threads = self.num_threads
+        self.use_tma_O = Arch.sm_90 <= self.arch < Arch.sm_120
+        self._setup_attributes()
+        SharedStorage = self._get_shared_storage_cls()
+        mQ, mK, mV, mO = [assume_tensor_aligned(t) for t in (mQ, mK, mV, mO)]
+        # Layout permutation: 4D non-varlen vs 3D varlen
+        QO_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]
+        KV_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensK is None) else [0, 2, 1]
+        mQ, mO = [
+            cute.make_tensor(t.iterator, cute.select(t.layout, mode=QO_layout_transpose))
+            for t in (mQ, mO)
+        ]
+        mK, mV = [
+            cute.make_tensor(t.iterator, cute.select(t.layout, mode=KV_layout_transpose))
+            for t in (mK, mV)
+        ]
+        if const_expr(mLSE is not None):
+            LSE_layout_transpose = [2, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 0]
+            mLSE = cute.make_tensor(
+                mLSE.iterator, cute.select(mLSE.layout, mode=LSE_layout_transpose)
+            )
+        if const_expr(self.pack_gqa):
+            nheads_kv = mK.shape[2]
+            mQ = pack_gqa_layout(mQ, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            mO = pack_gqa_layout(mO, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            if const_expr(mLSE is not None):
+                mLSE = pack_gqa_layout(mLSE, self.qhead_per_kvhead, nheads_kv, head_idx=1)
+        # TileScheduler for varlen, simple grid for non-varlen
+        if const_expr(mCuSeqlensQ is not None or mSeqUsedQ is not None):
+            TileScheduler = SingleTileVarlenScheduler
+        else:
+            TileScheduler = SingleTileScheduler
+        num_batch = (
+            mCuSeqlensQ.shape[0] - 1
+            if const_expr(mCuSeqlensQ is not None)
+            else cute.size(mQ.shape[3])
+        )
+        tile_sched_args = TileSchedulerArguments(
+            num_block=cute.ceil_div(cute.size(mQ.shape[0]), self.tile_m),
+            num_head=cute.size(mQ.shape[2]),
+            num_batch=num_batch,
+            num_splits=1,
+            seqlen_k=0,
+            headdim=mQ.shape[1],
+            total_q=cute.size(mQ.shape[0])
+            if const_expr(mCuSeqlensQ is not None)
+            else cute.size(mQ.shape[0]) * cute.size(mQ.shape[3]),
+            tile_shape_mn=(self.tile_m, self.tile_n),
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            mCuSeqlensQ=mCuSeqlensQ,
+            mSeqUsedQ=mSeqUsedQ,
+        )
+        tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
+        grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
+        softmax_scale_log2, softmax_scale = utils.compute_softmax_scale_log2(
+            softmax_scale, self.score_mod
+        )
+        fastdiv_mods = utils.compute_fastdiv_mods(
+            mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_data.tensors
+        )
+
+        self.kernel(
+            mQ,
+            mK,
+            mV,
+            mO,
+            mLSE,
+            mCuSeqlensQ,
+            mCuSeqlensK,
+            mSeqUsedQ,
+            mSeqUsedK,
+            softmax_scale_log2,
+            softmax_scale,
+            softmax_threshold,
+            window_size_left,
+            window_size_right,
+            self.sQ_layout,
+            self.sK_layout,
+            self.sV_layout,
+            self.sO_layout,
+            self.sP_layout,
+            self.sSkip_layout,
+            self.gmem_tiled_copy_Q,
+            self.gmem_tiled_copy_K,
+            self.gmem_tiled_copy_V,
+            self.gmem_tiled_copy_O,
+            tiled_mma_qk,
+            tiled_mma_pv,
+            SharedStorage,
+            tile_sched_params,
+            TileScheduler,
+            aux_data,
+            fastdiv_mods,
+        ).launch(
+            grid=grid_dim,
+            block=[self.num_threads, 1, 1],
+            smem=SharedStorage.size_in_bytes(),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        mCuSeqlensQ: Optional[cute.Tensor],
+        mCuSeqlensK: Optional[cute.Tensor],
+        mSeqUsedQ: Optional[cute.Tensor],
+        mSeqUsedK: Optional[cute.Tensor],
+        softmax_scale_log2: Float32,
+        softmax_scale: Optional[Float32],
+        softmax_threshold: Float32,
+        window_size_left: Optional[Int32],
+        window_size_right: Optional[Int32],
+        sQ_layout: cute.ComposedLayout,
+        sK_layout: cute.ComposedLayout,
+        sV_layout: cute.ComposedLayout,
+        sO_layout: cute.ComposedLayout,
+        sP_layout: cute.ComposedLayout | None,
+        sSkip_layout: cute.Layout,
+        gmem_tiled_copy_Q: cute.TiledCopy,
+        gmem_tiled_copy_K: cute.TiledCopy,
+        gmem_tiled_copy_V: cute.TiledCopy,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tiled_mma_qk: cute.TiledMma,
+        tiled_mma_pv: cute.TiledMma,
+        SharedStorage: cutlass.Constexpr,
+        tile_sched_params,
+        TileScheduler: cutlass.Constexpr[Callable],
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=None,
+    ):
+        # Thread index, block index
+        tidx, _, _ = cute.arch.thread_idx()
+
+        tile_scheduler = TileScheduler.create(tile_sched_params)
+        work_tile = tile_scheduler.initial_work_tile_info()
+        m_block, num_head, batch_size, _ = work_tile.tile_idx
+
+        block_info = BlockInfo(
+            self.tile_m,
+            self.tile_n,
+            self.is_causal,
+            self.is_local,
+            False,  # is_split_kv
+            window_size_left,
+            window_size_right,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+        seqlen = SeqlenInfoQK.create(
+            batch_idx=batch_size,
+            seqlen_q_static=mQ.shape[0] if const_expr(not self.pack_gqa) else mQ.shape[0][1],
+            seqlen_k_static=mK.shape[0],
+            mCuSeqlensQ=mCuSeqlensQ,
+            mCuSeqlensK=mCuSeqlensK,
+            mSeqUsedQ=mSeqUsedQ,
+            mSeqUsedK=mSeqUsedK,
+        )
+        n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
+        # For varlen, wasted grid tiles (where batch_idx >= num_batch) will have
+        # seqlen_q=seqlen_k=0 and n_block_max=0.  Clamp to 0 so we don't use a
+        # negative block index for K/V loads; the load/store predicates already
+        # guard all memory accesses when seqlen is 0.
+        n_block = cutlass.max(n_block_max - 1, 0)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Get the appropriate tiles for this thread block.
+        # ///////////////////////////////////////////////////////////////////////////////
+        blkQ_shape = (self.tile_m, self.tile_hdim)
+        blkK_shape = (self.tile_n, self.tile_hdim)
+        blkV_shape = (self.tile_n, self.tile_hdim)
+        num_head_kv = num_head if const_expr(self.pack_gqa) else num_head // self.qhead_per_kvhead
+        mQ_cur = seqlen.offset_batch_Q(mQ, batch_size, dim=3)[None, None, num_head]
+        if const_expr(not seqlen.has_cu_seqlens_k):
+            mK_cur = mK[None, None, num_head_kv, batch_size]
+            mV_cur = mV[None, None, num_head_kv, batch_size]
+        else:
+            mK_cur = cute.domain_offset((seqlen.offset_k, 0), mK[None, None, num_head_kv])
+            mV_cur = cute.domain_offset((seqlen.offset_k, 0), mV[None, None, num_head_kv])
+        if const_expr(not self.pack_gqa):
+            gQ = cute.local_tile(mQ_cur, blkQ_shape, (m_block, 0))
+        gK = cute.local_tile(mK_cur, blkK_shape, (None, 0))
+        gV = cute.local_tile(mV_cur, blkV_shape, (None, 0))
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Get shared memory buffer
+        # ///////////////////////////////////////////////////////////////////////////////
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sQ = storage.sQ.get_tensor(sQ_layout)
+        sK = storage.sK.get_tensor(sK_layout)
+        if const_expr(not self.Q_in_regs):
+            sV = storage.sV.get_tensor(sV_layout)
+        else:
+            sV = cute.make_tensor(cute.recast_ptr(sQ.iterator, dtype=self.dtype), sV_layout)
+        sSkip = storage.get_sSkip(sSkip_layout)
+        # Transpose view of V to tensor with layout (head_dim, tile_n) for tiled mma
+        sVt = layout_utils.transpose_view(sV)
+
+        gmem_thr_copy_K = gmem_tiled_copy_K.get_slice(tidx)
+        gmem_thr_copy_V = gmem_tiled_copy_V.get_slice(tidx)
+        # (CPY_Atom, CPY_N, CPY_K, n_block)
+        tKsK, tKgK = gmem_thr_copy_K.partition_D(sK), gmem_thr_copy_K.partition_S(gK)
+        # (CPY_Atom, CPY_N, CPY_K, n_block)
+        tVsV, tVgV = gmem_thr_copy_V.partition_D(sV), gmem_thr_copy_V.partition_S(gV)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Tile MMA compute thread partitions and allocate accumulators
+        # ///////////////////////////////////////////////////////////////////////////////
+        thr_mma_qk = tiled_mma_qk.get_slice(tidx)
+        thr_mma_pv = tiled_mma_pv.get_slice(tidx)
+        tSrQ = thr_mma_qk.make_fragment_A(thr_mma_qk.partition_A(sQ))
+        tSrK = thr_mma_qk.make_fragment_B(thr_mma_qk.partition_B(sK[None, None, 0]))
+        tOrVt = thr_mma_pv.make_fragment_B(thr_mma_pv.partition_B(sVt[None, None, 0]))
+        acc_shape_O = thr_mma_pv.partition_shape_C((self.tile_m, self.tile_hdim))
+        acc_O = cute.make_rmem_tensor(acc_shape_O, Float32)
+        acc_O.fill(0.0)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Smem copy atom tiling
+        # ///////////////////////////////////////////////////////////////////////////////
+        smem_copy_atom_QK = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+            self.dtype,
+        )
+        smem_copy_atom_V = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4),
+            self.dtype,
+        )
+        smem_thr_copy_Q = utils.make_tiled_copy_A(smem_copy_atom_QK, tiled_mma_qk).get_slice(tidx)
+        smem_thr_copy_K = utils.make_tiled_copy_B(smem_copy_atom_QK, tiled_mma_qk).get_slice(tidx)
+        smem_thr_copy_V = utils.make_tiled_copy_B(smem_copy_atom_V, tiled_mma_pv).get_slice(tidx)
+
+        tSsQ = smem_thr_copy_Q.partition_S(sQ)
+        tSsK = smem_thr_copy_K.partition_S(sK)
+        tOsVt = smem_thr_copy_V.partition_S(sVt)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Predicate: Mark indices that need to copy when problem_shape isn't a multiple
+        # of tile_shape
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Construct identity layout for KV
+        cK = cute.make_identity_tensor((self.tile_n, self.tile_hdim))
+        tKcK = gmem_thr_copy_K.partition_S(cK)
+        t0KcK = gmem_thr_copy_K.get_slice(0).partition_S(cK)
+        tVcV = tKcK
+        t0VcV = t0KcK
+        # Allocate predicate tensors for m and n, here we only allocate the tile of k, and
+        # use "if" on the mn dimension.
+        # This is to reduce register pressure and gets 2-3% performance gain.
+        tKpK = utils.predicate_k(tKcK, limit=mK.shape[1])
+        tVpV = tKpK
+
+        # shape: (atom_v_m * rest_m)
+        softmax = Softmax.create(
+            softmax_scale_log2,
+            num_rows=acc_O.shape[0][0] * acc_O.shape[1],
+            softmax_scale=softmax_scale,
+        )
+        softmax.reset()
+
+        # group parameters for compute_one_n_block
+        mma_params = SimpleNamespace(
+            thr_mma_qk=thr_mma_qk,
+            thr_mma_pv=thr_mma_pv,
+            tSrQ=tSrQ,
+            tSrK=tSrK,
+            tOrVt=tOrVt,
+            acc_O=acc_O,
+        )
+        smem_copy_params = SimpleNamespace(
+            smem_thr_copy_Q=smem_thr_copy_Q,
+            smem_thr_copy_K=smem_thr_copy_K,
+            smem_thr_copy_V=smem_thr_copy_V,
+            tSsQ=tSsQ,
+            tSsK=tSsK,
+            tOsVt=tOsVt,
+        )
+        load_K = partial(
+            self.load_K, gmem_tiled_copy_K, tKgK, tKsK, tKcK, t0KcK, tKpK, seqlen=seqlen.seqlen_k
+        )
+        load_V = partial(
+            self.load_V, gmem_tiled_copy_V, tVgV, tVsV, tVcV, t0VcV, tVpV, seqlen=seqlen.seqlen_k
+        )
+        softmax_threshold_log2 = seqlen.get_softmax_threshold(
+            softmax_threshold,
+            m_block,
+            softmax.row_max,
+            thr_mma_qk,
+            self.tile_m,
+            self.tile_n,
+            self.is_causal,
+            self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+        skip_fn = partial(
+            softmax.skip,
+            softmax_threshold_log2=softmax_threshold_log2,
+            sSkip=sSkip,
+            num_warps=self.num_warps,
+        )
+
+        compute_one_n_block = partial(
+            self.compute_one_n_block,
+            mma_params=mma_params,
+            smem_copy_params=smem_copy_params,
+            softmax=softmax,
+            load_K=load_K,
+            load_V=load_V,
+            score_mod=self.score_mod,
+            batch_idx=batch_size,
+            head_idx=num_head,
+            m_block=m_block,
+            aux_data=aux_data,
+            fastdiv_mods=fastdiv_mods,
+            skip_fn=skip_fn,
+        )
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Prologue
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Start async loads of the last mn-tile, where we take care of the mn residue
+        gmem_thr_copy_Q = gmem_tiled_copy_Q.get_slice(tidx)
+        if const_expr(not self.pack_gqa):
+            self.load_Q(
+                gmem_thr_copy_Q, gQ, sQ, m_block, seqlen=seqlen.seqlen_q, headdim=mQ.shape[1]
+            )
+        else:
+            pack_gqa = PackGQA(
+                self.tile_m, self.tile_hdim, self.check_hdim_oob, self.qhead_per_kvhead
+            )
+            pack_gqa.load_Q(mQ_cur, sQ, gmem_tiled_copy_Q, tidx, m_block, seqlen.seqlen_q)
+        cute.arch.cp_async_commit_group()
+
+        def preprocess_Q():
+            if const_expr(self.Q_in_regs):
+                cute.arch.cp_async_wait_group(0)
+            else:
+                cute.arch.cp_async_wait_group(self.num_stages)
+            if const_expr(self.Q_in_regs):
+                cute.arch.barrier()
+                tSrQ_copy_view = smem_thr_copy_Q.retile(tSrQ)
+                cute.copy(smem_thr_copy_Q, tSsQ, tSrQ_copy_view)
+
+        # If Q_in_regs, we load Q, then load 1 stage of K, then (optionally) rotate Q and
+        # read from smem_q to registers, then load V.
+        # If !Q_in_regs, we load Q, load all stages of K & V, then (optionally) rotate Q.
+        if const_expr(self.Q_in_regs):
+            load_K(n_block, smem_pipe_write=0, need_predicates=True)
+            cute.arch.cp_async_commit_group()
+            preprocess_Q()
+            cute.arch.barrier()  # Make sure all threads have read smem_q before the mainloop
+
+        for stage in cutlass.range_constexpr(self.num_stages):
+            if const_expr(not self.Q_in_regs or stage > 0):
+                if stage == 0 or n_block - stage >= 0:
+                    load_K(n_block - stage, smem_pipe_write=stage, need_predicates=stage == 0)
+                cute.arch.cp_async_commit_group()
+        if const_expr(not self.Q_in_regs):
+            preprocess_Q()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Mainloop
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Start processing of the first n-block.
+        # For performance reason, we separate out two kinds of iterations:
+        # those that need masking on S, and those that don't.
+        # We need masking on S for the very last block when K and V has length not multiple of tile_n.
+        # We also need masking on S if it's causal, for the last several blocks.
+        mask = AttentionMask(
+            self.tile_m,
+            self.tile_n,
+            seqlen,
+            window_size_left,
+            window_size_right,
+            self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+        mask_fn = partial(
+            mask.apply_mask,
+            batch_idx=batch_size,
+            head_idx=num_head,
+            m_block=m_block,
+            thr_mma=thr_mma_qk,
+            mask_causal=self.is_causal,
+            mask_local=self.is_local,
+            aux_data=aux_data,
+            fastdiv_mods=fastdiv_mods if const_expr(self.mask_mod is not None) else None,
+        )
+
+        # First iteration with seqlen masking
+        smem_pipe_read = Int32(0)
+        smem_pipe_write = Int32(self.num_stages - 1)
+        compute_one_n_block(
+            n_block,
+            smem_pipe_read,
+            smem_pipe_write,
+            is_first_n_block=True,
+            seqlen=seqlen,
+            mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=True),
+        )
+        smem_pipe_read = self.advance_pipeline(smem_pipe_read)
+        smem_pipe_write = self.advance_pipeline(smem_pipe_write)
+        # Next couple of iterations with causal masking
+        if const_expr(self.is_causal or self.is_local):
+            n_block_min_causal_local_mask = block_info.get_n_block_min_causal_local_mask(
+                seqlen, m_block, n_block_min
+            )
+            for n_tile in cutlass.range(n_block_max - 1 - n_block_min_causal_local_mask, unroll=1):
+                n_block = n_block_max - 2 - n_tile
+                compute_one_n_block(
+                    n_block,
+                    smem_pipe_read,
+                    smem_pipe_write,
+                    seqlen=seqlen,
+                    mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=True),
+                )
+                smem_pipe_read = self.advance_pipeline(smem_pipe_read)
+                smem_pipe_write = self.advance_pipeline(smem_pipe_write)
+        # The remaining iterations have no masking
+        for n_tile in cutlass.range(n_block, unroll=1):
+            compute_one_n_block(
+                n_block - n_tile - 1,
+                smem_pipe_read,
+                smem_pipe_write,
+                seqlen=seqlen,
+                is_first_n_block=False,
+                mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False),
+            )
+            smem_pipe_read = self.advance_pipeline(smem_pipe_read)
+            smem_pipe_write = self.advance_pipeline(smem_pipe_write)
+        # TODO: local
+
+        # normalize acc_O by row_sum and calculate the lse
+        row_scale = softmax.finalize()
+        softmax.rescale_O(acc_O, row_scale)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Epilogue
+        # ///////////////////////////////////////////////////////////////////////////////
+        # reuse sQ's data iterator
+        sO = cute.make_tensor(sQ.iterator, sO_layout)
+        self.epilogue(
+            acc_O,
+            softmax.row_sum,
+            mO,
+            mLSE,
+            sO,
+            seqlen,
+            gmem_tiled_copy_O,
+            None,
+            tiled_mma_pv,
+            tidx,
+            m_block,
+            num_head,
+            batch_size,
+        )
+
+    @cute.jit
+    def compute_one_n_block(
+        self,
+        n_block: Int32,
+        smem_pipe_read: Int32,
+        smem_pipe_write: Int32,
+        mma_params: SimpleNamespace,
+        smem_copy_params: SimpleNamespace,
+        softmax: Softmax,
+        load_K: Callable,
+        load_V: Callable,
+        score_mod: Callable | None,
+        batch_idx: Int32,
+        head_idx: Int32,
+        m_block: Int32,
+        seqlen: SeqlenInfoQK,
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=None,
+        mask_fn: Optional[Callable] = None,
+        skip_fn: Optional[Callable] = None,
+        is_first_n_block: cutlass.Constexpr = False,
+        check_inf: cutlass.Constexpr = True,
+    ):
+        def load_K_next(
+            self,
+            load_K: Callable,
+            n_block: Int32,
+            smem_pipe_write: Int32,
+        ):
+            if n_block - self.num_stages >= 0:
+                load_K(n_block - self.num_stages, smem_pipe_write, need_predicates=False)
+                cute.arch.cp_async_commit_group()
+
+        acc_shape_S = mma_params.thr_mma_qk.partition_shape_C((self.tile_m, self.tile_n))
+        acc_S = cute.make_rmem_tensor(acc_shape_S, Float32)
+        acc_S.fill(0.0)
+        # Wait for the current Q/K tiles before computing S.
+        cute.arch.cp_async_wait_group(self.num_stages - 1)
+        cute.arch.barrier()
+
+        sm80_utils.gemm(
+            mma_params.thr_mma_qk,
+            acc_S,
+            mma_params.tSrQ,
+            mma_params.tSrK,
+            smem_copy_params.tSsQ,
+            smem_copy_params.tSsK[
+                None, None, None, smem_pipe_read if const_expr(self.num_stages > 1) else 0
+            ],
+            smem_copy_params.smem_thr_copy_Q,
+            smem_copy_params.smem_thr_copy_K,
+            # hook_fn=load_V_next,
+            A_in_regs=self.Q_in_regs,
+        )
+        if const_expr(score_mod is not None):
+            self.apply_score_mod(
+                mma_params.thr_mma_qk,
+                batch_idx,
+                head_idx,
+                m_block,
+                acc_S,
+                n_block,
+                softmax_scale=softmax.softmax_scale,
+                seqlen=seqlen,
+                aux_data=aux_data,
+                fastdiv_mods=fastdiv_mods,
+            )
+        if const_expr(mask_fn is not None):
+            mask_fn(acc_S, n_block=n_block)
+        if const_expr(mask_fn is not None):
+            is_skip = skip_fn(acc_S, is_first=is_first_n_block)
+        else:
+            is_skip = cutlass.Boolean(False)
+
+        smem_pipe_write = self.advance_pipeline(smem_pipe_write)
+
+        if is_skip:
+            load_K_next(self, load_K, n_block, smem_pipe_write)
+        else:
+            # need predicates for the first tile
+            load_V(
+                n_block,
+                smem_pipe_write=0,
+                need_predicates=is_first_n_block,
+            )
+            cute.arch.cp_async_commit_group()
+            load_K_next(self, load_K, n_block, smem_pipe_write)
+            row_scale = softmax.online_softmax(
+                acc_S, is_first=is_first_n_block, check_inf=check_inf
+            )
+            softmax.rescale_O(mma_params.acc_O, row_scale)
+            rP = cute.make_fragment_like(acc_S, self.dtype)
+            rP.store(acc_S.load().to(self.dtype))
+            tOrP = layout_utils.reshape_acc_to_frgA(rP)
+            if n_block - self.num_stages >= 0:
+                cute.arch.cp_async_wait_group(1)
+                cute.arch.barrier()
+            else:
+                cute.arch.cp_async_wait_group(0)
+                cute.arch.barrier()
+            sm80_utils.gemm_rs(
+                mma_params.thr_mma_pv,
+                mma_params.acc_O,
+                tOrP,
+                mma_params.tOrVt,
+                smem_copy_params.tOsVt[None, None, None, 0],
+                smem_copy_params.smem_thr_copy_V,
+                # hook_fn=load_K_next,
+            )
 
     @cute.jit
     def apply_score_mod(

--- a/flash_sparse_attn/ops/cute/flash_fwd.py
+++ b/flash_sparse_attn/ops/cute/flash_fwd.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2026, Jingze Shi.
 # Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 # A reimplementation of
+# https://github.com/HKUSTDial/flash-sparse-attention/blob/main/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
+# from Triton to Cute-DSL.
+# A reimplementation of
 # https://github.com/Dao-AILab/flash-attention/blob/main/hopper/flash_fwd_kernel_sm80.h
 # and https://github.com/Dao-AILab/flash-attention/blob/main/hopper/flash_fwd_kernel_sm90.h
 # from Cutlass C++ to Cute-DSL.
-# A reimplementation of
-# https://github.com/HKUSTDial/flash-sparse-attention/blob/main/flash_sparse_attn/ops/triton/flash_sparse_fwd.py
-# from Triton to Cute-DSL.
 # Built on Cute-DSL example: https://github.com/NVIDIA/cutlass/blob/main/examples/python/CuTeDSL/ampere/flash_attention_v2.py
 
 import math

--- a/flash_sparse_attn/ops/cute/flash_fwd_sm120.py
+++ b/flash_sparse_attn/ops/cute/flash_fwd_sm120.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026, Jingze Shi.
 # Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 # SM120 (Blackwell GeForce / DGX Spark) forward pass.
 #
@@ -9,10 +10,59 @@ import cutlass
 import cutlass.utils as utils_basic
 from cutlass.base_dsl.arch import Arch
 
-from flash_sparse_attn.ops.cute.flash_fwd import FlashAttentionForwardSm80
+from flash_sparse_attn.ops.cute.flash_fwd import (
+    FlashAttentionForwardSm80,
+    FlashSparseAttentionForwardSm80,
+)
 
 
 class FlashAttentionForwardSm120(FlashAttentionForwardSm80):
+    def __init__(self, *args, **kwargs):
+        """Force SM80 code paths while the DSL still targets the resident SM120 GPU."""
+        super().__init__(*args, **kwargs)
+        self.arch = Arch.sm_80
+
+    @staticmethod
+    def can_implement(
+        dtype,
+        head_dim,
+        tile_m,
+        tile_n,
+        num_stages,
+        num_threads,
+        is_causal,
+        Q_in_regs=False,
+    ) -> bool:
+        """Check if the kernel can be implemented on SM120.
+
+        Same logic as SM80 but uses SM120's shared memory capacity (99 KB).
+        """
+        if dtype not in [cutlass.Float16, cutlass.BFloat16]:
+            return False
+        if head_dim % 8 != 0:
+            return False
+        if tile_n % 16 != 0:
+            return False
+        if num_threads % 32 != 0:
+            return False
+        # Shared memory usage: Q tile + (K tile + V tile)
+        smem_usage_Q = tile_m * head_dim * 2
+        smem_usage_K = tile_n * head_dim * num_stages * 2
+        smem_usage_V = tile_n * head_dim * num_stages * 2
+        smem_usage_QV = (
+            (smem_usage_Q + smem_usage_V) if not Q_in_regs else max(smem_usage_Q, smem_usage_V)
+        )
+        smem_usage = smem_usage_QV + smem_usage_K
+        # SM120 has 99 KB shared memory (vs 163 KB on SM80)
+        smem_capacity = utils_basic.get_smem_capacity_in_bytes("sm_120")
+        if smem_usage > smem_capacity:
+            return False
+        if (tile_m * 2) % num_threads != 0:
+            return False
+        return True
+
+
+class FlashSparseAttentionForwardSm120(FlashSparseAttentionForwardSm80):
     def __init__(self, *args, **kwargs):
         """Force SM80 code paths while the DSL still targets the resident SM120 GPU."""
         super().__init__(*args, **kwargs)

--- a/flash_sparse_attn/ops/cute/interface.py
+++ b/flash_sparse_attn/ops/cute/interface.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026, Jingze Shi.
 # Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 # [2025-07-04] Version in Cute-DSL, for Hopper and Blackwell. You'll need install nvidia-cutlass-dsl==4.2.0.
 
@@ -33,15 +34,27 @@ from flash_sparse_attn.ops.cute.cute_dsl_utils import (
     to_cute_aux_tensor,
     to_cute_tensor,
 )
-from flash_sparse_attn.ops.cute.flash_fwd import FlashAttentionForwardSm80
+from flash_sparse_attn.ops.cute.flash_fwd import (
+    FlashAttentionForwardSm80,
+    FlashSparseAttentionForwardSm80,
+)
 from flash_sparse_attn.ops.cute.flash_fwd_sm90 import FlashAttentionForwardSm90
 from flash_sparse_attn.ops.cute.flash_fwd_sm100 import FlashAttentionForwardSm100, DescaleTensors
-from flash_sparse_attn.ops.cute.flash_fwd_sm120 import FlashAttentionForwardSm120
+from flash_sparse_attn.ops.cute.flash_fwd_sm120 import (
+    FlashAttentionForwardSm120,
+    FlashSparseAttentionForwardSm120,
+)
 from flash_sparse_attn.ops.cute.flash_bwd_preprocess import FlashAttentionBackwardPreprocess
-from flash_sparse_attn.ops.cute.flash_bwd import FlashAttentionBackwardSm80
+from flash_sparse_attn.ops.cute.flash_bwd import (
+    FlashAttentionBackwardSm80,
+    FlashSparseAttentionBackwardSm80,
+)
 from flash_sparse_attn.ops.cute.flash_bwd_sm90 import FlashAttentionBackwardSm90
 from flash_sparse_attn.ops.cute.flash_bwd_sm100 import FlashAttentionBackwardSm100
-from flash_sparse_attn.ops.cute.flash_bwd_sm120 import FlashAttentionBackwardSm120
+from flash_sparse_attn.ops.cute.flash_bwd_sm120 import (
+    FlashAttentionBackwardSm120,
+    FlashSparseAttentionBackwardSm120,
+)
 from flash_sparse_attn.ops.cute.flash_bwd_postprocess import FlashAttentionBackwardPostprocess
 from flash_sparse_attn.ops.cute.flash_fwd_combine import FlashAttentionForwardCombine
 
@@ -327,6 +340,7 @@ def _flash_attn_fwd(
     min_seqlen_k: Optional[int] = None,
     page_table: Optional[torch.Tensor] = None,
     softmax_scale: Optional[float] = None,
+    softmax_threshold: Optional[float] = None,
     causal: bool = False,
     softcap: Optional[float] = None,
     window_size_left: Optional[int] = None,
@@ -798,7 +812,12 @@ def _flash_attn_fwd(
         if arch // 10 == 8:
             assert page_table is None, "paged KV not supported on SM 8.0"
             assert not is_split_kv, "SplitKV not supported on SM 8.0"
-            fa_fwd = FlashAttentionForwardSm80(
+            flash_fwd_obj_cls = (
+                FlashAttentionForwardSm80
+                if softmax_threshold is None
+                else FlashSparseAttentionForwardSm80
+            )
+            fa_fwd = flash_fwd_obj_cls(
                 dtype,
                 head_dim,
                 qhead_per_kvhead,
@@ -868,7 +887,12 @@ def _flash_attn_fwd(
             assert not use_block_sparsity, "Block sparsity not supported on SM 12.0"
             assert page_table is None, "Paged KV not supported on SM 12.0 in this PR"
             assert not is_split_kv, "SplitKV not supported on SM 12.0 in this PR"
-            fa_fwd = FlashAttentionForwardSm120(
+            flash_fwd_obj_cls = (
+                FlashAttentionForwardSm120
+                if softmax_threshold is None
+                else FlashSparseAttentionForwardSm120
+            )
+            fa_fwd = flash_fwd_obj_cls(
                 dtype,
                 head_dim,
                 qhead_per_kvhead,
@@ -897,15 +921,21 @@ def _flash_attn_fwd(
             o_tensor,
             lse_tensor,
             softmax_scale,
-            cu_seqlens_q_tensor,
-            cu_seqlens_k_tensor,
-            seqused_q_tensor,
-            seqused_k_tensor,
-            page_table_tensor,
-            window_size_left,
-            window_size_right,
-            learnable_sink_tensor,
         ]
+        if softmax_threshold is not None:
+            compile_args.append(softmax_threshold)
+        compile_args.extend(
+            [
+                cu_seqlens_q_tensor,
+                cu_seqlens_k_tensor,
+                seqused_q_tensor,
+                seqused_k_tensor,
+                page_table_tensor,
+                window_size_left,
+                window_size_right,
+                learnable_sink_tensor,
+            ]
+        )
         if arch // 10 in [10, 11]:
             compile_args.append(descale_tensors_tensor)
         compile_args.extend(
@@ -936,15 +966,21 @@ def _flash_attn_fwd(
             out.detach() if not is_split_kv else out_partial,
             lse_partial if is_split_kv else lse,
             softmax_scale,
-            cu_seqlens_q,
-            cu_seqlens_k,
-            seqused_q,
-            seqused_k,
-            page_table,
-            window_size_left,
-            window_size_right,
-            learnable_sink,
         ]
+        if softmax_threshold is not None:
+            call_args.append(softmax_threshold)
+        call_args.extend(
+            [
+                cu_seqlens_q,
+                cu_seqlens_k,
+                seqused_q,
+                seqused_k,
+                page_table,
+                window_size_left,
+                window_size_right,
+                learnable_sink,
+            ]
+        )
         if arch // 10 in [10, 11]:
             call_args.append(descale_tensors)
         call_args.extend(
@@ -1270,6 +1306,7 @@ def _flash_attn_bwd(
     dout: torch.Tensor,
     lse: torch.Tensor,
     softmax_scale: Optional[float] = None,
+    softmax_threshold: Optional[float] = None,
     causal: bool = False,
     softcap: float = 0.0,
     window_size_left: Optional[int] = None,
@@ -1307,8 +1344,8 @@ def _flash_attn_bwd(
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     aux_scalars = tuple(aux_scalars) if aux_scalars else None
     arch = _get_device_arch()
-    assert arch // 10 in [9, 10, 11, 12], (
-        "Unsupported compute capability. Supported: 9.x, 10.x, 11.x, 12.x"
+    assert arch // 10 in [8, 9, 10, 11, 12], (
+        "Unsupported compute capability. Supported: 8.x, 9.x, 10.x, 11.x, 12.x"
     )
     sparse_q = None
     kv_subtile_factor = 1
@@ -1327,7 +1364,26 @@ def _flash_attn_bwd(
         causal, window_size_left, window_size_right
     )
 
-    if arch // 10 == 12:
+    if arch // 10 == 8:
+        m_block_size = 64
+        n_block_size = 128
+        num_stages_Q = 2
+        num_stages_dO = 1
+        num_threads = 256
+        SdP_swapAB = False
+        dKV_swapAB = False
+        dQ_swapAB = False
+        AtomLayoutMSdP = 2
+        AtomLayoutNdKV = 2
+        AtomLayoutMdQ = 2
+        V_in_regs = False
+        dQ_single_wg = False
+        cluster_size = 1
+        use_2cta_instrs = False
+        assert block_sparse_tensors is None, "Block sparsity backward is not supported on SM8x"
+        assert mask_mod is None, "mask_mod backward is not supported on SM8x"
+        assert deterministic is False, "deterministic backward is not supported on SM8x"
+    elif arch // 10 == 12:
         # SM120: uses SM80 MMA with 99 KB SMEM, 128 threads (4 warps).
         m_block_size = 64
         n_block_size = 64
@@ -1669,7 +1725,7 @@ def _flash_attn_bwd(
     )
     # num_threads: SM90 derives from BwdConfig.num_wg, SM120 is set to 128 above,
     # SM100/SM110 uses default from function signature (384).
-    if arch // 10 not in [9, 12]:
+    if arch // 10 not in [8, 9, 12]:
         num_threads = 384
 
     # Backward kernel: compute dk, dv, dq_accum.
@@ -1730,6 +1786,7 @@ def _flash_attn_bwd(
             dtype,
             head_dim,
             qhead_per_kvhead,
+            softmax_threshold is not None,
             causal,
             window_size_left is not None,
             window_size_right is not None,
@@ -1738,7 +1795,7 @@ def _flash_attn_bwd(
             num_threads,
             pack_gqa,
             num_stages_Q,
-            num_stages_dO,
+            None if softmax_threshold is not None else num_stages_dO,
             SdP_swapAB,
             dKV_swapAB,
             dQ_swapAB,
@@ -1830,27 +1887,44 @@ def _flash_attn_bwd(
             for t in (dQ_semaphore, dK_semaphore, dV_semaphore)
         ]
         if arch // 10 in [8, 12]:
-            flash_bwd_obj_cls = (
-                FlashAttentionBackwardSm120 if arch // 10 == 12 else FlashAttentionBackwardSm80
-            )
-            fa_bwd_obj = flash_bwd_obj_cls(
+            if arch // 10 == 12:
+                flash_bwd_obj_cls = (
+                    FlashSparseAttentionBackwardSm120
+                    if softmax_threshold is not None
+                    else FlashAttentionBackwardSm120
+                )
+            else:
+                flash_bwd_obj_cls = (
+                    FlashSparseAttentionBackwardSm80
+                    if softmax_threshold is not None
+                    else FlashAttentionBackwardSm80
+                )
+            flash_bwd_obj_args = [
                 dtype,
                 head_dim,
                 qhead_per_kvhead,
                 m_block_size,
                 n_block_size,
                 num_stages_Q,
-                num_stages_dO,
-                num_threads,
-                pack_gqa,
-                causal,
-                local,
-                SdP_swapAB,
-                dKV_swapAB,
-                dQ_swapAB,
-                AtomLayoutMSdP,
-                AtomLayoutNdKV,
-                AtomLayoutMdQ,
+            ]
+            if softmax_threshold is None:
+                flash_bwd_obj_args.append(num_stages_dO)
+            flash_bwd_obj_args.extend(
+                [
+                    num_threads,
+                    pack_gqa,
+                    causal,
+                    local,
+                    SdP_swapAB,
+                    dKV_swapAB,
+                    dQ_swapAB,
+                    AtomLayoutMSdP,
+                    AtomLayoutNdKV,
+                    AtomLayoutMdQ,
+                ]
+            )
+            fa_bwd_obj = flash_bwd_obj_cls(
+                *flash_bwd_obj_args,
                 V_in_regs=V_in_regs,
                 score_mod=score_mod,
                 score_mod_bwd=score_mod_bwd,
@@ -1908,7 +1982,7 @@ def _flash_attn_bwd(
         if normalized_block_sparse_tensors is not None:
             sparse_tensors_compile = to_cute_block_sparse_tensors(normalized_block_sparse_tensors)
         # TODO: check @can_implement
-        _flash_attn_bwd.compile_cache[compile_key] = cute.compile(
+        compile_args = [
             fa_bwd_obj,
             q_tensor,
             k_tensor,
@@ -1920,22 +1994,31 @@ def _flash_attn_bwd(
             dk_tensor if not dKV_postprocess else dk_accum_tensor,
             dv_tensor if not dKV_postprocess else dv_accum_tensor,
             softmax_scale,
-            cu_seqlens_q_tensor,
-            cu_seqlens_k_tensor,
-            seqused_q_tensor,
-            seqused_k_tensor,
-            window_size_left,
-            window_size_right,
-            dQ_semaphore_tensor,
-            dK_semaphore_tensor,
-            dV_semaphore_tensor,
-            AuxData(cute_aux_tensors, aux_scalars),
-            sparse_tensors_compile,
-            current_stream,
+        ]
+        if softmax_threshold is not None:
+            compile_args.append(softmax_threshold)
+        compile_args.extend(
+            [
+                cu_seqlens_q_tensor,
+                cu_seqlens_k_tensor,
+                seqused_q_tensor,
+                seqused_k_tensor,
+                window_size_left,
+                window_size_right,
+                dQ_semaphore_tensor,
+                dK_semaphore_tensor,
+                dV_semaphore_tensor,
+                AuxData(cute_aux_tensors, aux_scalars),
+                sparse_tensors_compile,
+                current_stream,
+            ]
+        )
+        _flash_attn_bwd.compile_cache[compile_key] = cute.compile(
+            *compile_args,
             options="--enable-tvm-ffi",
         )
     if not is_fake_mode():
-        _flash_attn_bwd.compile_cache[compile_key](
+        call_args = [
             q.detach(),
             k.detach(),
             v.detach(),
@@ -1946,31 +2029,41 @@ def _flash_attn_bwd(
             dk if not dKV_postprocess else dk_accum,
             dv if not dKV_postprocess else dv_accum,
             softmax_scale,
-            cu_seqlens_q,
-            cu_seqlens_k,
-            seqused_q,
-            seqused_k,
-            window_size_left,
-            window_size_right,
-            dQ_semaphore,
-            dK_semaphore,
-            dV_semaphore,
-            AuxData(aux_tensors, aux_scalars),
-            (
-                normalized_block_sparse_tensors.mask_block_cnt,
-                normalized_block_sparse_tensors.mask_block_idx,
-                normalized_block_sparse_tensors.full_block_cnt,
-                normalized_block_sparse_tensors.full_block_idx,
-                normalized_block_sparse_tensors.cu_total_m_blocks,
-                normalized_block_sparse_tensors.cu_block_idx_offsets,
-                normalized_block_sparse_tensors.dq_write_order,
-                normalized_block_sparse_tensors.dq_write_order_full,
-            )
-            if normalized_block_sparse_tensors is not None
-            else None,
+        ]
+        if softmax_threshold is not None:
+            call_args.append(softmax_threshold)
+        call_args.extend(
+            [
+                cu_seqlens_q,
+                cu_seqlens_k,
+                seqused_q,
+                seqused_k,
+                window_size_left,
+                window_size_right,
+                dQ_semaphore,
+                dK_semaphore,
+                dV_semaphore,
+                AuxData(aux_tensors, aux_scalars),
+                (
+                    normalized_block_sparse_tensors.mask_block_cnt,
+                    normalized_block_sparse_tensors.mask_block_idx,
+                    normalized_block_sparse_tensors.full_block_cnt,
+                    normalized_block_sparse_tensors.full_block_idx,
+                    normalized_block_sparse_tensors.cu_total_m_blocks,
+                    normalized_block_sparse_tensors.cu_block_idx_offsets,
+                    normalized_block_sparse_tensors.dq_write_order,
+                    normalized_block_sparse_tensors.dq_write_order_full,
+                )
+                if normalized_block_sparse_tensors is not None
+                else None,
+            ]
         )
+        _flash_attn_bwd.compile_cache[compile_key](*call_args)
     # Postprocess: convert dq_accum from float32 to dq in bf16/fp16
-    if arch // 10 == 9:
+    if arch // 10 == 8:
+        num_threads_post_dQ = num_threads
+        num_threads_post_dKV = num_threads
+    elif arch // 10 == 9:
         # dQ postprocess: match main kernel's MMA WG count, unless dQ_single_wg
         num_threads_post_dQ = 128 if dQ_single_wg else cfg.num_wg * 128
         num_threads_post_dKV = cfg.num_wg * 128
@@ -2043,6 +2136,7 @@ class FlashAttnFunc(torch.autograd.Function):
         k: torch.Tensor,
         v: torch.Tensor,
         softmax_scale: Optional[float] = None,
+        softmax_threshold: Optional[float] = None,
         causal: bool = False,
         window_size: Tuple[Optional[int], Optional[int]] = (None, None),
         learnable_sink: Optional[torch.Tensor] = None,
@@ -2065,6 +2159,7 @@ class FlashAttnFunc(torch.autograd.Function):
             k,
             v,
             softmax_scale=softmax_scale,
+            softmax_threshold=softmax_threshold,
             causal=causal,
             window_size_left=window_size[0],
             window_size_right=window_size[1],
@@ -2081,6 +2176,7 @@ class FlashAttnFunc(torch.autograd.Function):
         )
         ctx.save_for_backward(q, k, v, out, lse, *(aux_tensors or ()))
         ctx.softmax_scale = softmax_scale
+        ctx.softmax_threshold = softmax_threshold
         ctx.causal = causal
         ctx.window_size = window_size
         ctx.softcap = softcap
@@ -2110,6 +2206,7 @@ class FlashAttnFunc(torch.autograd.Function):
             dout,
             lse,
             ctx.softmax_scale,
+            ctx.softmax_threshold,
             ctx.causal,
             ctx.softcap,
             window_size_left=ctx.window_size[0],
@@ -2142,6 +2239,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         min_seqlen_k: Optional[int] = None,
         page_table: Optional[torch.Tensor] = None,
         softmax_scale: Optional[float] = None,
+        softmax_threshold: Optional[float] = None,
         causal: bool = False,
         window_size: Tuple[Optional[int], Optional[int]] = (None, None),
         learnable_sink: Optional[torch.Tensor] = None,
@@ -2171,6 +2269,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             min_seqlen_k=min_seqlen_k,
             page_table=page_table,
             softmax_scale=softmax_scale,
+            softmax_threshold=softmax_threshold,
             causal=causal,
             window_size_left=window_size[0],
             window_size_right=window_size[1],
@@ -2198,6 +2297,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             *(aux_tensors or ()),
         )
         ctx.softmax_scale = softmax_scale
+        ctx.softmax_threshold = softmax_threshold
         ctx.causal = causal
         ctx.window_size = window_size
         ctx.softcap = softcap
@@ -2240,6 +2340,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             dout,
             lse,
             ctx.softmax_scale,
+            ctx.softmax_threshold,
             ctx.causal,
             ctx.softcap,
             window_size_left=ctx.window_size[0],
@@ -2266,6 +2367,7 @@ def flash_attn_func(
     k: torch.Tensor,
     v: torch.Tensor,
     softmax_scale: Optional[float] = None,
+    softmax_threshold: Optional[float] = None,
     causal: bool = False,
     window_size: Tuple[Optional[int], Optional[int]] = (None, None),
     learnable_sink: Optional[torch.Tensor] = None,
@@ -2287,6 +2389,7 @@ def flash_attn_func(
         k,
         v,
         softmax_scale,
+        softmax_threshold,
         causal,
         window_size,
         learnable_sink,
@@ -2318,6 +2421,7 @@ def flash_attn_varlen_func(
     seqused_k: Optional[torch.Tensor] = None,
     page_table: Optional[torch.Tensor] = None,
     softmax_scale: Optional[float] = None,
+    softmax_threshold: Optional[float] = None,
     causal: bool = False,
     window_size: Tuple[Optional[int], Optional[int]] = (None, None),
     learnable_sink: Optional[torch.Tensor] = None,
@@ -2359,6 +2463,7 @@ def flash_attn_varlen_func(
         min_seqlen_k,
         page_table,
         softmax_scale,
+        softmax_threshold,
         causal,
         window_size,
         learnable_sink,

--- a/flash_sparse_attn/ops/cute/mask.py
+++ b/flash_sparse_attn/ops/cute/mask.py
@@ -188,6 +188,7 @@ class AttentionMask:
         mask_mod: cutlass.Constexpr[Optional[Callable]] = None,
         aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
+        use_r2p: cutlass.Constexpr[bool] = True,
     ) -> None:
         assert not (mask_causal and mask_local), "mask_causal and mask_local cannot be both True"
         acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S, transpose=self.swap_AB)
@@ -210,7 +211,7 @@ class AttentionMask:
         seqlenk_col_limit = self.seqlen_k - n_block * self.tile_n - thr_col_offset
         if const_expr(not mask_causal and not mask_local and mask_mod is None):
             if const_expr(mask_seqlen):
-                r2p = const_expr(not self.swap_AB)
+                r2p = const_expr(use_r2p and not self.swap_AB)
                 if const_expr(not r2p):
                     # traverse column index.
                     for c in cutlass.range(cute.size(tScS_mn.shape[1]), unroll_full=True):
@@ -301,7 +302,9 @@ class AttentionMask:
                     1 + self.seqlen_k - n_block * self.tile_n - self.seqlen_q - thr_col_offset
                 )
                 if const_expr(mask_causal):
-                    r2p = const_expr(not self.swap_AB)  # R2P trick, see apply_mask_sm100
+                    r2p = const_expr(
+                        use_r2p and not self.swap_AB
+                    )  # R2P trick, see apply_mask_sm100
                     for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
                         # get the column index limit based on current row. Only consider the row index, so the column index sets to 0.
                         if const_expr(self.qhead_per_kvhead_packgqa == 1):
@@ -339,7 +342,7 @@ class AttentionMask:
                         if const_expr(self.window_size_left is not None)
                         else None
                     )
-                    r2p_local = const_expr(not self.swap_AB)
+                    r2p_local = const_expr(use_r2p and not self.swap_AB)
                     for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
                         if const_expr(self.qhead_per_kvhead_packgqa == 1):
                             row_idx = tScS_mn[r, 0][0] + m_block * self.tile_m

--- a/flash_sparse_attn/ops/cute/seqlen_info.py
+++ b/flash_sparse_attn/ops/cute/seqlen_info.py
@@ -3,9 +3,9 @@ from dataclasses import dataclass
 
 import cutlass
 import cutlass.cute as cute
-from cutlass import Int32, const_expr
+from cutlass import Float32, Int32, const_expr
 
-from quack import copy_utils
+from quack import copy_utils, layout_utils
 
 """
 This consolidates all the info related to sequence length. This is so that we can do all
@@ -215,6 +215,33 @@ class SeqlenInfoQK:
             return copy_utils.offset_ragged_tensor(
                 mK, offset_k, self.seqlen_k, ragged_dim=0, ptr_shift=True
             )
+
+    def get_softmax_threshold(
+        self,
+        softmax_threshold: Float32,
+        m_block: Int32,
+        row_fragment: cute.Tensor,
+        thr_mma: cute.ThrMma,
+        tile_m: cutlass.Constexpr[int],
+        tile_n: cutlass.Constexpr[int],
+        is_causal: cutlass.Constexpr[bool],
+        qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1,
+    ):
+        softmax_threshold_log2 = cute.make_fragment_like(row_fragment, Float32)
+        cS = cute.make_identity_tensor((tile_m, tile_n))
+        tScS_mn = layout_utils.reshape_acc_to_mn(thr_mma.partition_C(cS))
+        for r in range(cute.size(softmax_threshold_log2)):
+            q_idx = m_block * tile_m + tScS_mn[r, 0][0]
+            if const_expr(qhead_per_kvhead_packgqa > 1):
+                q_idx = q_idx // qhead_per_kvhead_packgqa
+            visible_len = (
+                cutlass.max(q_idx + self.seqlen_k - self.seqlen_q + 1, 1)
+                if const_expr(is_causal)
+                else cutlass.max(self.seqlen_k, 1)
+            )
+            threshold = cutlass.max(cutlass.min(softmax_threshold / Float32(visible_len), 1.0), 0.0)
+            softmax_threshold_log2[r] = cute.math.log2(threshold, fastmath=True)
+        return softmax_threshold_log2
 
 
 @dataclass(frozen=True)

--- a/flash_sparse_attn/ops/cute/softmax.py
+++ b/flash_sparse_attn/ops/cute/softmax.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 
 import cutlass
 import cutlass.cute as cute
-from cutlass import Float32, Boolean
+from cutlass import Float32, Int32, Boolean
 
 from quack import layout_utils
 import flash_sparse_attn.ops.cute.utils as utils
@@ -188,6 +188,42 @@ class Softmax(ParamsBase):
             acc_S_mn[r, None].store(acc_S_row_exp)
 
         return row_scale
+
+    @cute.jit
+    def skip(
+        self,
+        acc_S: cute.Tensor,
+        softmax_threshold_log2: cute.Tensor,
+        sSkip: cute.Tensor,
+        num_warps: cutlass.Constexpr[int],
+        is_first: cutlass.Constexpr[bool] = False,
+    ) -> Boolean:
+        """Determine whether to skip the softmax computation for this S."""
+        if cutlass.const_expr(is_first):
+            cute.arch.barrier()
+            return Boolean(False)
+
+        acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S)
+        row_sum_reduced = utils.warp_reduce(self.row_sum.load(), operator.add, width=4)
+        warp_skip = Boolean(True)
+        for r in cutlass.range(cute.size(self.row_max), unroll_full=True):
+            acc_S_row = acc_S_mn[r, None].load()
+            row_max_cur = self._compute_row_max(acc_S_row)
+            row_max_cur = cute.arch.warp_reduction_max(row_max_cur, threads_in_group=4)
+            row_max_diff_log2 = (row_max_cur - self.row_max[r]) * self.scale_log2 - cute.math.log2(
+                row_sum_reduced[r], fastmath=True
+            )
+            warp_skip = warp_skip and row_max_diff_log2 < softmax_threshold_log2[r]
+
+        cta_skip = utils.cta_reduce(
+            Int32(1) if warp_skip else Int32(0),
+            sSkip,
+            operator.and_,
+            Int32(1),
+            num_warps,
+        )
+        is_skip = Boolean(cta_skip != 0)
+        return is_skip
 
     @cute.jit
     def finalize(

--- a/flash_sparse_attn/ops/cute/utils.py
+++ b/flash_sparse_attn/ops/cute/utils.py
@@ -333,6 +333,33 @@ def warp_reduce(
     return val
 
 
+@cute.jit
+def cta_reduce(
+    val: cute.Numeric,
+    sReduce: cute.Tensor,
+    op: Callable,
+    identity: cute.Numeric,
+    num_warps: cutlass.Constexpr[int],
+) -> cute.Numeric:
+    assert num_warps <= cute.arch.WARP_SIZE
+    warp_val = warp_reduce(val, op)
+    tidx = cute.arch.thread_idx()[0]
+    lane_idx = cute.arch.lane_idx()
+    warp_idx = tidx // cute.arch.WARP_SIZE
+    if lane_idx == 0:
+        sReduce[warp_idx] = warp_val
+    cute.arch.barrier()
+    if warp_idx == 0:
+        cta_val = identity
+        if lane_idx < num_warps:
+            cta_val = sReduce[lane_idx]
+        cta_val = warp_reduce(cta_val, op)
+        if lane_idx == 0:
+            sReduce[0] = cta_val
+    cute.arch.barrier()
+    return sReduce[0]
+
+
 @dsl_user_op
 def smid(*, loc=None, ip=None) -> Int32:
     return Int32(


### PR DESCRIPTION
Closes #348

## Summary

- add dedicated `FlashSparseAttentionForwardSm80` and `FlashSparseAttentionBackwardSm80` kernels plus SM120 adapters
- implement CTA-uniform softmax-threshold skipping with visible-length normalization
- demand-load V in sparse forward and dO/dPsum in sparse backward so skipped tiles avoid unnecessary memory traffic
- preserve Q/K GEMM hook overlap and use explicit hook arguments for staged CuTe control flow
- keep dense and sparse compile/call argument lists separate, selecting sparse only when `softmax_threshold is not None`
- preserve standard PackGQA preprocessing/postprocessing while removing unused MLA/QV and `head_dim_v` paths
- retain scalar masking in backward because the current bwd MMA accumulator layout is not compatible with the existing R2P mapping

## Correctness

Validated on NVIDIA A800-SXM4-80GB with BF16, causal attention, `B=1`, `HQ/HK=32/8`, `D=128`, `PackGQA=False`:

- dense SM80 MHA forward/backward: PASS against SDPA
- dense SM80 GQA forward/backward: finite; mean dK/dV errors remain within the expected atomic accumulation envelope
- sparse forward: PASS for K stages 1/2, `Q_in_regs` false/true, no-skip/high-skip, and boundary lengths 1/63/64/65/127/128/129
- no-skip sparse forward matches dense CuTe exactly
- sparse forward vs Triton max absolute error: at most `0.015625`
- sparse backward outputs are finite; mean absolute error vs Triton is `3.58e-4` for dQ, `7.41e-5` for dK, and approximately zero for dV
- same-process dense-to-sparse calls pass, confirming compile keys keep the two ABIs separate

## Performance

A800 high-skip sweep, sequence lengths 1K through 128K:

- forward CuTe speedup vs SDPA: `1.30x-1.50x`
- forward CuTe speedup vs Triton: `1.34x-1.59x`
- backward CuTe speedup vs SDPA from 2K onward: `1.66x-2.33x`
- backward CuTe speedup vs Triton: `1.76x-2.56x`

## Notes

- SM120 reuses the SM80 MMA implementation with SM120 shared-memory checks. The adapters were reviewed statically; the correctness and benchmark runs above were performed on SM80 hardware.
- Backward R2P was tested separately and remains disabled because enabling it with the current `M64/N128/T256/AtomLayoutMSdP=2` layout produces incorrect masks.