### PR TITLE
Add flexible per-KV-head window sizes to CuTe sparse attention

### DIFF
--- a/flash_sparse_attn/ops/cute/block_info.py
+++ b/flash_sparse_attn/ops/cute/block_info.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026, Jingze Shi.
 # Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
 from typing import Tuple, Optional
 from dataclasses import dataclass
@@ -6,7 +7,7 @@ import cutlass
 import cutlass.cute as cute
 from cutlass import Int32, const_expr
 
-from flash_sparse_attn.ops.cute.seqlen_info import SeqlenInfoQK, SeqlenInfoQKNewK
+from flash_sparse_attn.ops.cute.seqlen_info import SeqlenInfoQK
 
 
 @dataclass(frozen=True)
@@ -16,8 +17,10 @@ class BlockInfo:
     is_causal: cutlass.Constexpr[bool]
     is_local: cutlass.Constexpr[bool] = False
     is_split_kv: cutlass.Constexpr[bool] = False
+    window_size_sink: Optional[Int32] = None
     window_size_left: Optional[Int32] = None
     window_size_right: Optional[Int32] = None
+    window_size_dist: Optional[Int32] = None
     qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1
 
     @cute.jit
@@ -27,79 +30,153 @@ class BlockInfo:
         m_block: Int32,
         split_idx: Int32 = 0,
         num_splits: Int32 = 1,
-    ) -> Tuple[Int32, Int32]:
+    ) -> Tuple[Int32, Int32, Int32, Int32, Int32, Int32]:
         n_block_max = cute.ceil_div(seqlen_info.seqlen_k, self.tile_n)
-        if const_expr(self.is_causal or (self.is_local and self.window_size_right is not None)):
+        n_block_min = Int32(0)
+        n_block_window_max = n_block_max
+        n_block_window_min = n_block_min
+        n_block_sink_min = Int32(0)
+        n_block_sink_max = Int32(0)
+        if const_expr(self.is_causal or self.is_local):
             m_idx_max = (m_block + 1) * self.tile_m
             if const_expr(self.qhead_per_kvhead_packgqa > 1):
                 m_idx_max = cute.ceil_div(m_idx_max, self.qhead_per_kvhead_packgqa)
+            m_idx_max = cutlass.min(m_idx_max, seqlen_info.seqlen_q)
             n_idx = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q
-            n_idx_right = n_idx if const_expr(self.is_causal) else n_idx + self.window_size_right
-            n_block_max = min(n_block_max, cute.ceil_div(n_idx_right, self.tile_n))
-        n_block_min = 0
-        if const_expr(self.is_local and self.window_size_left is not None):
+            n_block_max = cutlass.min(n_block_max, cute.ceil_div(n_idx, self.tile_n))
+            if const_expr(self.is_local):
+                n_idx_right = n_idx - self.window_size_dist - self.window_size_right
+                n_block_window_max = cutlass.min(
+                    n_block_window_max,
+                    cutlass.max(cute.ceil_div(n_idx_right, self.tile_n), 0),
+                )
+        if const_expr(self.is_local):
+            n_block_sink_max = cutlass.min(
+                cute.ceil_div(self.window_size_sink, self.tile_n),
+                cutlass.max(cute.ceil_div(n_idx, self.tile_n), 0),
+            )
+            n_block_sink_exclude_max = cute.ceil_div(self.window_size_sink, self.tile_n)
             m_idx_min = m_block * self.tile_m
             if const_expr(self.qhead_per_kvhead_packgqa > 1):
                 m_idx_min = m_idx_min // self.qhead_per_kvhead_packgqa
             n_idx = m_idx_min + seqlen_info.seqlen_k - seqlen_info.seqlen_q
-            n_idx_left = n_idx - self.window_size_left
-            n_block_min = cutlass.max(n_idx_left // self.tile_n, 0)
-        if cutlass.const_expr(self.is_split_kv):
-            num_n_blocks_per_split = (
-                Int32(0)
-                if n_block_max <= n_block_min
-                else (n_block_max - n_block_min + num_splits - 1) // num_splits
+            n_idx_dist = n_idx - self.window_size_dist
+            n_block_min = cutlass.max(n_idx_dist // self.tile_n, 0)
+            n_block_min = cutlass.max(n_block_min, n_block_sink_exclude_max)
+            n_idx_left = (
+                n_idx - self.window_size_dist - self.window_size_right - self.window_size_left
             )
-            n_block_min = n_block_min + split_idx * num_n_blocks_per_split
-            n_block_max = cutlass.min(n_block_min + num_n_blocks_per_split, n_block_max)
-        return n_block_min, n_block_max
+            n_block_window_min = cutlass.max(n_idx_left // self.tile_n, 0)
+            n_block_window_min = cutlass.max(n_block_window_min, n_block_sink_exclude_max)
+        if const_expr(self.is_split_kv):
+            if const_expr(self.is_local):
+                n_block_diag_min = (
+                    cutlass.max(
+                        cute.ceil_div(cutlass.max(n_idx_dist + 1, 0), self.tile_n),
+                        0,
+                    )
+                    if seqlen_info.seqlen_q == 1
+                    else n_block_min
+                )
+                n_block_diag_min = cutlass.max(n_block_diag_min, n_block_sink_exclude_max)
+                n_block_diag_max = n_block_max
+                n_block_window_max = cutlass.max(n_block_window_max, n_block_window_min)
+                total_n_blocks = cutlass.max(n_block_window_max - n_block_window_min, 0)
+                base = total_n_blocks // num_splits
+                extra = total_n_blocks % num_splits
+                n_block_window_min_new = n_block_window_min + (
+                    split_idx * (base + 1)
+                    if split_idx < extra
+                    else extra * (base + 1) + (split_idx - extra) * base
+                )
+                n_block_count = base + 1 if split_idx < extra else base
+                n_block_window_max = cutlass.min(
+                    n_block_window_min_new + n_block_count,
+                    n_block_window_max,
+                )
+                n_block_window_min = n_block_window_min_new
+                n_block_sink_max = n_block_sink_max if split_idx == 0 else Int32(0)
+                n_block_non_diag_max = cutlass.max(n_block_window_max, n_block_sink_max)
+                n_block_max = (
+                    n_block_diag_max if split_idx >= num_splits - 1 else n_block_non_diag_max
+                )
+                n_block_min = (
+                    n_block_diag_min if split_idx >= num_splits - 1 else n_block_non_diag_max
+                )
+            else:
+                total_n_blocks = cutlass.max(n_block_max - n_block_min, 0)
+                base = total_n_blocks // num_splits
+                extra = total_n_blocks % num_splits
+                n_block_min_new = n_block_min + (
+                    split_idx * (base + 1)
+                    if split_idx < extra
+                    else extra * (base + 1) + (split_idx - extra) * base
+                )
+                n_block_count = base + 1 if split_idx < extra else base
+                n_block_max = cutlass.min(n_block_min_new + n_block_count, n_block_max)
+                n_block_min = n_block_min_new
+                n_block_sink_max = n_block_sink_max if split_idx == 0 else Int32(0)
+        return (
+            n_block_min,
+            n_block_max,
+            n_block_window_min,
+            n_block_window_max,
+            n_block_sink_min,
+            n_block_sink_max,
+        )
 
     @cute.jit
-    def get_m_block_min_max(self, seqlen_info: SeqlenInfoQK, n_block: Int32) -> Tuple[Int32, Int32]:
+    def get_m_block_min_max(
+        self,
+        seqlen_info: SeqlenInfoQK,
+        n_block: Int32,
+    ) -> Tuple[Int32, Int32, Int32, Int32, Int32, Int32]:
         m_block_max = cute.ceil_div(seqlen_info.seqlen_q, self.tile_m)
-        m_block_min = 0
-        if const_expr(self.is_causal or (self.is_local and self.window_size_right is not None)):
+        m_block_min = Int32(0)
+        m_block_window_max = m_block_max
+        m_block_window_min = m_block_min
+        m_block_sink_min = Int32(0)
+        m_block_sink_max = Int32(0)
+        if const_expr(self.is_causal or self.is_local):
             n_idx_min = n_block * self.tile_n
             m_idx = n_idx_min + seqlen_info.seqlen_q - seqlen_info.seqlen_k
-            m_idx_right = m_idx if const_expr(self.is_causal) else m_idx - self.window_size_right
-            m_block_min = max(m_block_min, m_idx_right // self.tile_m)
-        if const_expr(self.is_local and self.window_size_left is not None):
+            m_block_min = cutlass.max(m_block_min, m_idx // self.tile_m)
+            if const_expr(self.is_local):
+                m_idx_right = m_idx + self.window_size_dist + self.window_size_right
+                m_block_window_min = cutlass.max(m_block_window_min, m_idx_right // self.tile_m)
+        if const_expr(self.is_local):
+            n_block_sink_exclude_max = cute.ceil_div(self.window_size_sink, self.tile_n)
+            is_sink_block = n_block < n_block_sink_exclude_max
+            n_idx_min = n_block * self.tile_n
+            m_idx_sink = n_idx_min + seqlen_info.seqlen_q - seqlen_info.seqlen_k
+            m_block_sink_min = cutlass.max(m_idx_sink // self.tile_m, 0)
+            m_block_sink_max = (
+                cute.ceil_div(seqlen_info.seqlen_q, self.tile_m) if is_sink_block else Int32(0)
+            )
+            m_block_sink_min = m_block_sink_min if is_sink_block else Int32(0)
             n_idx_max = (n_block + 1) * self.tile_n
             m_idx = n_idx_max + seqlen_info.seqlen_q - seqlen_info.seqlen_k
-            m_idx_left = m_idx + self.window_size_left
-            m_block_max = min(m_block_max, cute.ceil_div(m_idx_left, self.tile_m))
-        return m_block_min, m_block_max
-
-    @cute.jit
-    def get_n_block_k_new_min_max(
-        self,
-        seqlen_info: SeqlenInfoQKNewK,
-        m_block: Int32,
-        split_idx: Int32 = 0,
-        num_splits: Int32 = 1,
-    ) -> Tuple[Int32, Int32]:
-        """Get the block range for new K tokens (append KV).
-
-        First computes the full n_block range via get_n_block_min_max, then maps
-        those blocks into the new-K index space by subtracting seqlen_k_og.
-        """
-        n_block_min, n_block_max = self.get_n_block_min_max(
-            seqlen_info,
-            m_block,
-            split_idx,
-            num_splits,
+            m_idx_dist = m_idx + self.window_size_dist
+            m_block_max = cutlass.min(m_block_max, cute.ceil_div(m_idx_dist, self.tile_m))
+            m_idx_left = (
+                m_idx + self.window_size_dist + self.window_size_right + self.window_size_left
+            )
+            m_block_window_max = cutlass.min(
+                m_block_window_max,
+                cute.ceil_div(m_idx_left, self.tile_m),
+            )
+            m_block_min = Int32(0) if is_sink_block else m_block_min
+            m_block_max = Int32(0) if is_sink_block else m_block_max
+            m_block_window_min = Int32(0) if is_sink_block else m_block_window_min
+            m_block_window_max = Int32(0) if is_sink_block else m_block_window_max
+        return (
+            m_block_min,
+            m_block_max,
+            m_block_window_min,
+            m_block_window_max,
+            m_block_sink_min,
+            m_block_sink_max,
         )
-        idx_k_new_min = cutlass.max(n_block_min * self.tile_n - seqlen_info.seqlen_k_og, 0)
-        idx_k_new_max = cutlass.min(
-            n_block_max * self.tile_n - seqlen_info.seqlen_k_og, seqlen_info.seqlen_k_new
-        )
-        n_block_new_min = idx_k_new_min // self.tile_n
-        n_block_new_max = (
-            cute.ceil_div(idx_k_new_max, self.tile_n)
-            if idx_k_new_max > idx_k_new_min
-            else n_block_new_min
-        )
-        return n_block_new_min, n_block_new_max
 
     @cute.jit
     def get_n_block_min_causal_local_mask(
@@ -107,16 +184,18 @@ class BlockInfo:
         seqlen_info: SeqlenInfoQK,
         m_block: Int32,
         n_block_min: Int32,
+        is_local: cutlass.Constexpr[Optional[bool]] = None,
     ) -> Int32:
         """If we have separate iterations with causal or local masking at the start, where do we stop"""
+        is_local = self.is_local if const_expr(is_local is None) else is_local
         m_idx_min = m_block * self.tile_m
         if const_expr(self.qhead_per_kvhead_packgqa > 1):
             m_idx_min = m_idx_min // self.qhead_per_kvhead_packgqa
         n_idx = m_idx_min + seqlen_info.seqlen_k - seqlen_info.seqlen_q
         n_idx_right = (
             n_idx
-            if const_expr(not self.is_local or self.window_size_right is None)
-            else n_idx + self.window_size_right
+            if const_expr(not is_local)
+            else n_idx - self.window_size_dist - self.window_size_right
         )
         return cutlass.max(n_block_min, n_idx_right // self.tile_n)
 
@@ -128,15 +207,49 @@ class BlockInfo:
         n_block_min: Int32,
     ) -> Int32:
         """If we have separate iterations with local masking at the end, where do we stop the non-masked iterations"""
-        if const_expr(not self.is_local or self.window_size_left is None):
+        if const_expr(not self.is_local):
             return n_block_min
         else:
             m_idx_max = (m_block + 1) * self.tile_m
             if const_expr(self.qhead_per_kvhead_packgqa > 1):
                 m_idx_max = cute.ceil_div(m_idx_max, self.qhead_per_kvhead_packgqa)
             n_idx = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q
-            n_idx_left = n_idx - self.window_size_left
+            n_idx_left = (
+                n_idx - self.window_size_dist - self.window_size_right - self.window_size_left
+            )
             return cutlass.max(n_block_min, cute.ceil_div(n_idx_left, self.tile_n))
+
+    @cute.jit
+    def get_m_block_min_causal_local_mask(
+        self,
+        seqlen_info: SeqlenInfoQK,
+        n_block: Int32,
+        m_block_min: Int32,
+    ) -> Int32:
+        if const_expr(not self.is_causal and not self.is_local):
+            return m_block_min
+        n_idx_max = (n_block + 1) * self.tile_n
+        m_idx = n_idx_max + seqlen_info.seqlen_q - seqlen_info.seqlen_k
+        m_idx_right = (
+            m_idx
+            if const_expr(not self.is_local)
+            else m_idx + self.window_size_dist + self.window_size_right
+        )
+        return cutlass.max(m_block_min, cute.ceil_div(m_idx_right, self.tile_m))
+
+    @cute.jit
+    def get_m_block_max_before_local_mask(
+        self,
+        seqlen_info: SeqlenInfoQK,
+        n_block: Int32,
+        m_block_max: Int32,
+    ) -> Int32:
+        if const_expr(not self.is_local):
+            return m_block_max
+        n_idx_min = n_block * self.tile_n
+        m_idx = n_idx_min + seqlen_info.seqlen_q - seqlen_info.seqlen_k
+        m_idx_left = m_idx + self.window_size_dist + self.window_size_right + self.window_size_left
+        return cutlass.min(m_block_max, m_idx_left // self.tile_m)
 
     @cute.jit
     def get_n_block_max_for_m_block(
@@ -145,12 +258,10 @@ class BlockInfo:
         m_block: Int32,
     ) -> Int32:
         n_block_max = cute.ceil_div(seqlen_info.seqlen_k, self.tile_n)
-        if const_expr(self.is_causal or self.window_size_right is not None):
+        if const_expr(self.is_causal or self.is_local):
             m_idx_max = (m_block + 1) * self.tile_m
             if const_expr(self.qhead_per_kvhead_packgqa > 1):
                 m_idx_max = cute.ceil_div(m_idx_max, self.qhead_per_kvhead_packgqa)
             n_idx_right = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q
-            if const_expr(self.window_size_right is not None):
-                n_idx_right += self.window_size_right
-            n_block_max = min(n_block_max, cute.ceil_div(n_idx_right, self.tile_n))
+            n_block_max = cutlass.min(n_block_max, cute.ceil_div(n_idx_right, self.tile_n))
         return n_block_max

--- a/flash_sparse_attn/ops/cute/flash_bwd.py
+++ b/flash_sparse_attn/ops/cute/flash_bwd.py
@@ -6,7 +6,6 @@
 # A reimplementation of https://github.com/Dao-AILab/flash-attention/blob/main/hopper/mainloop_bwd_sm80.hpp
 # from Cutlass C++ to Cute-DSL.
 import math
-from types import SimpleNamespace
 from typing import Type, Callable, Optional
 from functools import partial
 
@@ -34,6 +33,11 @@ from flash_sparse_attn.ops.cute.tile_scheduler import (
 )
 from flash_sparse_attn.ops.cute.block_sparsity import BlockSparseTensors
 from flash_sparse_attn.ops.cute.utils import AuxData
+from flash_sparse_attn.ops.cute.namespace import (
+    FlashBwdGmemCopyParamsSm80,
+    FlashBwdMmaParamsSm80,
+    FlashBwdSmemCopyParamsSm80,
+)
 
 
 class FlashAttentionBackwardSm80:
@@ -633,7 +637,7 @@ class FlashAttentionBackwardSm80:
                 window_size_left,
                 window_size_right,
             )
-            m_block_min, m_block_max = block_info.get_m_block_min_max(seqlen, n_block)
+            (m_block_min, m_block_max, _, _, _, _) = block_info.get_m_block_min_max(seqlen, n_block)
             # TODO: return early if m_block_max == 0
 
             # ///////////////////////////////////////////////////////////////////////////////
@@ -845,7 +849,7 @@ class FlashAttentionBackwardSm80:
             tdOpdO = tQpQ
 
             # group parameters for compute_one_m_block
-            mma_params = SimpleNamespace(
+            mma_params = FlashBwdMmaParamsSm80(
                 thr_mma_sdp=thr_mma_sdp,
                 thr_mma_dkv=thr_mma_dkv,
                 thr_mma_dq=thr_mma_dq,
@@ -862,7 +866,7 @@ class FlashAttentionBackwardSm80:
                 acc_dK=acc_dK,
                 acc_dV=acc_dV,
             )
-            smem_copy_params = SimpleNamespace(
+            smem_copy_params = FlashBwdSmemCopyParamsSm80(
                 smem_thr_copy_QdO=smem_thr_copy_QdO,
                 smem_thr_copy_KV=smem_thr_copy_KV,
                 smem_thr_copy_PdSt=smem_thr_copy_PdSt,
@@ -885,7 +889,7 @@ class FlashAttentionBackwardSm80:
                 tdQsdS=tdQsdS,
                 tdQsKt=tdQsKt,
             )
-            gmem_copy_params = SimpleNamespace(
+            gmem_copy_params = FlashBwdGmemCopyParamsSm80(
                 gmem_thr_copy_dQaccum=gmem_thr_copy_dQaccum, tdQgdQaccum=tdQgdQaccum
             )
             load_Q_LSE = partial(
@@ -1041,9 +1045,9 @@ class FlashAttentionBackwardSm80:
         smem_pipe_read_do: cutlass.Int32,
         smem_pipe_write_q: cutlass.Int32,
         smem_pipe_write_do: cutlass.Int32,
-        mma_params: SimpleNamespace,
-        smem_copy_params: SimpleNamespace,
-        gmem_copy_params: SimpleNamespace,
+        mma_params: FlashBwdMmaParamsSm80,
+        smem_copy_params: FlashBwdSmemCopyParamsSm80,
+        gmem_copy_params: FlashBwdGmemCopyParamsSm80,
         load_Q_LSE: Callable,
         load_dO_dPsum: Callable,
         m_block_max: cutlass.Int32,
@@ -2028,13 +2032,12 @@ class FlashSparseAttentionBackwardSm80:
         mdK: cute.Tensor,
         mdV: cute.Tensor,
         softmax_scale: cutlass.Float32,
+        mWindowSizes: Optional[cute.Tensor],
         softmax_threshold: cutlass.Float32,
         mCuSeqlensQ: Optional[cute.Tensor] = None,
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
-        window_size_left: Int32 | int | None = None,
-        window_size_right: Int32 | int | None = None,
         mdQ_semaphore: Optional[cute.Tensor] = None,
         mdK_semaphore: Optional[cute.Tensor] = None,
         mdV_semaphore: Optional[cute.Tensor] = None,
@@ -2046,6 +2049,11 @@ class FlashSparseAttentionBackwardSm80:
         assert mdQ_semaphore is None and mdK_semaphore is None and mdV_semaphore is None, (
             "determinism not supported yet for Sm80"
         )
+        assert not self.is_local or mWindowSizes is not None, (
+            "mWindowSizes must be provided for local attention"
+        )
+        if cutlass.const_expr(mWindowSizes is not None):
+            assert mWindowSizes.element_type == Int32, "mWindowSizes must have dtype Int32"
         # Get the data type and check if it is fp16 or bf16
         self._check_type(
             *(
@@ -2122,8 +2130,7 @@ class FlashSparseAttentionBackwardSm80:
             softmax_scale,
             softmax_scale_log2,
             softmax_threshold,
-            window_size_left,
-            window_size_right,
+            mWindowSizes,
             self.sQ_layout,
             self.sK_layout,
             self.sV_layout,
@@ -2171,8 +2178,7 @@ class FlashSparseAttentionBackwardSm80:
         softmax_scale: cutlass.Float32,
         softmax_scale_log2: cutlass.Float32,
         softmax_threshold: cutlass.Float32,
-        window_size_left: Optional[Int32],
-        window_size_right: Optional[Int32],
+        mWindowSizes: Optional[cute.Tensor],
         sQ_layout: cute.ComposedLayout,
         sK_layout: cute.ComposedLayout,
         sV_layout: cute.ComposedLayout,
@@ -2216,16 +2222,77 @@ class FlashSparseAttentionBackwardSm80:
                 tile_n=self.n_block_size,
             )
 
-            block_info = BlockInfo(
-                self.m_block_size,
-                self.n_block_size,
-                self.is_causal,
-                self.is_local,
-                False,
+            (
+                window_size_sink,
                 window_size_left,
                 window_size_right,
+                window_size_dist,
+            ) = work_tile.load_window_sizes(
+                mWindowSizes,
+                self.is_local,
+                self.qhead_per_kvhead,
+                self.pack_gqa,
             )
-            m_block_min, m_block_max = block_info.get_m_block_min_max(seqlen, n_block)
+            block_info = BlockInfo(
+                tile_m=self.m_block_size,
+                tile_n=self.n_block_size,
+                is_causal=self.is_causal,
+                is_local=self.is_local,
+                is_split_kv=False,
+                window_size_sink=window_size_sink,
+                window_size_left=window_size_left,
+                window_size_right=window_size_right,
+                window_size_dist=window_size_dist,
+            )
+            (
+                m_block_min,
+                m_block_max,
+                m_block_window_min,
+                m_block_window_max,
+                m_block_sink_min,
+                m_block_sink_max,
+            ) = block_info.get_m_block_min_max(seqlen, n_block)
+            m_block_min_no_mask = block_info.get_m_block_min_causal_local_mask(
+                seqlen,
+                n_block,
+                m_block_min,
+            )
+            if cutlass.const_expr(self.is_local):
+                m_block_min_no_mask = m_block_max
+                m_block_window_min = cutlass.max(m_block_window_min, m_block_min_no_mask)
+                m_block_window_min_no_mask = block_info.get_m_block_min_causal_local_mask(
+                    seqlen,
+                    n_block,
+                    m_block_window_min,
+                )
+                m_block_window_min_no_mask = cutlass.max(
+                    m_block_window_min_no_mask,
+                    m_block_window_min,
+                )
+                m_block_window_max_no_mask = block_info.get_m_block_max_before_local_mask(
+                    seqlen,
+                    n_block,
+                    m_block_window_max,
+                )
+                m_block_window_max_no_mask = cutlass.max(
+                    m_block_window_max_no_mask,
+                    m_block_window_min_no_mask,
+                )
+                m_block_window_min_no_mask = cutlass.max(
+                    cutlass.min(m_block_window_min_no_mask, m_block_window_max),
+                    m_block_window_min,
+                )
+                m_block_window_max_no_mask = cutlass.max(
+                    cutlass.min(m_block_window_max_no_mask, m_block_window_max),
+                    m_block_window_min_no_mask,
+                )
+            else:
+                m_block_window_min = Int32(0)
+                m_block_window_max = Int32(0)
+                m_block_window_min_no_mask = Int32(0)
+                m_block_window_max_no_mask = Int32(0)
+                m_block_sink_min = Int32(0)
+                m_block_sink_max = Int32(0)
             # TODO: return early if m_block_max == 0
 
             # ///////////////////////////////////////////////////////////////////////////////
@@ -2440,7 +2507,7 @@ class FlashSparseAttentionBackwardSm80:
             tdOpdO = tQpQ
 
             # group parameters for compute_one_m_block
-            mma_params = SimpleNamespace(
+            mma_params = FlashBwdMmaParamsSm80(
                 thr_mma_sdp=thr_mma_sdp,
                 thr_mma_dkv=thr_mma_dkv,
                 thr_mma_dq=thr_mma_dq,
@@ -2457,7 +2524,7 @@ class FlashSparseAttentionBackwardSm80:
                 acc_dK=acc_dK,
                 acc_dV=acc_dV,
             )
-            smem_copy_params = SimpleNamespace(
+            smem_copy_params = FlashBwdSmemCopyParamsSm80(
                 smem_thr_copy_QdO=smem_thr_copy_QdO,
                 smem_thr_copy_KV=smem_thr_copy_KV,
                 smem_thr_copy_PdSt=smem_thr_copy_PdSt,
@@ -2480,7 +2547,7 @@ class FlashSparseAttentionBackwardSm80:
                 tdQsdS=tdQsdS,
                 tdQsKt=tdQsKt,
             )
-            gmem_copy_params = SimpleNamespace(
+            gmem_copy_params = FlashBwdGmemCopyParamsSm80(
                 gmem_thr_copy_dQaccum=gmem_thr_copy_dQaccum, tdQgdQaccum=tdQgdQaccum
             )
             load_Q_LSE = partial(
@@ -2533,69 +2600,245 @@ class FlashSparseAttentionBackwardSm80:
                 skip_fn=skip_fn,
             )
 
-            if m_block_min < m_block_max:
-                # ///////////////////////////////////////////////////////////////////////////////
-                # Prologue
-                # ///////////////////////////////////////////////////////////////////////////////
-                # Start async loads of the last mn-tile, where we take care of the mn residue
-                self.load_V(
-                    gmem_thr_copy_VdO, tVgV, tVsV, n_block, seqlen=seqlen.seqlen_k, headdim=d_head
-                )
-                if cutlass.const_expr(self.V_in_regs):
-                    cute.arch.cp_async_commit_group()
-                self.load_K(
-                    gmem_thr_copy_QK, tKgK, tKsK, n_block, seqlen=seqlen.seqlen_k, headdim=d_head
-                )
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Prologue
+            # ///////////////////////////////////////////////////////////////////////////////
+            self.load_V(
+                gmem_thr_copy_VdO, tVgV, tVsV, n_block, seqlen=seqlen.seqlen_k, headdim=d_head
+            )
+            if cutlass.const_expr(self.V_in_regs):
                 cute.arch.cp_async_commit_group()
+            self.load_K(
+                gmem_thr_copy_QK, tKgK, tKsK, n_block, seqlen=seqlen.seqlen_k, headdim=d_head
+            )
+            cute.arch.cp_async_commit_group()
 
-                if cutlass.const_expr(self.V_in_regs):
-                    cute.arch.cp_async_wait_group(1)
-                    cute.arch.barrier()
-                    tdPrV_copy_view = smem_thr_copy_KV.retile(tdPrV)
-                    cute.copy(smem_thr_copy_KV, tdPsV, tdPrV_copy_view)
-                    # Sync to avoid loading Q to smem_q, which overlaps with smem_v
-                    cute.arch.barrier()
+            if cutlass.const_expr(self.V_in_regs):
+                cute.arch.cp_async_wait_group(1)
+                cute.arch.barrier()
+                tdPrV_copy_view = smem_thr_copy_KV.retile(tdPrV)
+                cute.copy(smem_thr_copy_KV, tdPsV, tdPrV_copy_view)
+                # Sync to avoid loading Q to smem_q, which overlaps with smem_v
+                cute.arch.barrier()
 
-                m_block = m_block_min
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Mainloop
+            # ///////////////////////////////////////////////////////////////////////////////
+            mask = AttentionMask(
+                self.m_block_size,
+                self.n_block_size,
+                seqlen,
+                window_size_sink,
+                window_size_left,
+                window_size_right,
+                window_size_dist,
+            )
+            mask_fn = partial(
+                mask.apply_mask,
+                n_block=n_block,
+                thr_mma=thr_mma_sdp,
+                batch_idx=batch_idx,
+                head_idx=head_idx,
+                use_r2p=False,
+            )
+
+            if m_block_min < m_block_max:
                 for stage in cutlass.range_constexpr(self.num_stages_Q):
                     if cutlass.const_expr(self.num_stages_Q == 1 or stage < self.num_stages_Q - 1):
-                        if stage == 0 or m_block + stage < m_block_max:
-                            load_Q_LSE(m_block + stage, smem_pipe_write_q=stage)
+                        if stage == 0 or m_block_min + stage < m_block_max:
+                            load_Q_LSE(m_block_min + stage, smem_pipe_write_q=stage)
                         cute.arch.cp_async_commit_group()
+                smem_pipe_read_q = Int32(0)
+                smem_pipe_write_q = Int32(self.num_stages_Q - 1)
 
-                # ///////////////////////////////////////////////////////////////////////////////
-                # Mainloop
-                # ///////////////////////////////////////////////////////////////////////////////
-                # Start processing of the first n-block.
-                mask = AttentionMask(
-                    self.m_block_size,
-                    self.n_block_size,
-                    seqlen,
-                    window_size_left,
-                    window_size_right,
-                )
-                mask_fn = partial(
-                    mask.apply_mask,
-                    n_block=n_block,
-                    thr_mma=thr_mma_sdp,
-                    batch_idx=batch_idx,
-                    head_idx=head_idx,
-                    mask_seqlen=True,
-                    mask_causal=self.is_causal,
-                    mask_local=self.is_local,
-                    use_r2p=False,
-                )
-                smem_pipe_read_q = cutlass.Int32(0)
-                smem_pipe_write_q = cutlass.Int32(self.num_stages_Q - 1)
-                for m_tile in cutlass.range(m_block_min, m_block_max, unroll=1):
-                    compute_one_m_block(
-                        m_tile,
-                        smem_pipe_read_q,
-                        smem_pipe_write_q,
-                        mask_fn=mask_fn,
-                    )
-                    smem_pipe_read_q = self.advance_pipeline(smem_pipe_read_q, self.num_stages_Q)
-                    smem_pipe_write_q = self.advance_pipeline(smem_pipe_write_q, self.num_stages_Q)
+                # Process m_blocks with causal or local masking
+                if cutlass.const_expr(self.is_causal or self.is_local):
+                    for m_block in cutlass.range(
+                        m_block_min,
+                        m_block_min_no_mask,
+                        unroll=1,
+                    ):
+                        compute_one_m_block(
+                            m_block,
+                            smem_pipe_read_q,
+                            smem_pipe_write_q,
+                            mask_fn=partial(
+                                mask_fn,
+                                mask_seqlen=True,
+                                mask_causal=self.is_causal and not self.is_local,
+                                mask_local=self.is_local,
+                                mask_sink=False,
+                            ),
+                        )
+                        smem_pipe_read_q = self.advance_pipeline(
+                            smem_pipe_read_q, self.num_stages_Q
+                        )
+                        smem_pipe_write_q = self.advance_pipeline(
+                            smem_pipe_write_q, self.num_stages_Q
+                        )
+
+                # Process m_blocks without masking
+                if cutlass.const_expr(not self.is_local):
+                    for m_block in cutlass.range(
+                        m_block_min_no_mask,
+                        m_block_max,
+                        unroll=1,
+                    ):
+                        compute_one_m_block(
+                            m_block,
+                            smem_pipe_read_q,
+                            smem_pipe_write_q,
+                            mask_fn=partial(
+                                mask_fn,
+                                mask_seqlen=False,
+                                mask_causal=False,
+                                mask_local=False,
+                                mask_sink=False,
+                            ),
+                        )
+                        smem_pipe_read_q = self.advance_pipeline(
+                            smem_pipe_read_q, self.num_stages_Q
+                        )
+                        smem_pipe_write_q = self.advance_pipeline(
+                            smem_pipe_write_q, self.num_stages_Q
+                        )
+
+            if cutlass.const_expr(self.is_local):
+                if m_block_window_min < m_block_window_max:
+                    cute.arch.cp_async_wait_group(0)
+                    cute.arch.barrier()
+                    for stage in cutlass.range_constexpr(self.num_stages_Q):
+                        if cutlass.const_expr(
+                            self.num_stages_Q == 1 or stage < self.num_stages_Q - 1
+                        ):
+                            if stage == 0 or m_block_window_min + stage < m_block_window_max:
+                                load_Q_LSE(
+                                    m_block_window_min + stage,
+                                    smem_pipe_write_q=stage,
+                                )
+                            cute.arch.cp_async_commit_group()
+                    smem_pipe_read_q = Int32(0)
+                    smem_pipe_write_q = Int32(self.num_stages_Q - 1)
+
+                    # Process m_blocks with local right masking
+                    for m_block in cutlass.range(
+                        m_block_window_min,
+                        m_block_window_min_no_mask,
+                        unroll=1,
+                    ):
+                        compute_one_m_block(
+                            m_block,
+                            smem_pipe_read_q,
+                            smem_pipe_write_q,
+                            m_block_max=m_block_window_max,
+                            mask_fn=partial(
+                                mask_fn,
+                                mask_seqlen=True,
+                                mask_causal=False,
+                                mask_local=True,
+                                mask_sink=False,
+                            ),
+                        )
+                        smem_pipe_read_q = self.advance_pipeline(
+                            smem_pipe_read_q, self.num_stages_Q
+                        )
+                        smem_pipe_write_q = self.advance_pipeline(
+                            smem_pipe_write_q, self.num_stages_Q
+                        )
+
+                    # Process m_blocks without masking
+                    for m_block in cutlass.range(
+                        m_block_window_min_no_mask,
+                        m_block_window_max_no_mask,
+                        unroll=1,
+                    ):
+                        compute_one_m_block(
+                            m_block,
+                            smem_pipe_read_q,
+                            smem_pipe_write_q,
+                            m_block_max=m_block_window_max,
+                            mask_fn=partial(
+                                mask_fn,
+                                mask_seqlen=False,
+                                mask_causal=False,
+                                mask_local=False,
+                                mask_sink=False,
+                            ),
+                        )
+                        smem_pipe_read_q = self.advance_pipeline(
+                            smem_pipe_read_q, self.num_stages_Q
+                        )
+                        smem_pipe_write_q = self.advance_pipeline(
+                            smem_pipe_write_q, self.num_stages_Q
+                        )
+
+                    # Process m_blocks with local left masking
+                    for m_block in cutlass.range(
+                        m_block_window_max_no_mask,
+                        m_block_window_max,
+                        unroll=1,
+                    ):
+                        compute_one_m_block(
+                            m_block,
+                            smem_pipe_read_q,
+                            smem_pipe_write_q,
+                            m_block_max=m_block_window_max,
+                            mask_fn=partial(
+                                mask_fn,
+                                mask_seqlen=True,
+                                mask_causal=False,
+                                mask_local=True,
+                                mask_sink=False,
+                            ),
+                        )
+                        smem_pipe_read_q = self.advance_pipeline(
+                            smem_pipe_read_q, self.num_stages_Q
+                        )
+                        smem_pipe_write_q = self.advance_pipeline(
+                            smem_pipe_write_q, self.num_stages_Q
+                        )
+
+                if m_block_sink_min < m_block_sink_max:
+                    cute.arch.cp_async_wait_group(0)
+                    cute.arch.barrier()
+                    for stage in cutlass.range_constexpr(self.num_stages_Q):
+                        if cutlass.const_expr(
+                            self.num_stages_Q == 1 or stage < self.num_stages_Q - 1
+                        ):
+                            if stage == 0 or m_block_sink_min + stage < m_block_sink_max:
+                                load_Q_LSE(
+                                    m_block_sink_min + stage,
+                                    smem_pipe_write_q=stage,
+                                )
+                            cute.arch.cp_async_commit_group()
+                    smem_pipe_read_q = Int32(0)
+                    smem_pipe_write_q = Int32(self.num_stages_Q - 1)
+
+                    # Process m_blocks with local sink masking
+                    for m_block in cutlass.range(
+                        m_block_sink_min,
+                        m_block_sink_max,
+                        unroll=1,
+                    ):
+                        compute_one_m_block(
+                            m_block,
+                            smem_pipe_read_q,
+                            smem_pipe_write_q,
+                            m_block_max=m_block_sink_max,
+                            mask_fn=partial(
+                                mask_fn,
+                                mask_seqlen=True,
+                                mask_causal=False,
+                                mask_local=True,
+                                mask_sink=True,
+                            ),
+                        )
+                        smem_pipe_read_q = self.advance_pipeline(
+                            smem_pipe_read_q, self.num_stages_Q
+                        )
+                        smem_pipe_write_q = self.advance_pipeline(
+                            smem_pipe_write_q, self.num_stages_Q
+                        )
 
             # ///////////////////////////////////////////////////////////////////////////////
             # Epilogue
@@ -2630,9 +2873,9 @@ class FlashSparseAttentionBackwardSm80:
         m_block: cutlass.Int32,
         smem_pipe_read_q: cutlass.Int32,
         smem_pipe_write_q: cutlass.Int32,
-        mma_params: SimpleNamespace,
-        smem_copy_params: SimpleNamespace,
-        gmem_copy_params: SimpleNamespace,
+        mma_params: FlashBwdMmaParamsSm80,
+        smem_copy_params: FlashBwdSmemCopyParamsSm80,
+        gmem_copy_params: FlashBwdGmemCopyParamsSm80,
         load_Q_LSE: Callable,
         load_dO_dPsum: Callable,
         m_block_max: cutlass.Int32,

--- a/flash_sparse_attn/ops/cute/flash_fwd.py
+++ b/flash_sparse_attn/ops/cute/flash_fwd.py
@@ -10,7 +10,6 @@
 # Built on Cute-DSL example: https://github.com/NVIDIA/cutlass/blob/main/examples/python/CuTeDSL/ampere/flash_attention_v2.py
 
 import math
-from types import SimpleNamespace
 from typing import Type, Callable, Optional
 from functools import partial
 
@@ -43,6 +42,10 @@ from flash_sparse_attn.ops.cute.tile_scheduler import (
     TileSchedulerArguments,
 )
 from flash_sparse_attn.ops.cute.utils import AuxData
+from flash_sparse_attn.ops.cute.namespace import (
+    FlashFwdMmaParamsSm80,
+    FlashFwdSmemCopyParamsSm80,
+)
 
 
 class FlashAttentionForwardBase:
@@ -1343,7 +1346,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             mSeqUsedQ=mSeqUsedQ,
             mSeqUsedK=mSeqUsedK,
         )
-        n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
+        (n_block_min, n_block_max, _, _, _, _) = block_info.get_n_block_min_max(seqlen, m_block)
         # For varlen, wasted grid tiles (where batch_idx >= num_batch) will have
         # seqlen_q=seqlen_k=0 and n_block_max=0.  Clamp to 0 so we don't use a
         # negative block index for K/V loads; the load/store predicates already
@@ -1446,7 +1449,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         softmax.reset()
 
         # group parameters for compute_one_n_block
-        mma_params = SimpleNamespace(
+        mma_params = FlashFwdMmaParamsSm80(
             thr_mma_qk=thr_mma_qk,
             thr_mma_pv=thr_mma_pv,
             tSrQ=tSrQ,
@@ -1454,7 +1457,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             tOrVt=tOrVt,
             acc_O=acc_O,
         )
-        smem_copy_params = SimpleNamespace(
+        smem_copy_params = FlashFwdSmemCopyParamsSm80(
             smem_thr_copy_Q=smem_thr_copy_Q,
             smem_thr_copy_K=smem_thr_copy_K,
             smem_thr_copy_V=smem_thr_copy_V,
@@ -1630,8 +1633,8 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         n_block: Int32,
         smem_pipe_read: Int32,
         smem_pipe_write: Int32,
-        mma_params: SimpleNamespace,
-        smem_copy_params: SimpleNamespace,
+        mma_params: FlashFwdMmaParamsSm80,
+        smem_copy_params: FlashFwdSmemCopyParamsSm80,
         softmax: Softmax,
         load_K: Callable,
         load_V: Callable,
@@ -1832,14 +1835,13 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
         mO: cute.Tensor,
         mLSE: Optional[cute.Tensor],
         softmax_scale: Float32,
+        mWindowSizes: Optional[cute.Tensor],
         softmax_threshold: Float32,
         mCuSeqlensQ: Optional[cute.Tensor] = None,
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
         mPageTable: Optional[cute.Tensor] = None,
-        window_size_left: Int32 | int | None = None,
-        window_size_right: Int32 | int | None = None,
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_data: AuxData = AuxData(),
@@ -1852,6 +1854,11 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
         (batch_size, seqlen_q, num_head, head_dim):(_, _, _, 1)
         """
         assert learnable_sink is None, "Learnable sink is not supported in this kernel"
+        assert not self.is_local or mWindowSizes is not None, (
+            "mWindowSizes must be provided for local attention"
+        )
+        if const_expr(mWindowSizes is not None):
+            assert mWindowSizes.element_type == Int32, "mWindowSizes must have dtype Int32"
         self._check_type(
             *(
                 t.element_type if t is not None else None
@@ -1936,8 +1943,7 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
             softmax_scale_log2,
             softmax_scale,
             softmax_threshold,
-            window_size_left,
-            window_size_right,
+            mWindowSizes,
             self.sQ_layout,
             self.sK_layout,
             self.sV_layout,
@@ -1977,8 +1983,7 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
         softmax_scale_log2: Float32,
         softmax_scale: Optional[Float32],
         softmax_threshold: Float32,
-        window_size_left: Optional[Int32],
-        window_size_right: Optional[Int32],
+        mWindowSizes: Optional[cute.Tensor],
         sQ_layout: cute.ComposedLayout,
         sK_layout: cute.ComposedLayout,
         sV_layout: cute.ComposedLayout,
@@ -2004,16 +2009,6 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
         work_tile = tile_scheduler.initial_work_tile_info()
         m_block, num_head, batch_size, _ = work_tile.tile_idx
 
-        block_info = BlockInfo(
-            self.tile_m,
-            self.tile_n,
-            self.is_causal,
-            self.is_local,
-            False,  # is_split_kv
-            window_size_left,
-            window_size_right,
-            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
-        )
         seqlen = SeqlenInfoQK.create(
             batch_idx=batch_size,
             seqlen_q_static=mQ.shape[0] if const_expr(not self.pack_gqa) else mQ.shape[0][1],
@@ -2023,7 +2018,70 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
             mSeqUsedQ=mSeqUsedQ,
             mSeqUsedK=mSeqUsedK,
         )
-        n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
+        num_head_kv = num_head if const_expr(self.pack_gqa) else num_head // self.qhead_per_kvhead
+        (
+            window_size_sink,
+            window_size_left,
+            window_size_right,
+            window_size_dist,
+        ) = work_tile.load_window_sizes(
+            mWindowSizes,
+            self.is_local,
+            self.qhead_per_kvhead,
+            self.pack_gqa,
+        )
+        block_info = BlockInfo(
+            self.tile_m,
+            self.tile_n,
+            self.is_causal,
+            self.is_local,
+            False,  # is_split_kv
+            window_size_sink,
+            window_size_left,
+            window_size_right,
+            window_size_dist,
+            self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+        (
+            n_block_min,
+            n_block_max,
+            n_block_window_min,
+            n_block_window_max,
+            n_block_sink_min,
+            n_block_sink_max,
+        ) = block_info.get_n_block_min_max(seqlen, m_block)
+        n_block_max_no_mask = block_info.get_n_block_min_causal_local_mask(
+            seqlen,
+            m_block,
+            n_block_min,
+            is_local=False,
+        )
+        if const_expr(self.is_local):
+            n_block_max_no_mask = n_block_min
+            n_block_window_max = cutlass.min(n_block_window_max, n_block_max_no_mask)
+            n_block_window_max_no_mask = block_info.get_n_block_min_causal_local_mask(
+                seqlen,
+                m_block,
+                n_block_window_min,
+            )
+            n_block_window_min_no_mask = block_info.get_n_block_min_before_local_mask(
+                seqlen,
+                m_block,
+                n_block_window_min,
+            )
+            n_block_window_max_no_mask = cutlass.max(
+                cutlass.min(n_block_window_max_no_mask, n_block_window_max),
+                n_block_window_min,
+            )
+            n_block_window_min_no_mask = cutlass.max(
+                cutlass.min(n_block_window_min_no_mask, n_block_window_max_no_mask),
+                n_block_window_min,
+            )
+        else:
+            n_block_window_min = Int32(0)
+            n_block_window_max = Int32(0)
+            n_block_window_min_no_mask = Int32(0)
+            n_block_window_max_no_mask = Int32(0)
         # For varlen, wasted grid tiles (where batch_idx >= num_batch) will have
         # seqlen_q=seqlen_k=0 and n_block_max=0.  Clamp to 0 so we don't use a
         # negative block index for K/V loads; the load/store predicates already
@@ -2036,7 +2094,6 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
         blkQ_shape = (self.tile_m, self.tile_hdim)
         blkK_shape = (self.tile_n, self.tile_hdim)
         blkV_shape = (self.tile_n, self.tile_hdim)
-        num_head_kv = num_head if const_expr(self.pack_gqa) else num_head // self.qhead_per_kvhead
         mQ_cur = seqlen.offset_batch_Q(mQ, batch_size, dim=3)[None, None, num_head]
         if const_expr(not seqlen.has_cu_seqlens_k):
             mK_cur = mK[None, None, num_head_kv, batch_size]
@@ -2127,7 +2184,7 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
         softmax.reset()
 
         # group parameters for compute_one_n_block
-        mma_params = SimpleNamespace(
+        mma_params = FlashFwdMmaParamsSm80(
             thr_mma_qk=thr_mma_qk,
             thr_mma_pv=thr_mma_pv,
             tSrQ=tSrQ,
@@ -2135,7 +2192,7 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
             tOrVt=tOrVt,
             acc_O=acc_O,
         )
-        smem_copy_params = SimpleNamespace(
+        smem_copy_params = FlashFwdSmemCopyParamsSm80(
             smem_thr_copy_Q=smem_thr_copy_Q,
             smem_thr_copy_K=smem_thr_copy_K,
             smem_thr_copy_V=smem_thr_copy_V,
@@ -2165,7 +2222,6 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
             sSkip=sSkip,
             num_warps=self.num_warps,
         )
-
         compute_one_n_block = partial(
             self.compute_one_n_block,
             mma_params=mma_params,
@@ -2222,6 +2278,8 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
                 if stage == 0 or n_block - stage >= 0:
                     load_K(n_block - stage, smem_pipe_write=stage, need_predicates=stage == 0)
                 cute.arch.cp_async_commit_group()
+        smem_pipe_read = Int32(0)
+        smem_pipe_write = Int32(self.num_stages - 1)
         if const_expr(not self.Q_in_regs):
             preprocess_Q()
 
@@ -2237,8 +2295,10 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
             self.tile_m,
             self.tile_n,
             seqlen,
+            window_size_sink,
             window_size_left,
             window_size_right,
+            window_size_dist,
             self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
         )
         mask_fn = partial(
@@ -2247,54 +2307,182 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
             head_idx=num_head,
             m_block=m_block,
             thr_mma=thr_mma_qk,
-            mask_causal=self.is_causal,
-            mask_local=self.is_local,
             aux_data=aux_data,
             fastdiv_mods=fastdiv_mods if const_expr(self.mask_mod is not None) else None,
         )
 
         # First iteration with seqlen masking
-        smem_pipe_read = Int32(0)
-        smem_pipe_write = Int32(self.num_stages - 1)
         compute_one_n_block(
             n_block,
+            n_block_min,
             smem_pipe_read,
             smem_pipe_write,
             is_first_n_block=True,
             seqlen=seqlen,
-            mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=True),
+            mask_fn=partial(
+                mask_fn,
+                mask_mod=self.mask_mod,
+                mask_seqlen=True,
+                mask_causal=self.is_causal and not self.is_local,
+                mask_local=self.is_local,
+            ),
         )
         smem_pipe_read = self.advance_pipeline(smem_pipe_read)
         smem_pipe_write = self.advance_pipeline(smem_pipe_write)
-        # Next couple of iterations with causal masking
+
+        # Process n_blocks with causal or local masking
         if const_expr(self.is_causal or self.is_local):
-            n_block_min_causal_local_mask = block_info.get_n_block_min_causal_local_mask(
-                seqlen, m_block, n_block_min
-            )
-            for n_tile in cutlass.range(n_block_max - 1 - n_block_min_causal_local_mask, unroll=1):
-                n_block = n_block_max - 2 - n_tile
+            for n_block in cutlass.range(n_block_max - 1 - n_block_max_no_mask, unroll=1):
                 compute_one_n_block(
-                    n_block,
+                    n_block_max - 2 - n_block,
+                    n_block_min,
                     smem_pipe_read,
                     smem_pipe_write,
                     seqlen=seqlen,
-                    mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=True),
+                    is_first_n_block=False,
+                    mask_fn=partial(
+                        mask_fn,
+                        mask_mod=self.mask_mod,
+                        mask_seqlen=True,
+                        mask_causal=self.is_causal and not self.is_local,
+                        mask_local=self.is_local,
+                    ),
                 )
                 smem_pipe_read = self.advance_pipeline(smem_pipe_read)
                 smem_pipe_write = self.advance_pipeline(smem_pipe_write)
-        # The remaining iterations have no masking
-        for n_tile in cutlass.range(n_block, unroll=1):
+
+        # Process n_blocks without masking
+        for n_block in cutlass.range(n_block_max_no_mask - n_block_min, unroll=1):
             compute_one_n_block(
-                n_block - n_tile - 1,
+                n_block_max_no_mask - 1 - n_block,
+                n_block_min,
                 smem_pipe_read,
                 smem_pipe_write,
                 seqlen=seqlen,
                 is_first_n_block=False,
-                mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False),
+                mask_fn=partial(
+                    mask_fn,
+                    mask_mod=self.mask_mod,
+                    mask_seqlen=False,
+                    mask_causal=False,
+                    mask_local=False,
+                ),
             )
             smem_pipe_read = self.advance_pipeline(smem_pipe_read)
             smem_pipe_write = self.advance_pipeline(smem_pipe_write)
-        # TODO: local
+
+        if const_expr(self.is_local):
+            if n_block_window_max > n_block_window_min:
+                cute.arch.cp_async_wait_group(0)
+                cute.arch.barrier()
+                for stage in cutlass.range_constexpr(self.num_stages):
+                    n_block = n_block_window_max - 1 - stage
+                    if stage == 0 or n_block >= n_block_window_min:
+                        load_K(n_block, smem_pipe_write=stage, need_predicates=False)
+                    cute.arch.cp_async_commit_group()
+                smem_pipe_read = Int32(0)
+                smem_pipe_write = Int32(self.num_stages - 1)
+
+                # Process n_blocks with local right masking
+                for n_block in cutlass.range(
+                    n_block_window_max - n_block_window_max_no_mask,
+                    unroll=1,
+                ):
+                    compute_one_n_block(
+                        n_block_window_max - 1 - n_block,
+                        n_block_window_min,
+                        smem_pipe_read,
+                        smem_pipe_write,
+                        seqlen=seqlen,
+                        is_first_n_block=False,
+                        mask_fn=partial(
+                            mask_fn,
+                            mask_mod=self.mask_mod,
+                            mask_seqlen=False,
+                            mask_causal=False,
+                            mask_local=True,
+                        ),
+                    )
+                    smem_pipe_read = self.advance_pipeline(smem_pipe_read)
+                    smem_pipe_write = self.advance_pipeline(smem_pipe_write)
+
+                # Process n_blocks without masking
+                for n_block in cutlass.range(
+                    n_block_window_max_no_mask - n_block_window_min_no_mask,
+                    unroll=1,
+                ):
+                    compute_one_n_block(
+                        n_block_window_max_no_mask - 1 - n_block,
+                        n_block_window_min,
+                        smem_pipe_read,
+                        smem_pipe_write,
+                        seqlen=seqlen,
+                        is_first_n_block=False,
+                        mask_fn=partial(
+                            mask_fn,
+                            mask_mod=self.mask_mod,
+                            mask_seqlen=False,
+                            mask_causal=False,
+                            mask_local=False,
+                        ),
+                    )
+                    smem_pipe_read = self.advance_pipeline(smem_pipe_read)
+                    smem_pipe_write = self.advance_pipeline(smem_pipe_write)
+
+                # Process n_blocks with local left masking
+                for n_block in cutlass.range(
+                    n_block_window_min_no_mask - n_block_window_min,
+                    unroll=1,
+                ):
+                    compute_one_n_block(
+                        n_block_window_min_no_mask - 1 - n_block,
+                        n_block_window_min,
+                        smem_pipe_read,
+                        smem_pipe_write,
+                        seqlen=seqlen,
+                        is_first_n_block=False,
+                        mask_fn=partial(
+                            mask_fn,
+                            mask_mod=self.mask_mod,
+                            mask_seqlen=False,
+                            mask_causal=False,
+                            mask_local=True,
+                        ),
+                    )
+                    smem_pipe_read = self.advance_pipeline(smem_pipe_read)
+                    smem_pipe_write = self.advance_pipeline(smem_pipe_write)
+
+            if n_block_sink_max > n_block_sink_min:
+                cute.arch.cp_async_wait_group(0)
+                cute.arch.barrier()
+                for stage in cutlass.range_constexpr(self.num_stages):
+                    n_block = n_block_sink_max - 1 - stage
+                    if stage == 0 or n_block >= n_block_sink_min:
+                        load_K(n_block, smem_pipe_write=stage, need_predicates=False)
+                    cute.arch.cp_async_commit_group()
+                smem_pipe_read = Int32(0)
+                smem_pipe_write = Int32(self.num_stages - 1)
+
+                # Process n_blocks with local sink masking
+                for n_block in cutlass.range(n_block_sink_max - n_block_sink_min, unroll=1):
+                    compute_one_n_block(
+                        n_block_sink_max - 1 - n_block,
+                        n_block_sink_min,
+                        smem_pipe_read,
+                        smem_pipe_write,
+                        seqlen=seqlen,
+                        is_first_n_block=False,
+                        mask_fn=partial(
+                            mask_fn,
+                            mask_mod=self.mask_mod,
+                            mask_seqlen=True,
+                            mask_causal=False,
+                            mask_local=True,
+                            mask_sink=True,
+                        ),
+                    )
+                    smem_pipe_read = self.advance_pipeline(smem_pipe_read)
+                    smem_pipe_write = self.advance_pipeline(smem_pipe_write)
 
         # normalize acc_O by row_sum and calculate the lse
         row_scale = softmax.finalize()
@@ -2325,10 +2513,11 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
     def compute_one_n_block(
         self,
         n_block: Int32,
+        n_block_min: Int32,
         smem_pipe_read: Int32,
         smem_pipe_write: Int32,
-        mma_params: SimpleNamespace,
-        smem_copy_params: SimpleNamespace,
+        mma_params: FlashFwdMmaParamsSm80,
+        smem_copy_params: FlashFwdSmemCopyParamsSm80,
         softmax: Softmax,
         load_K: Callable,
         load_V: Callable,
@@ -2348,9 +2537,10 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
             self,
             load_K: Callable,
             n_block: Int32,
+            n_block_min: Int32,
             smem_pipe_write: Int32,
         ):
-            if n_block - self.num_stages >= 0:
+            if n_block - self.num_stages >= n_block_min:
                 load_K(n_block - self.num_stages, smem_pipe_write, need_predicates=False)
                 cute.arch.cp_async_commit_group()
 
@@ -2398,7 +2588,7 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
         smem_pipe_write = self.advance_pipeline(smem_pipe_write)
 
         if is_skip:
-            load_K_next(self, load_K, n_block, smem_pipe_write)
+            load_K_next(self, load_K, n_block, n_block_min, smem_pipe_write)
         else:
             # need predicates for the first tile
             load_V(
@@ -2407,7 +2597,7 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
                 need_predicates=is_first_n_block,
             )
             cute.arch.cp_async_commit_group()
-            load_K_next(self, load_K, n_block, smem_pipe_write)
+            load_K_next(self, load_K, n_block, n_block_min, smem_pipe_write)
             row_scale = softmax.online_softmax(
                 acc_S, is_first=is_first_n_block, check_inf=check_inf
             )
@@ -2415,7 +2605,7 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
             rP = cute.make_fragment_like(acc_S, self.dtype)
             rP.store(acc_S.load().to(self.dtype))
             tOrP = layout_utils.reshape_acc_to_frgA(rP)
-            if n_block - self.num_stages >= 0:
+            if n_block - self.num_stages >= n_block_min:
                 cute.arch.cp_async_wait_group(1)
                 cute.arch.barrier()
             else:

--- a/flash_sparse_attn/ops/cute/interface.py
+++ b/flash_sparse_attn/ops/cute/interface.py
@@ -35,24 +35,20 @@ from flash_sparse_attn.ops.cute.cute_dsl_utils import (
     to_cute_tensor,
 )
 from flash_sparse_attn.ops.cute.flash_fwd import (
-    FlashAttentionForwardSm80,
     FlashSparseAttentionForwardSm80,
 )
 from flash_sparse_attn.ops.cute.flash_fwd_sm90 import FlashAttentionForwardSm90
 from flash_sparse_attn.ops.cute.flash_fwd_sm100 import FlashAttentionForwardSm100, DescaleTensors
 from flash_sparse_attn.ops.cute.flash_fwd_sm120 import (
-    FlashAttentionForwardSm120,
     FlashSparseAttentionForwardSm120,
 )
 from flash_sparse_attn.ops.cute.flash_bwd_preprocess import FlashAttentionBackwardPreprocess
 from flash_sparse_attn.ops.cute.flash_bwd import (
-    FlashAttentionBackwardSm80,
     FlashSparseAttentionBackwardSm80,
 )
 from flash_sparse_attn.ops.cute.flash_bwd_sm90 import FlashAttentionBackwardSm90
 from flash_sparse_attn.ops.cute.flash_bwd_sm100 import FlashAttentionBackwardSm100
 from flash_sparse_attn.ops.cute.flash_bwd_sm120 import (
-    FlashAttentionBackwardSm120,
     FlashSparseAttentionBackwardSm120,
 )
 from flash_sparse_attn.ops.cute.flash_bwd_postprocess import FlashAttentionBackwardPostprocess
@@ -300,31 +296,51 @@ def num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, max_splits):
     return min(num_SMs // total_mblocks, max_splits, num_n_blocks)
 
 
-def _resolve_causal_local_window(causal, window_size_left, window_size_right, mask_mod=None):
-    """Resolve causal/local/window settings into canonical form.
-
-    Returns (causal, local, window_size_left, window_size_right).
+@lru_cache(maxsize=4096)
+def window_sizes_heuristic(
+    seqlen_k: int,
+    num_heads_kv: int,
+    device: torch.device,
+    equal_bandwidth: bool = True,
+    window_dist: int = 1024,
+    window_sink: int = 64,
+    num_heads_kv_global: int = 0,
+    tp_rank: int = 0,
+) -> torch.Tensor:
     """
-    if mask_mod is not None:
-        return False, False, window_size_left, window_size_right
-    if causal:
-        window_size_right = 0
-    if (
-        window_size_left is not None
-        and window_size_right is not None
-        and window_size_left + window_size_right < 0
-    ):
-        window_size_left = None
-        window_size_right = None
-    if window_size_left is not None or window_size_right is not None:
-        if window_size_left is None and window_size_right == 0:
-            causal, local = True, False
-            window_size_right = None
-        else:
-            causal, local = False, True
+    Compute token count window sizes that partition non-diagonal causal distances into bands.
+
+    :param seqlen_k: Sequence length of keys.
+    :param num_heads_kv: Number of local KV heads on this rank.
+    :param device: Target device.
+    :param equal_bandwidth: If True, use equal-bandwidth partitioning for balanced decode load. If False, use equal-area partitioning for balanced forward and backward load.
+    :param window_dist: Near-diagonal token count shared by all KV heads.
+    :param window_sink: Sink token count shared by all KV heads.
+    :param num_heads_kv_global: Total KV heads across all TP ranks.
+    :param tp_rank: Tensor parallel rank of this process.
+
+    :return: int32 tensor with shape [num_heads_kv, 4], columns are [window_sink, window_left, window_right, window_dist]. window_sink is the prefix sink token count, window_left is the distant local band token count, window_right is the token count gap after the near-diagonal window before the distant band, and window_dist is the near-diagonal token count.
+    """
+    if num_heads_kv_global <= 0:
+        num_heads_kv_global = num_heads_kv
+    window_dist = min(max(window_dist, 0), seqlen_k)
+    window_sink = min(max(window_sink, 0), max(seqlen_k - window_dist, 0))
+    head_offset = tp_rank * num_heads_kv
+    head_kv_idx = torch.arange(num_heads_kv + 1, dtype=torch.float32) + head_offset
+    distance_span = max(seqlen_k - window_sink - window_dist, 0)
+    if equal_bandwidth:
+        breakpoints = (distance_span * head_kv_idx / num_heads_kv_global).to(torch.int32)
     else:
-        local = False
-    return causal, local, window_size_left, window_size_right
+        breakpoints = (
+            distance_span * (1.0 - torch.sqrt(1.0 - head_kv_idx / num_heads_kv_global))
+        ).to(torch.int32)
+    window_size_left = breakpoints[1:] - breakpoints[:-1]
+    window_size_right = breakpoints[:-1]
+    window_size_dist = torch.full_like(window_size_left, window_dist)
+    window_size_sink = torch.full_like(window_size_left, window_sink)
+    return torch.stack(
+        [window_size_sink, window_size_left, window_size_right, window_size_dist], dim=1
+    ).to(device)
 
 
 def _flash_attn_fwd(
@@ -343,8 +359,8 @@ def _flash_attn_fwd(
     softmax_threshold: Optional[float] = None,
     causal: bool = False,
     softcap: Optional[float] = None,
-    window_size_left: Optional[int] = None,
-    window_size_right: Optional[int] = None,
+    window_sizes: Optional[torch.Tensor] = None,
+    local: bool = False,
     learnable_sink: Optional[torch.Tensor] = None,
     tile_mn: Optional[Tuple[int, int]] = None,
     mma_pv_is_rs: Optional[bool] = None,
@@ -476,6 +492,10 @@ def _flash_attn_fwd(
             )
         ), "inputs must be on CUDA device"
     arch = _get_device_arch() if _arch is None else _arch
+    # TODO: support 9.x, 10.x, 11.x for FSA
+    assert arch // 10 in [8, 12], (
+        "Unsupported compute capability. Supported: 8.x, 12.x for FlashSparseAttention yet."
+    )
     assert arch // 10 in [8, 9, 10, 11, 12], (
         "Unsupported compute capability. Supported: 8.x, 9.x, 10.x, 11.x, 12.x"
     )
@@ -527,6 +547,16 @@ def _flash_attn_fwd(
             lse.fill_(float("-inf"))
         return out, lse
 
+    if window_sizes is not None:
+        window_sizes = window_sizes.contiguous()
+        _validate_tensor(
+            window_sizes,
+            "window_sizes",
+            (num_head_kv, 4),
+            torch.int32,
+            device,
+        )
+
     if is_fp8:
         for t, name in (
             (q_descale, "q_descale"),
@@ -547,9 +577,9 @@ def _flash_attn_fwd(
         )
     use_block_sparsity = block_sparse_tensors is not None
 
-    causal, local, window_size_left, window_size_right = _resolve_causal_local_window(
-        causal, window_size_left, window_size_right, mask_mod
-    )
+    local = local or window_sizes is not None
+    if mask_mod is not None:
+        causal, local = False, False
 
     requested_use_clc_scheduler = utils._get_use_clc_scheduler_default()
     requested_disable_2cta = utils._get_disable_2cta_default(is_fwd=True)
@@ -589,6 +619,8 @@ def _flash_attn_fwd(
         max_seqlen_k = seqlen_k
     if cu_seqlens_k is None and seqused_k is None:
         min_seqlen_k = seqlen_k
+    if local and window_sizes is None:
+        window_sizes = window_sizes_heuristic(max_seqlen_k, num_head_kv, device)
     seqlen_q_packgqa = max_seqlen_q * qhead_per_kvhead
     if arch // 10 in [10, 11]:
         q_stage = 2 if seqlen_q_packgqa > tile_m else 1
@@ -596,23 +628,9 @@ def _flash_attn_fwd(
         q_stage = 1
 
     m_block_size_effective = q_stage * tile_m
-    seqlen_k_loaded = (
-        max_seqlen_k
-        if not local
-        else max(
-            0,
-            min(
-                max_seqlen_k,
-                (window_size_right or max_seqlen_k)
-                + (window_size_left or max_seqlen_k)
-                + 1
-                + tile_m,
-            ),
-        )
-    )
     num_m_blocks = (seqlen_q_packgqa + m_block_size_effective - 1) // m_block_size_effective
     total_mblocks = batch_size * num_head_kv * num_m_blocks
-    num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
+    num_n_blocks = (max_seqlen_k + tile_n - 1) // tile_n
     num_SMs = (
         132 if is_fake_mode() else torch.cuda.get_device_properties(device).multi_processor_count
     )
@@ -723,6 +741,7 @@ def _flash_attn_fwd(
         head_dim,
         qhead_per_kvhead,
         causal,
+        window_sizes is not None,
         score_mod_hash,
         mask_mod_hash,
         use_block_sparsity,
@@ -735,8 +754,6 @@ def _flash_attn_fwd(
         seqused_q is None,
         seqused_k is None,
         page_table is not None,
-        window_size_left is not None,
-        window_size_right is not None,
         learnable_sink is not None,
         q_descale is not None,
         k_descale is not None,
@@ -779,6 +796,9 @@ def _flash_attn_fwd(
         q_tensor, k_tensor, v_tensor, o_tensor = [
             to_cute_tensor(t) for t in (q, k, v, out if not is_split_kv else out_partial)
         ]
+        window_sizes_tensor = (
+            to_cute_tensor(window_sizes, assumed_align=4) if window_sizes is not None else None
+        )
         if is_split_kv:
             lse_tensor = to_cute_tensor(lse_partial, assumed_align=4)
         else:
@@ -812,12 +832,7 @@ def _flash_attn_fwd(
         if arch // 10 == 8:
             assert page_table is None, "paged KV not supported on SM 8.0"
             assert not is_split_kv, "SplitKV not supported on SM 8.0"
-            flash_fwd_obj_cls = (
-                FlashAttentionForwardSm80
-                if softmax_threshold is None
-                else FlashSparseAttentionForwardSm80
-            )
-            fa_fwd = flash_fwd_obj_cls(
+            fa_fwd = FlashSparseAttentionForwardSm80(
                 dtype,
                 head_dim,
                 qhead_per_kvhead,
@@ -887,12 +902,7 @@ def _flash_attn_fwd(
             assert not use_block_sparsity, "Block sparsity not supported on SM 12.0"
             assert page_table is None, "Paged KV not supported on SM 12.0 in this PR"
             assert not is_split_kv, "SplitKV not supported on SM 12.0 in this PR"
-            flash_fwd_obj_cls = (
-                FlashAttentionForwardSm120
-                if softmax_threshold is None
-                else FlashSparseAttentionForwardSm120
-            )
-            fa_fwd = flash_fwd_obj_cls(
+            fa_fwd = FlashSparseAttentionForwardSm120(
                 dtype,
                 head_dim,
                 qhead_per_kvhead,
@@ -922,8 +932,14 @@ def _flash_attn_fwd(
             lse_tensor,
             softmax_scale,
         ]
+        if window_sizes is not None:
+            compile_args.append(window_sizes_tensor)
+        else:
+            compile_args.append(None)
         if softmax_threshold is not None:
             compile_args.append(softmax_threshold)
+        else:
+            compile_args.append(0.0)
         compile_args.extend(
             [
                 cu_seqlens_q_tensor,
@@ -931,8 +947,6 @@ def _flash_attn_fwd(
                 seqused_q_tensor,
                 seqused_k_tensor,
                 page_table_tensor,
-                window_size_left,
-                window_size_right,
                 learnable_sink_tensor,
             ]
         )
@@ -967,8 +981,14 @@ def _flash_attn_fwd(
             lse_partial if is_split_kv else lse,
             softmax_scale,
         ]
+        if window_sizes is not None:
+            call_args.append(window_sizes)
+        else:
+            call_args.append(None)
         if softmax_threshold is not None:
             call_args.append(softmax_threshold)
+        else:
+            call_args.append(0.0)
         call_args.extend(
             [
                 cu_seqlens_q,
@@ -976,8 +996,6 @@ def _flash_attn_fwd(
                 seqused_q,
                 seqused_k,
                 page_table,
-                window_size_left,
-                window_size_right,
                 learnable_sink,
             ]
         )
@@ -1309,8 +1327,8 @@ def _flash_attn_bwd(
     softmax_threshold: Optional[float] = None,
     causal: bool = False,
     softcap: float = 0.0,
-    window_size_left: Optional[int] = None,
-    window_size_right: Optional[int] = None,
+    window_sizes: Optional[torch.Tensor] = None,
+    local: bool = False,
     m_block_size: int = 64,
     n_block_size: int = 128,
     num_threads: int = 256,
@@ -1344,6 +1362,10 @@ def _flash_attn_bwd(
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     aux_scalars = tuple(aux_scalars) if aux_scalars else None
     arch = _get_device_arch()
+    # TODO: support 9.x, 10.x, 11.x for FSA
+    assert arch // 10 in [8, 12], (
+        "Unsupported compute capability. Supported: 8.x, 12.x for FlashSparseAttention yet."
+    )
     assert arch // 10 in [8, 9, 10, 11, 12], (
         "Unsupported compute capability. Supported: 8.x, 9.x, 10.x, 11.x, 12.x"
     )
@@ -1359,10 +1381,7 @@ def _flash_attn_bwd(
     if arch // 10 in [10, 11] and head_dim == 256:
         raise NotImplementedError("SM100/SM110 backward with head_dim=256 is not supported")
 
-    window_size = [window_size_left, window_size_right]
-    causal, local, window_size_left, window_size_right = _resolve_causal_local_window(
-        causal, window_size_left, window_size_right
-    )
+    local = local or window_sizes is not None
 
     if arch // 10 == 8:
         m_block_size = 64
@@ -1602,6 +1621,19 @@ def _flash_attn_bwd(
     else:
         _validate_tensor(dv, "dv", v.shape, out_torch_dtype, device)
 
+    if window_sizes is not None:
+        window_sizes = window_sizes.contiguous()
+        _validate_tensor(
+            window_sizes,
+            "window_sizes",
+            (num_head_kv, 4),
+            torch.int32,
+            device,
+        )
+
+    if local and window_sizes is None:
+        window_sizes = window_sizes_heuristic(seqlen_k, num_head_kv, device)
+
     head_dim_rounded = (head_dim + 32 - 1) // 32 * 32
 
     if cu_seqlens_q is None:
@@ -1786,10 +1818,9 @@ def _flash_attn_bwd(
             dtype,
             head_dim,
             qhead_per_kvhead,
-            softmax_threshold is not None,
             causal,
-            window_size_left is not None,
-            window_size_right is not None,
+            softmax_threshold is not None,
+            window_sizes is not None,
             m_block_size,
             n_block_size,
             num_threads,
@@ -1833,8 +1864,7 @@ def _flash_attn_bwd(
             head_dim,
             qhead_per_kvhead,
             causal,
-            window_size_left is not None,
-            window_size_right is not None,
+            window_sizes is not None,
             m_block_size,
             n_block_size,
             num_threads,
@@ -1870,6 +1900,9 @@ def _flash_attn_bwd(
         q_tensor, k_tensor, v_tensor, do_tensor, dq_tensor, dk_tensor, dv_tensor = [
             to_cute_tensor(t) for t in (q, k, v, dout, dq, dk, dv)
         ]
+        window_sizes_tensor = (
+            to_cute_tensor(window_sizes, assumed_align=4) if window_sizes is not None else None
+        )
         lse_log2_tensor, dpsum_tensor = [to_cute_tensor(t) for t in (lse_log2, dpsum)]
         dq_accum_tensor = to_cute_tensor(dq_accum) if dq_accum is not None else None
         if dKV_postprocess:
@@ -1887,18 +1920,11 @@ def _flash_attn_bwd(
             for t in (dQ_semaphore, dK_semaphore, dV_semaphore)
         ]
         if arch // 10 in [8, 12]:
-            if arch // 10 == 12:
-                flash_bwd_obj_cls = (
-                    FlashSparseAttentionBackwardSm120
-                    if softmax_threshold is not None
-                    else FlashAttentionBackwardSm120
-                )
-            else:
-                flash_bwd_obj_cls = (
-                    FlashSparseAttentionBackwardSm80
-                    if softmax_threshold is not None
-                    else FlashAttentionBackwardSm80
-                )
+            flash_bwd_obj_cls = (
+                FlashSparseAttentionBackwardSm120
+                if arch // 10 == 12
+                else FlashSparseAttentionBackwardSm80
+            )
             flash_bwd_obj_args = [
                 dtype,
                 head_dim,
@@ -1906,23 +1932,17 @@ def _flash_attn_bwd(
                 m_block_size,
                 n_block_size,
                 num_stages_Q,
+                num_threads,
+                pack_gqa,
+                causal,
+                local,
+                SdP_swapAB,
+                dKV_swapAB,
+                dQ_swapAB,
+                AtomLayoutMSdP,
+                AtomLayoutNdKV,
+                AtomLayoutMdQ,
             ]
-            if softmax_threshold is None:
-                flash_bwd_obj_args.append(num_stages_dO)
-            flash_bwd_obj_args.extend(
-                [
-                    num_threads,
-                    pack_gqa,
-                    causal,
-                    local,
-                    SdP_swapAB,
-                    dKV_swapAB,
-                    dQ_swapAB,
-                    AtomLayoutMSdP,
-                    AtomLayoutNdKV,
-                    AtomLayoutMdQ,
-                ]
-            )
             fa_bwd_obj = flash_bwd_obj_cls(
                 *flash_bwd_obj_args,
                 V_in_regs=V_in_regs,
@@ -1995,16 +2015,20 @@ def _flash_attn_bwd(
             dv_tensor if not dKV_postprocess else dv_accum_tensor,
             softmax_scale,
         ]
+        if window_sizes is not None:
+            compile_args.append(window_sizes_tensor)
+        else:
+            compile_args.append(None)
         if softmax_threshold is not None:
             compile_args.append(softmax_threshold)
+        else:
+            compile_args.append(0.0)
         compile_args.extend(
             [
                 cu_seqlens_q_tensor,
                 cu_seqlens_k_tensor,
                 seqused_q_tensor,
                 seqused_k_tensor,
-                window_size_left,
-                window_size_right,
                 dQ_semaphore_tensor,
                 dK_semaphore_tensor,
                 dV_semaphore_tensor,
@@ -2030,16 +2054,20 @@ def _flash_attn_bwd(
             dv if not dKV_postprocess else dv_accum,
             softmax_scale,
         ]
+        if window_sizes is not None:
+            call_args.append(window_sizes)
+        else:
+            call_args.append(None)
         if softmax_threshold is not None:
             call_args.append(softmax_threshold)
+        else:
+            call_args.append(0.0)
         call_args.extend(
             [
                 cu_seqlens_q,
                 cu_seqlens_k,
                 seqused_q,
                 seqused_k,
-                window_size_left,
-                window_size_right,
                 dQ_semaphore,
                 dK_semaphore,
                 dV_semaphore,
@@ -2136,9 +2164,10 @@ class FlashAttnFunc(torch.autograd.Function):
         k: torch.Tensor,
         v: torch.Tensor,
         softmax_scale: Optional[float] = None,
+        is_causal: bool = False,
+        window_sizes: Optional[torch.Tensor] = None,
         softmax_threshold: Optional[float] = None,
-        causal: bool = False,
-        window_size: Tuple[Optional[int], Optional[int]] = (None, None),
+        is_local: bool = False,
         learnable_sink: Optional[torch.Tensor] = None,
         softcap: float = 0.0,
         num_splits: int = 1,
@@ -2160,9 +2189,9 @@ class FlashAttnFunc(torch.autograd.Function):
             v,
             softmax_scale=softmax_scale,
             softmax_threshold=softmax_threshold,
-            causal=causal,
-            window_size_left=window_size[0],
-            window_size_right=window_size[1],
+            causal=is_causal,
+            window_sizes=window_sizes,
+            local=is_local,
             learnable_sink=learnable_sink,
             softcap=softcap,
             num_splits=num_splits,
@@ -2176,9 +2205,10 @@ class FlashAttnFunc(torch.autograd.Function):
         )
         ctx.save_for_backward(q, k, v, out, lse, *(aux_tensors or ()))
         ctx.softmax_scale = softmax_scale
+        ctx.is_causal = is_causal
+        ctx.window_sizes = window_sizes
         ctx.softmax_threshold = softmax_threshold
-        ctx.causal = causal
-        ctx.window_size = window_size
+        ctx.is_local = is_local
         ctx.softcap = softcap
         ctx.deterministic = deterministic
         ctx.return_lse = return_lse
@@ -2207,10 +2237,10 @@ class FlashAttnFunc(torch.autograd.Function):
             lse,
             ctx.softmax_scale,
             ctx.softmax_threshold,
-            ctx.causal,
+            ctx.is_causal,
             ctx.softcap,
-            window_size_left=ctx.window_size[0],
-            window_size_right=ctx.window_size[1],
+            window_sizes=ctx.window_sizes,
+            local=ctx.is_local,
             deterministic=ctx.deterministic,
             score_mod=ctx.score_mod,
             score_mod_bwd=ctx.score_mod_bwd,
@@ -2239,9 +2269,10 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         min_seqlen_k: Optional[int] = None,
         page_table: Optional[torch.Tensor] = None,
         softmax_scale: Optional[float] = None,
+        is_causal: bool = False,
+        window_sizes: Optional[torch.Tensor] = None,
         softmax_threshold: Optional[float] = None,
-        causal: bool = False,
-        window_size: Tuple[Optional[int], Optional[int]] = (None, None),
+        is_local: bool = False,
         learnable_sink: Optional[torch.Tensor] = None,
         softcap: float = 0.0,
         num_splits: int = 1,
@@ -2270,9 +2301,9 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             page_table=page_table,
             softmax_scale=softmax_scale,
             softmax_threshold=softmax_threshold,
-            causal=causal,
-            window_size_left=window_size[0],
-            window_size_right=window_size[1],
+            causal=is_causal,
+            window_sizes=window_sizes,
+            local=is_local,
             learnable_sink=learnable_sink,
             softcap=softcap,
             num_splits=num_splits,
@@ -2297,9 +2328,10 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             *(aux_tensors or ()),
         )
         ctx.softmax_scale = softmax_scale
+        ctx.is_causal = is_causal
+        ctx.window_sizes = window_sizes
         ctx.softmax_threshold = softmax_threshold
-        ctx.causal = causal
-        ctx.window_size = window_size
+        ctx.is_local = is_local
         ctx.softcap = softcap
         ctx.deterministic = deterministic
         ctx.max_seqlen_q = max_seqlen_q
@@ -2341,10 +2373,10 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             lse,
             ctx.softmax_scale,
             ctx.softmax_threshold,
-            ctx.causal,
+            ctx.is_causal,
             ctx.softcap,
-            window_size_left=ctx.window_size[0],
-            window_size_right=ctx.window_size[1],
+            window_sizes=ctx.window_sizes,
+            local=ctx.is_local,
             cu_seqlens_q=cu_seqlens_q,
             cu_seqlens_k=cu_seqlens_k,
             seqused_q=seqused_q,
@@ -2367,9 +2399,10 @@ def flash_attn_func(
     k: torch.Tensor,
     v: torch.Tensor,
     softmax_scale: Optional[float] = None,
+    is_causal: bool = False,
+    window_sizes: Optional[torch.Tensor] = None,
     softmax_threshold: Optional[float] = None,
-    causal: bool = False,
-    window_size: Tuple[Optional[int], Optional[int]] = (None, None),
+    is_local: bool = False,
     learnable_sink: Optional[torch.Tensor] = None,
     softcap: float = 0.0,
     num_splits: int = 1,
@@ -2389,9 +2422,10 @@ def flash_attn_func(
         k,
         v,
         softmax_scale,
+        is_causal,
+        window_sizes,
         softmax_threshold,
-        causal,
-        window_size,
+        is_local,
         learnable_sink,
         softcap,
         num_splits,
@@ -2421,9 +2455,10 @@ def flash_attn_varlen_func(
     seqused_k: Optional[torch.Tensor] = None,
     page_table: Optional[torch.Tensor] = None,
     softmax_scale: Optional[float] = None,
+    is_causal: bool = False,
+    window_sizes: Optional[torch.Tensor] = None,
     softmax_threshold: Optional[float] = None,
-    causal: bool = False,
-    window_size: Tuple[Optional[int], Optional[int]] = (None, None),
+    is_local: bool = False,
     learnable_sink: Optional[torch.Tensor] = None,
     softcap: float = 0.0,
     num_splits: int = 1,
@@ -2463,9 +2498,10 @@ def flash_attn_varlen_func(
         min_seqlen_k,
         page_table,
         softmax_scale,
+        is_causal,
+        window_sizes,
         softmax_threshold,
-        causal,
-        window_size,
+        is_local,
         learnable_sink,
         softcap,
         num_splits,

--- a/flash_sparse_attn/ops/cute/mask.py
+++ b/flash_sparse_attn/ops/cute/mask.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026, Jingze Shi.
 # Copyright (c) 2025, Tri Dao.
 
 from typing import Optional, Callable, TypeAlias, Tuple
@@ -160,8 +161,10 @@ class AttentionMask:
     tile_m: cutlass.Constexpr[int]
     tile_n: cutlass.Constexpr[int]
     seqlen_info: SeqlenInfoQK
+    window_size_sink: Optional[Int32] = None
     window_size_left: Optional[Int32] = None
     window_size_right: Optional[Int32] = None
+    window_size_dist: Optional[Int32] = None
     qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1  # only pass in if we're doing PackGQA
     swap_AB: cutlass.Constexpr[bool] = False
 
@@ -185,12 +188,15 @@ class AttentionMask:
         mask_seqlen: cutlass.Constexpr[bool],
         mask_causal: cutlass.Constexpr[bool],
         mask_local: cutlass.Constexpr[bool] = False,
+        mask_sink: cutlass.Constexpr[bool] = False,
         mask_mod: cutlass.Constexpr[Optional[Callable]] = None,
         aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
         use_r2p: cutlass.Constexpr[bool] = True,
     ) -> None:
-        assert not (mask_causal and mask_local), "mask_causal and mask_local cannot be both True"
+        assert not (mask_causal and (mask_local or mask_sink)), (
+            "mask_causal cannot be combined with mask_local or mask_sink"
+        )
         acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S, transpose=self.swap_AB)
         acc_shape = (self.tile_m, self.tile_n)
         cS = cute.make_identity_tensor(acc_shape if not self.swap_AB else acc_shape[::-1])
@@ -209,7 +215,7 @@ class AttentionMask:
         if n_block < 0:
             n_block = 0
         seqlenk_col_limit = self.seqlen_k - n_block * self.tile_n - thr_col_offset
-        if const_expr(not mask_causal and not mask_local and mask_mod is None):
+        if const_expr(not mask_causal and not mask_local and not mask_sink and mask_mod is None):
             if const_expr(mask_seqlen):
                 r2p = const_expr(use_r2p and not self.swap_AB)
                 if const_expr(not r2p):
@@ -223,7 +229,7 @@ class AttentionMask:
                     mask_r2p_lambda(acc_S_mn, lambda s: r2p_bitmask_below(seqlenk_col_limit_r2p, s))
 
         elif const_expr(
-            not mask_causal and not mask_local and mask_mod is not None
+            not mask_causal and not mask_local and not mask_sink and mask_mod is not None
         ):  # FlexAttention mask mod
             nrow = const_expr(cute.size(tScS_mn.shape[0]))
             ncol = const_expr(cute.size(tScS_mn.shape[1]))
@@ -331,17 +337,7 @@ class AttentionMask:
                                 lambda s: r2p_bitmask_below(col_limit_r2p, s),
                                 rank1=True,
                             )
-                else:  # Local
-                    local_row_offset_right = (
-                        causal_row_offset + self.window_size_right
-                        if const_expr(self.window_size_right is not None)
-                        else None
-                    )
-                    local_row_offset_left = (
-                        causal_row_offset - 1 - self.window_size_left
-                        if const_expr(self.window_size_left is not None)
-                        else None
-                    )
+                else:  # Local and/or sink
                     r2p_local = const_expr(use_r2p and not self.swap_AB)
                     for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
                         if const_expr(self.qhead_per_kvhead_packgqa == 1):
@@ -350,31 +346,55 @@ class AttentionMask:
                             row_idx = utils.shuffle_sync(
                                 mma_m_idx, r % threads_per_row, width=threads_per_row
                             )
-                        if const_expr(self.window_size_right is not None):
-                            col_limit_right = row_idx + local_row_offset_right
-                        else:
-                            col_limit_right = self.tile_n
+                        col_limit_right = row_idx + causal_row_offset
                         if const_expr(mask_seqlen):
                             col_limit_right = cutlass.min(col_limit_right, seqlenk_col_limit)
-                        col_limit_left = (
-                            row_idx + local_row_offset_left
-                            if const_expr(self.window_size_left is not None)
-                            else 0
+                        col_limit_dist_left = col_limit_right - self.window_size_dist
+                        col_limit_window_right = col_limit_dist_left - self.window_size_right
+                        col_limit_window_left = col_limit_window_right - self.window_size_left
+                        col_limit_sink_right = cutlass.min(
+                            col_limit_right,
+                            self.window_size_sink - n_block * self.tile_n - thr_col_offset,
                         )
                         if const_expr(not r2p_local):
                             # traverse column index.
                             for c in cutlass.range(cute.size(tScS_mn.shape[1]), unroll_full=True):
                                 col_idx = t0ScS_mn[0, c][1]
-                                if col_idx >= col_limit_right or col_idx < col_limit_left:
+                                allowed = cutlass.Boolean(False)
+                                if const_expr(mask_local):
+                                    allowed = (
+                                        (col_idx >= col_limit_dist_left)
+                                        and (col_idx < col_limit_right)
+                                    ) or (
+                                        (col_idx >= col_limit_window_left)
+                                        and (col_idx < col_limit_window_right)
+                                    )
+                                if const_expr(mask_sink):
+                                    allowed = allowed or (
+                                        (col_idx >= 0) and (col_idx < col_limit_sink_right)
+                                    )
+                                if not allowed:
                                     acc_S_mn[r, c] = -Float32.inf
                         else:
                             col_limit_right_r2p = sm90_col_to_r2p_idx(col_limit_right)
-                            col_limit_left_r2p = sm90_col_to_r2p_idx(col_limit_left)
+                            col_limit_dist_left_r2p = sm90_col_to_r2p_idx(col_limit_dist_left)
+                            col_limit_window_right_r2p = sm90_col_to_r2p_idx(col_limit_window_right)
+                            col_limit_window_left_r2p = sm90_col_to_r2p_idx(col_limit_window_left)
+                            col_limit_sink_right_r2p = sm90_col_to_r2p_idx(col_limit_sink_right)
 
                             def mask_gen_fn(s: int) -> Uint32:
-                                return r2p_bitmask_below(
-                                    col_limit_right_r2p, s
-                                ) & r2p_bitmask_above(col_limit_left_r2p, s)
+                                mask = Uint32(0)
+                                if const_expr(mask_local):
+                                    mask = (
+                                        r2p_bitmask_below(col_limit_right_r2p, s)
+                                        & r2p_bitmask_above(col_limit_dist_left_r2p, s)
+                                    ) | (
+                                        r2p_bitmask_below(col_limit_window_right_r2p, s)
+                                        & r2p_bitmask_above(col_limit_window_left_r2p, s)
+                                    )
+                                if const_expr(mask_sink):
+                                    mask = mask | r2p_bitmask_below(col_limit_sink_right_r2p, s)
+                                return mask
 
                             mask_r2p_lambda(acc_S_mn[r, None], mask_gen_fn, rank1=True)
             else:  # swap_AB
@@ -399,7 +419,7 @@ class AttentionMask:
                                 if t0ScS_mn[r, 0][ROW] < row_limit_top
                                 else acc_S_mn[r, c]
                             )
-                else:
+                else:  # Local and/or sink
                     for c in cutlass.range(cute.size(tScS_mn.shape[1]), unroll_full=True):
                         col0 = t0ScS_mn[0, c][COL]
                         # If col0 is beyond the column limit, we want to mask out the entire
@@ -407,24 +427,28 @@ class AttentionMask:
                         row_limit_top = (
                             self.tile_m
                             if col0 >= seqlenk_col_limit and mask_seqlen
-                            else (
-                                col0 - causal_row_offset - self.window_size_right
-                                if const_expr(self.window_size_right is not None)
-                                else 0
-                            )
+                            else col0 - causal_row_offset
                         )
-                        row_limit_bot = (
-                            col0 - causal_row_offset + self.window_size_left
-                            if const_expr(self.window_size_left is not None)
-                            else self.tile_m
-                        )
+                        row_limit_dist_bot = row_limit_top + self.window_size_dist
+                        row_limit_window_top = row_limit_dist_bot + self.window_size_right
+                        row_limit_window_bot = row_limit_window_top + self.window_size_left
+                        global_k_idx = n_block * self.tile_n + thr_col_offset + col0
                         for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
                             row_idx = t0ScS_mn[r, 0][ROW]
-                            acc_S_mn[r, c] = (
-                                -Float32.inf
-                                if row_idx < row_limit_top or row_idx > row_limit_bot
-                                else acc_S_mn[r, c]
-                            )
+                            allowed = cutlass.Boolean(False)
+                            if const_expr(mask_local):
+                                allowed = (
+                                    (row_idx >= row_limit_top) and (row_idx < row_limit_dist_bot)
+                                ) or (
+                                    (row_idx >= row_limit_window_top)
+                                    and (row_idx < row_limit_window_bot)
+                                )
+                            if const_expr(mask_sink):
+                                allowed = allowed or (
+                                    (global_k_idx < self.window_size_sink)
+                                    and (row_idx >= row_limit_top)
+                                )
+                            acc_S_mn[r, c] = acc_S_mn[r, c] if allowed else -Float32.inf
 
     @cute.jit
     def apply_mask_mod_sm100_scalar(

--- a/flash_sparse_attn/ops/cute/namespace.py
+++ b/flash_sparse_attn/ops/cute/namespace.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, Jingze Shi.
+
+from typing import Any, NamedTuple
+
+
+class FlashFwdMmaParamsSm80(NamedTuple):
+    thr_mma_qk: Any
+    thr_mma_pv: Any
+    tSrQ: Any
+    tSrK: Any
+    tOrVt: Any
+    acc_O: Any
+
+
+class FlashFwdSmemCopyParamsSm80(NamedTuple):
+    smem_thr_copy_Q: Any
+    smem_thr_copy_K: Any
+    smem_thr_copy_V: Any
+    tSsQ: Any
+    tSsK: Any
+    tOsVt: Any
+
+
+class FlashBwdMmaParamsSm80(NamedTuple):
+    thr_mma_sdp: Any
+    thr_mma_dkv: Any
+    thr_mma_dq: Any
+    tSrQ: Any
+    tSrK: Any
+    tdPrdO: Any
+    tdPrV: Any
+    tdVrP: Any
+    tdVrdO: Any
+    tdKrdS: Any
+    tdKrQ: Any
+    tdQrdS: Any
+    tdQrK: Any
+    acc_dK: Any
+    acc_dV: Any
+
+
+class FlashBwdSmemCopyParamsSm80(NamedTuple):
+    smem_thr_copy_QdO: Any
+    smem_thr_copy_KV: Any
+    smem_thr_copy_PdSt: Any
+    smem_thr_copy_QdOt: Any
+    smem_thr_copy_dS: Any
+    smem_thr_copy_Kt: Any
+    r2s_thr_copy_PdS: Any
+    tSsQ: Any
+    tSsK: Any
+    tdPsdO: Any
+    tdPsV: Any
+    tSsLSEMma: Any
+    tSsdPsumMma: Any
+    tPsP: Any
+    tdSsdS: Any
+    tdVsPt: Any
+    tdVsdOt: Any
+    tdKsdSt: Any
+    tdKsQt: Any
+    tdQsdS: Any
+    tdQsKt: Any
+
+
+class FlashBwdGmemCopyParamsSm80(NamedTuple):
+    gmem_thr_copy_dQaccum: Any
+    tdQgdQaccum: Any

--- a/flash_sparse_attn/ops/cute/tile_scheduler.py
+++ b/flash_sparse_attn/ops/cute/tile_scheduler.py
@@ -101,6 +101,33 @@ class WorkTileInfo(cutlass.utils.WorkTileInfo):
         new_is_valid_tile = cutlass.new_from_mlir_values(self._is_valid_tile, [values[-1]])
         return WorkTileInfo(new_tile_idx, new_is_valid_tile)
 
+    @cute.jit
+    def load_window_sizes(
+        self,
+        mWindowSizes: Optional[cute.Tensor],
+        is_local: cutlass.Constexpr[bool],
+        qhead_per_kvhead: cutlass.Constexpr[int],
+        pack_gqa: cutlass.Constexpr[bool],
+    ) -> Tuple[Int32, Int32, Int32, Int32]:
+        if const_expr(is_local):
+            _, head_idx, _, _ = self.tile_idx
+            head_kv_idx = head_idx if const_expr(pack_gqa) else head_idx // qhead_per_kvhead
+            window_size_sink = mWindowSizes[head_kv_idx, 0]
+            window_size_left = mWindowSizes[head_kv_idx, 1]
+            window_size_right = mWindowSizes[head_kv_idx, 2]
+            window_size_dist = mWindowSizes[head_kv_idx, 3]
+        else:
+            window_size_sink = Int32(0)
+            window_size_left = Int32(0)
+            window_size_right = Int32(0)
+            window_size_dist = Int32(0)
+        return (
+            window_size_sink,
+            window_size_left,
+            window_size_right,
+            window_size_dist,
+        )
+
 
 @runtime_checkable
 class TileSchedulerProtocol(Protocol):


### PR DESCRIPTION
Closes #350.

## Summary

- migrate the CuTe SM80 sparse attention mask from scalar left/right windows to per-KV-head `[sink, left, right, dist]` window sizes
- align CuTe block-range calculation, masking, and tile scheduling with the Triton flexible-window implementation
- add flexible-window support to both sparse forward and backward kernels
- update the CuTe fixed-length and variable-length interfaces to accept `window_sizes` and `is_local`
- generate the same default window-size heuristic as Triton when local attention is enabled without an explicit tensor
- allow non-local sparse kernels to receive `window_sizes=None`, and use a zero sparse threshold when the threshold is omitted to preserve exact-attention behavior
- replace ad-hoc parameter namespaces with typed SM80 forward/backward parameter tuples

## Validation

Tested on an NVIDIA A800-SXM4-80GB with BF16, causal attention, Hq=32, Hkv=8, and D=128.

- sparse forward pipeline: PASS for stage 1/2, Q-in-registers on/off, no-skip/high-skip profiles, and boundary sequence lengths
- default exact CuTe path vs SDPA: output max error 0.001953, dQ 0.001953, dK 0.03125, dV 0.0625
- sparse, heuristic-window, and custom-window CuTe paths vs Triton: output max error 0.003906, dQ 0.023438, dK 0.03125, dV at most 0.015625
- sparse backward: PASS for local, non-local `window_sizes=None`, and non-block-aligned sequence length 2113
- local high-sparsity benchmark at sequence length 131072:
  - forward: CuTe 60.236 ms, Triton 99.320 ms, SDPA 642.048 ms
  - backward: CuTe 120.845 ms, Triton 246.461 ms, SDPA 1804.545 ms

The benchmark used `softmax_threshold=1.0`, the default local-window heuristic, `pack_gqa=False`, and fixed Triton launch configurations `(128, 32, 4, 1, 1)` for forward and `(32, 128, 8, 1, 1)` for backward.
