### PR TITLE
Support flexible windows and softmax threshold on SM90

### DIFF
--- a/flash_sparse_attn/ops/cute/block_info.py
+++ b/flash_sparse_attn/ops/cute/block_info.py
@@ -116,6 +116,16 @@ class BlockInfo:
                 n_block_max = cutlass.min(n_block_min_new + n_block_count, n_block_max)
                 n_block_min = n_block_min_new
                 n_block_sink_max = n_block_sink_max if split_idx == 0 else Int32(0)
+        n_block_min = cutlass.min(n_block_min, n_block_max)
+        if const_expr(self.is_local):
+            n_block_window_max = cutlass.max(
+                cutlass.min(n_block_window_max, n_block_min),
+                n_block_window_min,
+            )
+            n_block_sink_max = cutlass.max(n_block_sink_max, n_block_sink_min)
+        else:
+            n_block_window_min = Int32(0)
+            n_block_window_max = Int32(0)
         return (
             n_block_min,
             n_block_max,
@@ -169,6 +179,16 @@ class BlockInfo:
             m_block_max = Int32(0) if is_sink_block else m_block_max
             m_block_window_min = Int32(0) if is_sink_block else m_block_window_min
             m_block_window_max = Int32(0) if is_sink_block else m_block_window_max
+        m_block_min = cutlass.min(m_block_min, m_block_max)
+        if const_expr(self.is_local):
+            m_block_window_min = cutlass.min(
+                cutlass.max(m_block_window_min, m_block_max),
+                m_block_window_max,
+            )
+            m_block_sink_min = cutlass.min(m_block_sink_min, m_block_sink_max)
+        else:
+            m_block_window_min = Int32(0)
+            m_block_window_max = Int32(0)
         return (
             m_block_min,
             m_block_max,

--- a/flash_sparse_attn/ops/cute/block_sparse_utils.py
+++ b/flash_sparse_attn/ops/cute/block_sparse_utils.py
@@ -187,6 +187,12 @@ def load_block_list(
         Updated kv_producer_state after processing the block list.
 
     """
+    separate_kv_state = const_expr(isinstance(kv_producer_state, tuple))
+    if const_expr(separate_kv_state):
+        k_producer_state, v_producer_state = kv_producer_state
+    else:
+        k_producer_state = kv_producer_state
+        v_producer_state = kv_producer_state
     if block_count > 0:
         total_blocks = block_count * kv_subtile_factor
         if const_expr(not intra_wg_overlap):
@@ -196,11 +202,13 @@ def load_block_list(
                     total_blocks - 1 - offset,
                     kv_subtile_factor,
                 )
-                pipeline_k.producer_acquire(kv_producer_state)
-                load_K(src_idx=n_block, producer_state=kv_producer_state)
-                pipeline_v.producer_acquire(kv_producer_state)
-                load_V(src_idx=n_block, producer_state=kv_producer_state)
-                kv_producer_state.advance()
+                pipeline_k.producer_acquire(k_producer_state)
+                load_K(src_idx=n_block, producer_state=k_producer_state)
+                pipeline_v.producer_acquire(v_producer_state)
+                load_V(src_idx=n_block, producer_state=v_producer_state)
+                k_producer_state.advance()
+                if const_expr(separate_kv_state):
+                    v_producer_state.advance()
         else:
             n_block_first = sparse_physical_n_block_forward(
                 block_indices,
@@ -208,8 +216,8 @@ def load_block_list(
                 kv_subtile_factor,
             )
             if const_expr(not first_block_preloaded):
-                pipeline_k.producer_acquire(kv_producer_state)
-                load_K(src_idx=n_block_first, producer_state=kv_producer_state)
+                pipeline_k.producer_acquire(k_producer_state)
+                load_K(src_idx=n_block_first, producer_state=k_producer_state)
 
             for idx in cutlass.range(total_blocks - 1, unroll=1):
                 n_block_prev = sparse_physical_n_block_forward(
@@ -222,14 +230,24 @@ def load_block_list(
                     total_blocks - 1 - (idx + 1),
                     kv_subtile_factor,
                 )
-                kv_producer_state_prev = kv_producer_state.clone()
-                kv_producer_state.advance()
-                pipeline_k.producer_acquire(kv_producer_state)
-                load_K(src_idx=n_block, producer_state=kv_producer_state)
-                pipeline_v.producer_acquire(kv_producer_state_prev)
-                load_V(src_idx=n_block_prev, producer_state=kv_producer_state_prev)
+                if const_expr(separate_kv_state):
+                    k_producer_state.advance()
+                    pipeline_k.producer_acquire(k_producer_state)
+                    load_K(src_idx=n_block, producer_state=k_producer_state)
+                    pipeline_v.producer_acquire(v_producer_state)
+                    load_V(src_idx=n_block_prev, producer_state=v_producer_state)
+                    v_producer_state.advance()
+                else:
+                    kv_producer_state_prev = k_producer_state.clone()
+                    k_producer_state.advance()
+                    pipeline_k.producer_acquire(k_producer_state)
+                    load_K(src_idx=n_block, producer_state=k_producer_state)
+                    pipeline_v.producer_acquire(kv_producer_state_prev)
+                    load_V(src_idx=n_block_prev, producer_state=kv_producer_state_prev)
 
-    return kv_producer_state
+    return (
+        (k_producer_state, v_producer_state) if const_expr(separate_kv_state) else k_producer_state
+    )
 
 
 @cute.jit
@@ -242,13 +260,23 @@ def finish_overlap_v_load(
     kv_subtile_factor: cutlass.Constexpr[int] = 1,
 ):
     """Load the final V block after overlapped K/V loads."""
+    separate_kv_state = const_expr(isinstance(kv_producer_state, tuple))
+    if const_expr(separate_kv_state):
+        k_producer_state, v_producer_state = kv_producer_state
+    else:
+        k_producer_state = kv_producer_state
+        v_producer_state = kv_producer_state
     if block_count > 0:
         n_block_last = block_indices[0] * kv_subtile_factor
-        pipeline_v.producer_acquire(kv_producer_state)
-        load_V(src_idx=n_block_last, producer_state=kv_producer_state)
-        kv_producer_state.advance()
+        pipeline_v.producer_acquire(v_producer_state)
+        load_V(src_idx=n_block_last, producer_state=v_producer_state)
+        v_producer_state.advance()
+        if const_expr(separate_kv_state):
+            k_producer_state.advance()
 
-    return kv_producer_state
+    return (
+        (k_producer_state, v_producer_state) if const_expr(separate_kv_state) else k_producer_state
+    )
 
 
 @cute.jit
@@ -303,6 +331,7 @@ def produce_block_sparse_loads(
     assert kv_subtile_factor == 1, (
         "Coarse KV blocks (kv_subtile_factor > 1) are not supported on the SM90 forward path yet."
     )
+    separate_kv_state = const_expr(isinstance(kv_producer_state, tuple))
     m_block_sparse = sparse_tensor_m_block(m_block, qhead_per_kvhead, q_subtile_factor)
 
     (
@@ -381,12 +410,22 @@ def produce_block_sparse_loads(
                     curr_full_block_cnt * kv_subtile_factor - 1,
                     kv_subtile_factor,
                 )
-                kv_producer_state_prev = kv_producer_state.clone()
-                kv_producer_state.advance()
-                pipeline_k.producer_acquire(kv_producer_state)
-                load_K(src_idx=n_block_full_first, producer_state=kv_producer_state)
-                pipeline_v.producer_acquire(kv_producer_state_prev)
-                load_V(src_idx=n_block_mask_last, producer_state=kv_producer_state_prev)
+                if const_expr(separate_kv_state):
+                    k_producer_state, v_producer_state = kv_producer_state
+                    k_producer_state.advance()
+                    pipeline_k.producer_acquire(k_producer_state)
+                    load_K(src_idx=n_block_full_first, producer_state=k_producer_state)
+                    pipeline_v.producer_acquire(v_producer_state)
+                    load_V(src_idx=n_block_mask_last, producer_state=v_producer_state)
+                    v_producer_state.advance()
+                    kv_producer_state = k_producer_state, v_producer_state
+                else:
+                    kv_producer_state_prev = kv_producer_state.clone()
+                    kv_producer_state.advance()
+                    pipeline_k.producer_acquire(kv_producer_state)
+                    load_K(src_idx=n_block_full_first, producer_state=kv_producer_state)
+                    pipeline_v.producer_acquire(kv_producer_state_prev)
+                    load_V(src_idx=n_block_mask_last, producer_state=kv_producer_state_prev)
 
                 kv_producer_state = load_block_list(
                     curr_full_block_idx,
@@ -1824,7 +1863,7 @@ def consume_block_sparse_mma_bwd_sm90(
         m_block = curr_q_idx[sparse_idx] * q_subtile_factor + subtile_offset
 
         if m_block < m_block_max:
-            consumer_state_Q, consumer_state_dO = mma_one_m_block_fn(
+            consumer_state_Q, consumer_state_dO, _ = mma_one_m_block_fn(
                 m_block,
                 consumer_state_Q,
                 consumer_state_dO,
@@ -1842,7 +1881,7 @@ def consume_block_sparse_mma_bwd_sm90(
             m_block = curr_full_idx[sparse_idx] * q_subtile_factor + subtile_offset
 
             if m_block < m_block_max:
-                consumer_state_Q, consumer_state_dO = mma_one_m_block_fn(
+                consumer_state_Q, consumer_state_dO, _ = mma_one_m_block_fn(
                     m_block,
                     consumer_state_Q,
                     consumer_state_dO,

--- a/flash_sparse_attn/ops/cute/flash_bwd.py
+++ b/flash_sparse_attn/ops/cute/flash_bwd.py
@@ -6,6 +6,7 @@
 # A reimplementation of https://github.com/Dao-AILab/flash-attention/blob/main/hopper/mainloop_bwd_sm80.hpp
 # from Cutlass C++ to Cute-DSL.
 import math
+from types import SimpleNamespace
 from typing import Type, Callable, Optional
 from functools import partial
 
@@ -40,6 +41,7 @@ from flash_sparse_attn.ops.cute.namespace import (
 )
 
 
+# NOTE: only for sync
 class FlashAttentionBackwardSm80:
     def __init__(
         self,
@@ -637,7 +639,7 @@ class FlashAttentionBackwardSm80:
                 window_size_left,
                 window_size_right,
             )
-            (m_block_min, m_block_max, _, _, _, _) = block_info.get_m_block_min_max(seqlen, n_block)
+            m_block_min, m_block_max = block_info.get_m_block_min_max(seqlen, n_block)
             # TODO: return early if m_block_max == 0
 
             # ///////////////////////////////////////////////////////////////////////////////
@@ -849,7 +851,7 @@ class FlashAttentionBackwardSm80:
             tdOpdO = tQpQ
 
             # group parameters for compute_one_m_block
-            mma_params = FlashBwdMmaParamsSm80(
+            mma_params = SimpleNamespace(
                 thr_mma_sdp=thr_mma_sdp,
                 thr_mma_dkv=thr_mma_dkv,
                 thr_mma_dq=thr_mma_dq,
@@ -866,7 +868,7 @@ class FlashAttentionBackwardSm80:
                 acc_dK=acc_dK,
                 acc_dV=acc_dV,
             )
-            smem_copy_params = FlashBwdSmemCopyParamsSm80(
+            smem_copy_params = SimpleNamespace(
                 smem_thr_copy_QdO=smem_thr_copy_QdO,
                 smem_thr_copy_KV=smem_thr_copy_KV,
                 smem_thr_copy_PdSt=smem_thr_copy_PdSt,
@@ -889,7 +891,7 @@ class FlashAttentionBackwardSm80:
                 tdQsdS=tdQsdS,
                 tdQsKt=tdQsKt,
             )
-            gmem_copy_params = FlashBwdGmemCopyParamsSm80(
+            gmem_copy_params = SimpleNamespace(
                 gmem_thr_copy_dQaccum=gmem_thr_copy_dQaccum, tdQgdQaccum=tdQgdQaccum
             )
             load_Q_LSE = partial(
@@ -1045,9 +1047,9 @@ class FlashAttentionBackwardSm80:
         smem_pipe_read_do: cutlass.Int32,
         smem_pipe_write_q: cutlass.Int32,
         smem_pipe_write_do: cutlass.Int32,
-        mma_params: FlashBwdMmaParamsSm80,
-        smem_copy_params: FlashBwdSmemCopyParamsSm80,
-        gmem_copy_params: FlashBwdGmemCopyParamsSm80,
+        mma_params: SimpleNamespace,
+        smem_copy_params: SimpleNamespace,
+        gmem_copy_params: SimpleNamespace,
         load_Q_LSE: Callable,
         load_dO_dPsum: Callable,
         m_block_max: cutlass.Int32,

--- a/flash_sparse_attn/ops/cute/flash_bwd.py
+++ b/flash_sparse_attn/ops/cute/flash_bwd.py
@@ -2056,6 +2056,10 @@ class FlashSparseAttentionBackwardSm80:
         )
         if cutlass.const_expr(mWindowSizes is not None):
             assert mWindowSizes.element_type == Int32, "mWindowSizes must have dtype Int32"
+        if cutlass.const_expr(blocksparse_tensors is not None):
+            assert not self.is_local, (
+                "block sparsity and window sizes cannot be enabled at the same time"
+            )
         # Get the data type and check if it is fp16 or bf16
         self._check_type(
             *(
@@ -2261,7 +2265,6 @@ class FlashSparseAttentionBackwardSm80:
             )
             if cutlass.const_expr(self.is_local):
                 m_block_min_no_mask = m_block_max
-                m_block_window_min = cutlass.max(m_block_window_min, m_block_min_no_mask)
                 m_block_window_min_no_mask = block_info.get_m_block_min_causal_local_mask(
                     seqlen,
                     n_block,

--- a/flash_sparse_attn/ops/cute/flash_bwd_sm90.py
+++ b/flash_sparse_attn/ops/cute/flash_bwd_sm90.py
@@ -2224,12 +2224,12 @@ class FlashSparseAttentionBackwardSm90:
         mdK: cute.Tensor,
         mdV: cute.Tensor,
         softmax_scale: Float32,
+        mWindowSizes: Optional[cute.Tensor],
+        softmax_threshold: Float32,
         mCuSeqlensQ: Optional[cute.Tensor] = None,
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
-        window_size_left: Int32 | int | None = None,
-        window_size_right: Int32 | int | None = None,
         mdQ_semaphore: Optional[cute.Tensor] = None,
         mdK_semaphore: Optional[cute.Tensor] = None,
         mdV_semaphore: Optional[cute.Tensor] = None,
@@ -2238,6 +2238,15 @@ class FlashSparseAttentionBackwardSm90:
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
+        assert not self.is_local or mWindowSizes is not None, (
+            "mWindowSizes must be provided for local attention"
+        )
+        if const_expr(mWindowSizes is not None):
+            assert mWindowSizes.element_type == Int32, "mWindowSizes must have dtype Int32"
+        if const_expr(blocksparse_tensors is not None):
+            assert not self.is_local, (
+                "block sparsity and window sizes cannot be enabled at the same time"
+            )
         # For GQA (qhead_per_kvhead > 1), multiple Q heads accumulate into the same dK/dV,
         # so we need the float32 accum path + postprocess.
         # For varlen_k with qhead_per_kvhead == 1, we use ragged TMA tensors.
@@ -2438,11 +2447,6 @@ class FlashSparseAttentionBackwardSm90:
 
         self.use_block_sparsity = cutlass.const_expr(blocksparse_tensors is not None)
 
-        if const_expr(window_size_left is not None):
-            window_size_left = Int32(window_size_left)
-        if const_expr(window_size_right is not None):
-            window_size_right = Int32(window_size_right)
-
         self.kernel(
             tma_tensor_Q,
             tma_tensor_K,
@@ -2486,8 +2490,7 @@ class FlashSparseAttentionBackwardSm90:
             mdQ_semaphore,
             mdK_semaphore,
             mdV_semaphore,
-            window_size_left,
-            window_size_right,
+            mWindowSizes,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -2541,8 +2544,7 @@ class FlashSparseAttentionBackwardSm90:
         mdQ_semaphore: Optional[cute.Tensor] = None,
         mdK_semaphore: Optional[cute.Tensor] = None,
         mdV_semaphore: Optional[cute.Tensor] = None,
-        window_size_left: Optional[Int32] = None,
-        window_size_right: Optional[Int32] = None,
+        mWindowSizes: Optional[cute.Tensor] = None,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
 
@@ -2598,14 +2600,30 @@ class FlashSparseAttentionBackwardSm90:
         )
         sdQaccum = storage.sdQaccum.get_tensor(sdQaccum_layout)
 
+        TileSchedulerCls = partial(TileScheduler.create, tile_sched_params)
+        tile_scheduler = TileSchedulerCls()
+        work_tile = tile_scheduler.initial_work_tile_info()
+        (
+            window_size_sink,
+            window_size_left,
+            window_size_right,
+            window_size_dist,
+        ) = work_tile.load_window_sizes(
+            mWindowSizes,
+            self.is_local,
+            self.qhead_per_kvhead,
+            False,  # pack_gqa
+        )
         block_info = BlockInfo(
             self.tile_m,
             self.tile_n,
             self.is_causal,
             self.is_local,
             False,  # is_split_kv
+            window_size_sink,
             window_size_left,
             window_size_right,
+            window_size_dist,
             qhead_per_kvhead_packgqa=1,
         )
         SeqlenInfoCls = partial(
@@ -2623,11 +2641,12 @@ class FlashSparseAttentionBackwardSm90:
             AttentionMask,
             self.tile_m,
             self.tile_n,
+            window_size_sink=window_size_sink,
             window_size_left=window_size_left,
             window_size_right=window_size_right,
+            window_size_dist=window_size_dist,
             swap_AB=self.SdP_swapAB,
         )
-        TileSchedulerCls = partial(TileScheduler.create, tile_sched_params)
 
         if warp_idx < 4:
             cute.arch.setmaxregister_decrease(self.num_producer_regs)
@@ -2803,14 +2822,24 @@ class FlashSparseAttentionBackwardSm90:
                 load_dPsum = copy_utils.cpasync_bulk_get_copy_fn(gdPsum, sdPsum)
                 load_dPsum = copy_utils.tma_producer_copy_fn(load_dPsum, pipeline_dO)
 
-                m_block_min, m_block_max = block_info.get_m_block_min_max(seqlen, n_block)
-
+                (
+                    m_block_min,
+                    m_block_max,
+                    m_block_window_min,
+                    m_block_window_max,
+                    m_block_sink_min,
+                    m_block_sink_max,
+                ) = block_info.get_m_block_min_max(seqlen, n_block)
                 if const_expr(not self.use_block_sparsity):
-                    total_m_block_cnt = m_block_max - m_block_min
-                    process_tile = (
-                        const_expr(not self.is_local and not self.is_varlen_q)
-                        or m_block_min < m_block_max
+                    total_m_block_cnt = (
+                        m_block_max
+                        - m_block_min
+                        + (m_block_window_max - m_block_window_min)
+                        + (m_block_sink_max - m_block_sink_min)
                     )
+                    process_tile = const_expr(
+                        not self.is_local and not self.is_varlen_q
+                    ) or total_m_block_cnt > Int32(0)
                 else:
                     total_m_block_cnt = get_total_q_block_count_bwd(
                         blocksparse_tensors,
@@ -2825,6 +2854,14 @@ class FlashSparseAttentionBackwardSm90:
                 if process_tile:
                     if const_expr(not self.use_block_sparsity):
                         first_m_block = m_block_min
+                        if const_expr(self.is_local):
+                            if m_block_min == m_block_max:
+                                if m_block_window_min < m_block_window_max:
+                                    first_m_block = m_block_window_min
+                                    m_block_window_min += 1
+                                else:
+                                    first_m_block = m_block_sink_min
+                                    m_block_sink_min += 1
                         pipeline_Q.producer_acquire(
                             producer_state_Q, extra_tx_count=self.tma_copy_bytes["K"]
                         )
@@ -2861,6 +2898,41 @@ class FlashSparseAttentionBackwardSm90:
                             load_dPsum(m_block, producer_state=producer_state_dO_cur)
                             producer_state_Q.advance()
                             producer_state_dO.advance()
+
+                        if const_expr(self.is_local):
+                            for m_block in cutlass.range(
+                                m_block_window_min, m_block_window_max, unroll=1
+                            ):
+                                pipeline_Q.producer_acquire(producer_state_Q)
+                                load_Q(m_block, producer_state=producer_state_Q)
+                                load_LSE(m_block, producer_state=producer_state_Q)
+                                producer_state_dO_cur = (
+                                    producer_state_dO
+                                    if const_expr(self.Q_stage != self.dO_stage)
+                                    else producer_state_Q
+                                )
+                                pipeline_dO.producer_acquire(producer_state_dO_cur)
+                                load_dO(m_block, producer_state=producer_state_dO_cur)
+                                load_dPsum(m_block, producer_state=producer_state_dO_cur)
+                                producer_state_Q.advance()
+                                producer_state_dO.advance()
+
+                            for m_block in cutlass.range(
+                                m_block_sink_min, m_block_sink_max, unroll=1
+                            ):
+                                pipeline_Q.producer_acquire(producer_state_Q)
+                                load_Q(m_block, producer_state=producer_state_Q)
+                                load_LSE(m_block, producer_state=producer_state_Q)
+                                producer_state_dO_cur = (
+                                    producer_state_dO
+                                    if const_expr(self.Q_stage != self.dO_stage)
+                                    else producer_state_Q
+                                )
+                                pipeline_dO.producer_acquire(producer_state_dO_cur)
+                                load_dO(m_block, producer_state=producer_state_dO_cur)
+                                load_dPsum(m_block, producer_state=producer_state_dO_cur)
+                                producer_state_Q.advance()
+                                producer_state_dO.advance()
                     else:
                         producer_state_Q, producer_state_dO = produce_block_sparse_q_loads_bwd_sm90(
                             blocksparse_tensors,
@@ -3196,13 +3268,23 @@ class FlashSparseAttentionBackwardSm90:
                 n_block=n_block,
                 seqlen_info=seqlen,
             )
-            m_block_min, m_block_max = block_info.get_m_block_min_max(seqlen, n_block)
-
+            (
+                m_block_min,
+                m_block_max,
+                m_block_window_min,
+                m_block_window_max,
+                m_block_sink_min,
+                m_block_sink_max,
+            ) = block_info.get_m_block_min_max(seqlen, n_block)
+            total_m_block_cnt = (
+                (m_block_max - m_block_min)
+                + (m_block_window_max - m_block_window_min)
+                + (m_block_sink_max - m_block_sink_min)
+            )
             if const_expr(not self.use_block_sparsity):
-                process_tile = (
-                    const_expr(not self.is_local and not self.is_varlen_q)
-                    or m_block_min < m_block_max
-                )
+                process_tile = const_expr(
+                    not self.is_local and not self.is_varlen_q
+                ) or total_m_block_cnt > Int32(0)
             else:
                 total_m_block_cnt = get_total_q_block_count_bwd(
                     blocksparse_tensors,
@@ -3222,9 +3304,6 @@ class FlashSparseAttentionBackwardSm90:
                         head_idx=head_idx,
                         n_block=n_block,
                         thr_mma=thr_mma_SdP,
-                        mask_seqlen=True,
-                        mask_causal=self.is_causal,
-                        mask_local=self.is_local,
                         mask_mod=self.mask_mod,
                         aux_data=aux_data,
                         fastdiv_mods=fastdiv_mods,
@@ -3235,7 +3314,47 @@ class FlashSparseAttentionBackwardSm90:
                             m_block,
                             consumer_state_Q,
                             consumer_state_dO,
-                            mask_fn=mask_fn,
+                            mask_fn=partial(
+                                mask_fn,
+                                mask_seqlen=True,
+                                mask_causal=self.is_causal and not self.is_local,
+                                mask_local=self.is_local,
+                                mask_sink=False,
+                            ),
+                            score_mod_fn=score_mod_fn_cur,
+                            score_mod_bwd_fn=score_mod_bwd_fn_cur,
+                            dKV_accumulate=dKV_accumulate,
+                        )
+                        dKV_accumulate = True
+                    for m_block in cutlass.range(m_block_window_min, m_block_window_max, unroll=1):
+                        consumer_state_Q, consumer_state_dO = mma_one_m_block_all(
+                            m_block,
+                            consumer_state_Q,
+                            consumer_state_dO,
+                            mask_fn=partial(
+                                mask_fn,
+                                mask_seqlen=True,
+                                mask_causal=False,
+                                mask_local=True,
+                                mask_sink=False,
+                            ),
+                            score_mod_fn=score_mod_fn_cur,
+                            score_mod_bwd_fn=score_mod_bwd_fn_cur,
+                            dKV_accumulate=dKV_accumulate,
+                        )
+                        dKV_accumulate = True
+                    for m_block in cutlass.range(m_block_sink_min, m_block_sink_max, unroll=1):
+                        consumer_state_Q, consumer_state_dO = mma_one_m_block_all(
+                            m_block,
+                            consumer_state_Q,
+                            consumer_state_dO,
+                            mask_fn=partial(
+                                mask_fn,
+                                mask_seqlen=True,
+                                mask_causal=False,
+                                mask_local=True,
+                                mask_sink=True,
+                            ),
                             score_mod_fn=score_mod_fn_cur,
                             score_mod_bwd_fn=score_mod_bwd_fn_cur,
                             dKV_accumulate=dKV_accumulate,
@@ -3687,13 +3806,24 @@ class FlashSparseAttentionBackwardSm90:
                 # mdQ_semaphore is (num_m_blocks, cluster_size, num_head, batch) after transpose
                 mdQ_semaphore_cur = mdQ_semaphore[None, None, head_idx, batch_idx]
 
-            m_block_min, m_block_max = block_info.get_m_block_min_max(seqlen, n_block)
+            (
+                m_block_min,
+                m_block_max,
+                m_block_window_min,
+                m_block_window_max,
+                m_block_sink_min,
+                m_block_sink_max,
+            ) = block_info.get_m_block_min_max(seqlen, n_block)
             if const_expr(not self.use_block_sparsity):
+                loop_count = (
+                    m_block_max
+                    - m_block_min
+                    + (m_block_window_max - m_block_window_min)
+                    + (m_block_sink_max - m_block_sink_min)
+                )
                 process_tile = (
                     const_expr(not self.is_local and not self.is_varlen_q)
-                    or m_block_min < m_block_max
-                )
-                loop_count = m_block_max - m_block_min
+                ) or loop_count > Int32(0)
             else:
                 total_block_cnt = get_total_q_block_count_bwd(
                     blocksparse_tensors,
@@ -3709,6 +3839,17 @@ class FlashSparseAttentionBackwardSm90:
                 if const_expr(not self.use_block_sparsity):
                     for iter_idx in cutlass.range(loop_count, unroll=1):
                         m_block = m_block_min + iter_idx
+                        if iter_idx >= (m_block_max - m_block_min):
+                            m_block = m_block_window_min + iter_idx - (m_block_max - m_block_min)
+                        if iter_idx >= (m_block_max - m_block_min) + (
+                            m_block_window_max - m_block_window_min
+                        ):
+                            m_block = (
+                                m_block_sink_min
+                                + iter_idx
+                                - (m_block_max - m_block_min)
+                                - (m_block_window_max - m_block_window_min)
+                            )
                         m_block_safe = m_block
 
                         num_dQ_chunks = self.num_wg_dQ
@@ -3727,10 +3868,41 @@ class FlashSparseAttentionBackwardSm90:
                         # Semaphore acquire: wait for prior n_blocks to finish writing this m_block
                         if const_expr(self.deterministic):
                             if const_expr(self.spt):
-                                _, n_block_max_for_m_block = block_info.get_n_block_min_max(
-                                    seqlen, m_block_safe
+                                (
+                                    n_block_min_for_m_block,
+                                    n_block_max_for_m_block,
+                                    n_block_window_min_for_m_block,
+                                    n_block_window_max_for_m_block,
+                                    n_block_sink_min_for_m_block,
+                                    n_block_sink_max_for_m_block,
+                                ) = block_info.get_n_block_min_max(seqlen, m_block_safe)
+                                if const_expr(self.is_local):
+                                    n_block_window_max_for_m_block = cutlass.min(
+                                        n_block_window_max_for_m_block,
+                                        n_block_min_for_m_block,
+                                    )
+                                else:
+                                    n_block_window_min_for_m_block = Int32(0)
+                                    n_block_window_max_for_m_block = Int32(0)
+                                    n_block_sink_min_for_m_block = Int32(0)
+                                    n_block_sink_max_for_m_block = Int32(0)
+                                lock_value = (
+                                    cutlass.max(
+                                        n_block_max_for_m_block
+                                        - cutlass.max(n_block + 1, n_block_min_for_m_block),
+                                        0,
+                                    )
+                                    + cutlass.max(
+                                        n_block_window_max_for_m_block
+                                        - cutlass.max(n_block + 1, n_block_window_min_for_m_block),
+                                        0,
+                                    )
+                                    + cutlass.max(
+                                        n_block_sink_max_for_m_block
+                                        - cutlass.max(n_block + 1, n_block_sink_min_for_m_block),
+                                        0,
+                                    )
                                 )
-                                lock_value = n_block_max_for_m_block - 1 - n_block
                             else:
                                 lock_value = n_block
                             barrier.wait_eq(
@@ -3783,9 +3955,7 @@ class FlashSparseAttentionBackwardSm90:
 
             # For local masking + deterministic (non-spt): signal remaining m_blocks
             # that this n_block won't visit, so they don't deadlock waiting.
-            if const_expr(
-                self.deterministic and not self.spt and block_info.window_size_left is not None
-            ):
+            if const_expr(self.deterministic and not self.spt and self.is_local):
                 m_block_global_max = cute.ceil_div(seqlen.seqlen_q, self.tile_m)
                 for m_block in cutlass.range(m_block_max, m_block_global_max, unroll=1):
                     barrier.arrive_inc(

--- a/flash_sparse_attn/ops/cute/flash_bwd_sm90.py
+++ b/flash_sparse_attn/ops/cute/flash_bwd_sm90.py
@@ -43,7 +43,1887 @@ from flash_sparse_attn.ops.cute.block_sparse_utils import (
 )
 
 
+# NOTE: only for sync
 class FlashAttentionBackwardSm90:
+    arch = 90
+
+    def __init__(
+        self,
+        dtype: Type[cutlass.Numeric],
+        head_dim: int,
+        qhead_per_kvhead: int = 1,
+        is_causal: bool = False,
+        is_local: bool = False,
+        deterministic: bool = False,
+        tile_m: int = 64,
+        tile_n: int = 128,
+        Q_stage: int = 2,
+        dO_stage: int = 2,
+        PdS_stage: int = 2,
+        SdP_swapAB: bool = False,
+        dKV_swapAB: bool = False,
+        dQ_swapAB: bool = False,
+        AtomLayoutMSdP: int = 1,
+        AtomLayoutNdKV: int = 2,
+        AtomLayoutMdQ: int = 1,
+        num_threads: int = 384,
+        V_in_regs: bool = False,
+        score_mod: cutlass.Constexpr | None = None,
+        score_mod_bwd: cutlass.Constexpr | None = None,
+        mask_mod: cutlass.Constexpr | None = None,
+        has_aux_tensors: cutlass.Constexpr = False,
+        q_subtile_factor: cutlass.Constexpr[int] = 1,
+        dQ_single_wg: bool = False,
+    ):
+        self.dtype = dtype
+        # padding head_dim to a multiple of 16 as k_block_size
+        hdim_multiple_of = 16
+        self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
+        # Can save registers (and hence be faster) if we don't have to check hdim predication
+        self.check_hdim_oob = head_dim != self.tile_hdim
+        self.qhead_per_kvhead = qhead_per_kvhead
+        self.is_causal = is_causal
+        self.is_local = is_local
+        self.deterministic = deterministic
+        self.tile_m = tile_m
+        self.tile_n = tile_n
+        self.num_threads = num_threads
+        self.Q_stage = Q_stage
+        self.dO_stage = dO_stage
+        self.PdS_stage = PdS_stage
+        assert self.dO_stage in [1, self.Q_stage]
+        assert self.PdS_stage in [1, self.Q_stage]
+        self.SdP_swapAB = SdP_swapAB
+        self.dKV_swapAB = dKV_swapAB
+        self.dQ_swapAB = dQ_swapAB
+        self.AtomLayoutMSdP = AtomLayoutMSdP
+        self.AtomLayoutNdKV = AtomLayoutNdKV
+        self.AtomLayoutMdQ = AtomLayoutMdQ
+        self.num_wg_mma = (self.num_threads // 128) - 1
+        self.mma_dkv_is_rs = (
+            AtomLayoutMSdP == 1
+            and AtomLayoutNdKV == self.num_wg_mma
+            and SdP_swapAB
+            and not dKV_swapAB
+        )
+        self.V_in_regs = V_in_regs
+        # May be overridden in __call__ for varlen inputs.
+        if qhead_per_kvhead > 1:
+            assert self.num_wg_mma == 2, "GQA backward assumes 2 warp groups"
+        # These are tuned for speed
+        # Do we keep the LSE and dPsum in each thread, or split them across 8 threads that share
+        # them and then shuffle to get the value whenever we need? This can reduce register
+        # pressure when SdP_swapAB, where each thread needs to keep statistics for (kBlockM / 4)
+        # rows. If !SdP_swapAB, each thread only needs to keep statistics for 2 rows.
+        self.shuffle_LSE = self.SdP_swapAB and self.tile_hdim <= 64
+        self.shuffle_dPsum = self.SdP_swapAB and self.tile_hdim <= 64
+
+        self.buffer_align_bytes = 1024
+
+        self.score_mod = score_mod
+        self.score_mod_bwd = score_mod_bwd
+        self.mask_mod = mask_mod
+        self.has_aux_tensors = has_aux_tensors
+        self.q_subtile_factor = q_subtile_factor
+        if cutlass.const_expr(has_aux_tensors):
+            self.vec_size: cutlass.Constexpr = 1
+        else:
+            self.vec_size: cutlass.Constexpr = 4
+        self.qk_acc_dtype = Float32
+        # dQ_single_wg: WG0 computes the full dQ GEMM, WG1 skips it.
+        # Only valid for 2 MMA warp groups.
+        # Credit: Ben Spector
+        if dQ_single_wg:
+            assert self.num_wg_mma == 2, "dQ_single_wg only supports 2 warp groups"
+        self.num_wg_dQ = 1 if dQ_single_wg else self.num_wg_mma
+
+    @staticmethod
+    def can_implement(
+        dtype,
+        head_dim,
+        tile_m,
+        tile_n,
+        Q_stage,
+        num_threads,
+        V_in_regs=False,
+    ) -> bool:
+        if dtype not in [cutlass.Float16, cutlass.BFloat16]:
+            return False
+        if head_dim % 8 != 0:
+            return False
+        if tile_n % 16 != 0:
+            return False
+        if num_threads % 32 != 0:
+            return False
+        if (tile_m * 2) % num_threads != 0:
+            return False
+        return True
+
+    def _check_type(
+        self,
+        mQ_type: Type[cutlass.Numeric],
+        mK_type: Type[cutlass.Numeric],
+        mV_type: Type[cutlass.Numeric],
+        mdO_type: Type[cutlass.Numeric],
+        mLSE_type: Type[cutlass.Numeric],
+        mdPsum_type: Type[cutlass.Numeric],
+        mdQaccum_type: Type[cutlass.Numeric],
+        mdK_type: Type[cutlass.Numeric],
+        mdV_type: Type[cutlass.Numeric],
+    ):
+        # Get the data type and check if it is fp16 or bf16
+        if const_expr(not (mQ_type == mK_type == mV_type == mdO_type)):
+            raise TypeError("All tensors must have the same data type")
+        if const_expr(mQ_type not in [cutlass.Float16, cutlass.BFloat16]):
+            raise TypeError("Only Float16 or BFloat16 is supported")
+        if const_expr(mLSE_type not in [Float32]):
+            raise TypeError("LSE tensor must be Float32")
+        if const_expr(mdPsum_type not in [Float32]):
+            raise TypeError("dPsum tensor must be Float32")
+        if const_expr(mdQaccum_type not in [Float32]):
+            raise TypeError("dQaccum tensor must be Float32")
+        if const_expr(self.qhead_per_kvhead == 1):
+            if const_expr(not (mdK_type == mdV_type == mQ_type)):
+                raise TypeError("mdK and mdV tensors must have the same data type as mQ")
+        else:
+            if const_expr(not (mdK_type == mdV_type == Float32)):
+                raise TypeError("mdKaccum and mdVaccum tensors must have the data type Float32")
+        assert mQ_type == self.dtype
+
+    def _setup_attributes(self):
+        # We need to accommodate both Q and Q^T (and dO and dO^T) in shared memory.
+        # Q & dO are used in the SdP Mma and Q^T and dO^T are used in the dKV Mma.
+        # The M dimension (tile_m) doesn't matter for the layout, only the K dimension
+        wg_d_dKV = self.num_wg_mma // self.AtomLayoutNdKV
+        self.sQ_layout, self.sdO_layout = [
+            # Need to set major_mode_size (mms) to accommodate Q and Q.T
+            sm90_utils.make_smem_layout(
+                self.dtype,
+                LayoutEnum.ROW_MAJOR,
+                shape,
+                stage,
+                major_mode_size=mms,
+            )
+            for shape, stage, mms in [
+                ((self.tile_m, self.tile_hdim), self.Q_stage, self.tile_hdim // wg_d_dKV),
+                ((self.tile_m, self.tile_hdim), self.dO_stage, self.tile_hdim // wg_d_dKV),
+            ]
+        ]
+        wg_d_dQ = self.num_wg_dQ // self.AtomLayoutMdQ
+        # Accomodate both K and K.T
+        self.sK_layout = sm90_utils.make_smem_layout(
+            self.dtype,
+            LayoutEnum.ROW_MAJOR,
+            (self.tile_n, self.tile_hdim),
+            stage=None,
+            major_mode_size=self.tile_hdim // wg_d_dQ,
+        )
+        # There's only V, no V.T, so layout is normal
+        self.sV_layout = sm90_utils.make_smem_layout(
+            self.dtype, LayoutEnum.ROW_MAJOR, (self.tile_n, self.tile_hdim), None
+        )
+        # Accomodate both S and S.T
+        wg_n_SdP = self.num_wg_mma // self.AtomLayoutMSdP
+        wg_n_dKV = self.AtomLayoutNdKV
+        self.sPdS_layout = sm90_utils.make_smem_layout(
+            self.dtype,
+            LayoutEnum.ROW_MAJOR,
+            (self.tile_m, self.tile_n),
+            stage=self.PdS_stage,
+            major_mode_size=math.gcd(self.tile_n // wg_n_SdP, self.tile_n // wg_n_dKV),
+        )
+        self.sdQaccum_layout = cute.make_layout(
+            (self.tile_m * self.tile_hdim // self.num_wg_dQ, self.num_wg_dQ)
+        )
+        # dQaccum R->S
+        self.r2s_tiled_copy_dQaccum = cute.make_tiled_copy_tv(
+            cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), Float32, num_bits_per_copy=128),
+            # thr_layout
+            cute.make_layout((self.num_threads_per_warp_group, self.num_wg_dQ)),
+            cute.make_layout(128 // Float32.width),  # val_layout
+        )
+        # dKVaccum for GQA epilogue - reuses sV+sK memory recast as f32
+        # TODO: assert that sVaccum and sKaccum don't overflow smem
+
+    def _get_tiled_mma(self):
+        maybe_swap_mn = lambda shape, swap: (shape[1], shape[0], *shape[2:]) if swap else shape
+        # S = Q @ K.T, dP = dO @ V.T
+        atom_layout_SdP = (self.AtomLayoutMSdP, self.num_wg_mma // self.AtomLayoutMSdP, 1)
+        tiler_mn_SdP = (self.tile_m // atom_layout_SdP[0], self.tile_n // atom_layout_SdP[1])
+        tiled_mma_SdP = sm90_utils_basic.make_trivial_tiled_mma(
+            self.dtype,
+            self.dtype,
+            warpgroup.OperandMajorMode.K,
+            warpgroup.OperandMajorMode.K,
+            Float32,
+            atom_layout_mnk=maybe_swap_mn(atom_layout_SdP, self.SdP_swapAB),
+            tiler_mn=(64, tiler_mn_SdP[1] if not self.SdP_swapAB else tiler_mn_SdP[0]),
+        )
+        # dV = P.T @ dO, dK = dS.T @ Q
+        atom_layout_dKV = (self.AtomLayoutNdKV, self.num_wg_mma // self.AtomLayoutNdKV, 1)
+        tiler_mn_dK = (self.tile_n // atom_layout_dKV[0], self.tile_hdim // atom_layout_dKV[1])
+        tiler_mn_dV = (self.tile_n // atom_layout_dKV[0], self.tile_hdim // atom_layout_dKV[1])
+        tiled_mma_dK, tiled_mma_dV = [
+            sm90_utils_basic.make_trivial_tiled_mma(
+                self.dtype,
+                self.dtype,
+                warpgroup.OperandMajorMode.MN
+                if not self.mma_dkv_is_rs
+                else warpgroup.OperandMajorMode.K,
+                warpgroup.OperandMajorMode.MN,
+                Float32,
+                atom_layout_mnk=maybe_swap_mn(atom_layout_dKV, self.dKV_swapAB),
+                tiler_mn=(64, tiler_mn_d[1] if not self.dKV_swapAB else tiler_mn_d[0]),
+                a_source=warpgroup.OperandSource.RMEM
+                if self.mma_dkv_is_rs
+                else warpgroup.OperandSource.SMEM,
+            )
+            for tiler_mn_d in (tiler_mn_dK, tiler_mn_dV)
+        ]
+        # dQ = dS @ K
+        assert self.num_wg_dQ % self.AtomLayoutMdQ == 0
+        atom_layout_dQ = (self.AtomLayoutMdQ, self.num_wg_dQ // self.AtomLayoutMdQ, 1)
+        tiler_mn_dQ = (self.tile_m // atom_layout_dQ[0], self.tile_hdim // atom_layout_dQ[1])
+        tiled_mma_dQ = sm90_utils_basic.make_trivial_tiled_mma(
+            self.dtype,
+            self.dtype,
+            warpgroup.OperandMajorMode.K if not self.dQ_swapAB else warpgroup.OperandMajorMode.MN,
+            warpgroup.OperandMajorMode.MN if not self.dQ_swapAB else warpgroup.OperandMajorMode.K,
+            Float32,
+            atom_layout_mnk=maybe_swap_mn(atom_layout_dQ, self.dQ_swapAB),
+            tiler_mn=(64, tiler_mn_dQ[1] if not self.dQ_swapAB else tiler_mn_dQ[0]),
+        )
+        return tiled_mma_SdP, tiled_mma_dK, tiled_mma_dV, tiled_mma_dQ
+
+    def _get_shared_storage_cls(self):
+        sQ_struct, sK_struct, sV_struct, sdO_struct, sdQaccum_struct = [
+            cute.struct.Align[cute.struct.MemRange[t, cute.cosize(layout)], self.buffer_align_bytes]
+            for (layout, t) in [
+                (self.sQ_layout, self.dtype),
+                (self.sK_layout, self.dtype),
+                (self.sV_layout, self.dtype),
+                (self.sdO_layout, self.dtype),
+                (self.sdQaccum_layout, Float32),
+            ]
+        ]
+
+        cosize_sdS = cute.cosize(self.sPdS_layout)
+        cosize_sP = cute.cosize(self.sPdS_layout) if const_expr(not self.mma_dkv_is_rs) else 0
+        sLSE_struct = cute.struct.Align[
+            cute.struct.MemRange[Float32, cute.round_up(self.tile_m, 64) * self.Q_stage], 128
+        ]
+        sdPsum_struct = cute.struct.Align[
+            cute.struct.MemRange[Float32, cute.round_up(self.tile_m, 64) * self.dO_stage], 128
+        ]
+
+        @cute.struct
+        class SharedStorageQKV:
+            mbar_ptr_Q: cute.struct.MemRange[cutlass.Int64, self.Q_stage * 2]
+            mbar_ptr_dO: cute.struct.MemRange[cutlass.Int64, self.dO_stage * 2]
+            sLSE: sLSE_struct
+            sdPsum: sdPsum_struct
+            sQ: sQ_struct
+            sV: sV_struct
+            sK: sK_struct
+            sdO: sdO_struct
+            sP: cute.struct.Align[cute.struct.MemRange[self.dtype, cosize_sP], 1024]
+            sdS: cute.struct.Align[cute.struct.MemRange[self.dtype, cosize_sdS], 1024]
+            sdQaccum: sdQaccum_struct
+
+        return SharedStorageQKV
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mdO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mdPsum: cute.Tensor,
+        mdQaccum: cute.Tensor,
+        mdK: cute.Tensor,
+        mdV: cute.Tensor,
+        softmax_scale: Float32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        mSeqUsedQ: Optional[cute.Tensor] = None,
+        mSeqUsedK: Optional[cute.Tensor] = None,
+        window_size_left: Int32 | int | None = None,
+        window_size_right: Int32 | int | None = None,
+        mdQ_semaphore: Optional[cute.Tensor] = None,
+        mdK_semaphore: Optional[cute.Tensor] = None,
+        mdV_semaphore: Optional[cute.Tensor] = None,
+        aux_data: AuxData = AuxData(),
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
+        stream: cuda.CUstream = None,
+    ):
+        # For GQA (qhead_per_kvhead > 1), multiple Q heads accumulate into the same dK/dV,
+        # so we need the float32 accum path + postprocess.
+        # For varlen_k with qhead_per_kvhead == 1, we use ragged TMA tensors.
+        self.varlen_k = mCuSeqlensK is not None or mSeqUsedK is not None
+
+        self._check_type(
+            *(
+                t.element_type if t is not None else None
+                for t in (mQ, mK, mV, mdO, mLSE, mdPsum, mdQaccum, mdK, mdV)
+            )
+        )
+
+        self.is_varlen_q = mCuSeqlensQ is not None or mSeqUsedQ is not None
+
+        mQ, mK, mV, mdO, mLSE, mdPsum, mdQaccum, mdK, mdV = [
+            assume_tensor_aligned(t) for t in (mQ, mK, mV, mdO, mLSE, mdPsum, mdQaccum, mdK, mdV)
+        ]
+
+        # Non-varlen inputs are (b, s, n, h), varlen inputs are (s, n, h).
+        # We convert both to a seqlen-major view with head-dim second.
+        # Each tensor may have different rank when Q is padded (seqused_q) but K/V are unpadded (cu_seqlens_k).
+        def _qkv_transpose(t):
+            return layout_utils.select(t, [1, 3, 2, 0] if cute.rank(t.shape) == 4 else [0, 2, 1])
+
+        mQ, mK, mV, mdO = [_qkv_transpose(t) for t in (mQ, mK, mV, mdO)]
+        if const_expr(self.qhead_per_kvhead == 1):
+            mdK, mdV = [_qkv_transpose(t) for t in (mdK, mdV)]
+        else:
+            # Accum tensors are (b, n, s*h) for non-varlen and (n, s*h) for varlen.
+            accum_transpose = [2, 1, 0] if cute.rank(mdK.shape) == 3 else [1, 0]
+            mdK, mdV = [layout_utils.select(t, accum_transpose) for t in (mdK, mdV)]
+        # Non-varlen stats are (b, n, s), varlen stats are (n, s).
+        LSE_dPsum_dQaccum_transpose = [2, 1, 0] if cute.rank(mLSE.shape) == 3 else [1, 0]
+        mLSE, mdPsum, mdQaccum = [
+            layout_utils.select(t, LSE_dPsum_dQaccum_transpose) for t in (mLSE, mdPsum, mdQaccum)
+        ]
+
+        tiled_mma_SdP, tiled_mma_dK, tiled_mma_dV, tiled_mma_dQ = self._get_tiled_mma()
+        # (batch, num_head, num_m_blocks, cluster_size) -> (num_m_blocks, cluster_size, num_head, batch)
+        if const_expr(self.deterministic):
+            assert mdQ_semaphore is not None
+            mdQ_semaphore = layout_utils.select(mdQ_semaphore, mode=[2, 3, 1, 0])
+        if const_expr(self.deterministic and self.qhead_per_kvhead > 1):
+            assert mdK_semaphore is not None
+            assert mdV_semaphore is not None
+            mdK_semaphore, mdV_semaphore = [
+                layout_utils.select(t, mode=[2, 3, 1, 0]) for t in (mdK_semaphore, mdV_semaphore)
+            ]
+        else:
+            mdK_semaphore = None
+            mdV_semaphore = None
+
+        self.num_mma_threads = tiled_mma_SdP.size
+        assert self.num_mma_threads + 128 == self.num_threads
+
+        self.num_threads_per_warp_group = 128
+        self.num_producer_threads = 32
+
+        REG_LIMIT = 504 if self.num_wg_mma == 2 else 512
+        if const_expr(self.num_wg_mma == 2):
+            if const_expr(self.num_wg_dQ == 1):
+                self.num_mma_regs_wg0 = 256
+                self.num_mma_regs_wg1 = 224
+            else:
+                self.num_mma_regs_wg0 = 240
+                self.num_mma_regs_wg1 = 240
+            self.num_mma_regs = self.num_mma_regs_wg0  # for backward compat
+            self.num_producer_regs = 24
+            assert (
+                self.num_mma_regs_wg0 + self.num_mma_regs_wg1 + self.num_producer_regs <= REG_LIMIT
+            )
+        else:  # 3 warp groups
+            self.num_mma_regs_wg0 = 160
+            self.num_mma_regs_wg1 = 160
+            self.num_mma_regs = 160
+            self.num_producer_regs = 32
+            assert self.num_mma_regs_wg0 * self.num_wg_mma + self.num_producer_regs <= REG_LIMIT
+
+        self._setup_attributes()
+        SharedStorage = self._get_shared_storage_cls()
+
+        self.tma_copy_bytes = {
+            name: cute.size_in_bytes(mX.element_type, cute.select(layout, mode=[0, 1]))
+            for name, mX, layout in [
+                ("Q", mQ, self.sQ_layout),
+                ("K", mK, self.sK_layout),
+                ("V", mV, self.sV_layout),
+                ("dO", mdO, self.sdO_layout),
+            ]
+        }
+        self.tma_copy_bytes["LSE"] = self.tile_m * Float32.width // 8
+        self.tma_copy_bytes["dPsum"] = self.tile_m * Float32.width // 8
+        self.tma_copy_bytes["dQ"] = (
+            self.tile_m * self.tile_hdim * Float32.width // 8 // self.num_wg_dQ
+        )
+        self.tma_copy_bytes["dKacc"] = self.tile_n * self.tile_hdim * Float32.width // 8
+        self.tma_copy_bytes["dVacc"] = self.tile_n * self.tile_hdim * Float32.width // 8
+
+        tma_atom_Q, tma_tensor_Q = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            mQ,
+            cute.select(self.sQ_layout, mode=[0, 1]),
+            (self.tile_m, self.tile_hdim),
+        )
+        tma_atom_K, tma_tensor_K = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            mK,
+            cute.select(self.sK_layout, mode=[0, 1]),
+            (self.tile_n, self.tile_hdim),
+        )
+        tma_atom_V, tma_tensor_V = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            mV,
+            cute.select(self.sV_layout, mode=[0, 1]),
+            (self.tile_n, self.tile_hdim),
+        )
+        tma_atom_dO, tma_tensor_dO = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            mdO,
+            cute.select(self.sdO_layout, mode=[0, 1]),
+            (self.tile_m, self.tile_hdim),
+        )
+        if const_expr(self.qhead_per_kvhead == 1):
+            mdK_tma = (
+                copy_utils.create_ragged_tensor_for_tma(mdK, ragged_dim=0, ptr_shift=True)
+                if self.varlen_k
+                else mdK
+            )
+            mdV_tma = (
+                copy_utils.create_ragged_tensor_for_tma(mdV, ragged_dim=0, ptr_shift=True)
+                if self.varlen_k
+                else mdV
+            )
+            tma_atom_dK, tma_tensor_dK = cpasync.make_tiled_tma_atom(
+                cpasync.CopyBulkTensorTileS2GOp(),
+                mdK_tma,
+                cute.select(self.sK_layout, mode=[0, 1]),
+                (self.tile_n, self.tile_hdim),
+            )
+            tma_atom_dV, tma_tensor_dV = cpasync.make_tiled_tma_atom(
+                cpasync.CopyBulkTensorTileS2GOp(),
+                mdV_tma,
+                cute.select(self.sV_layout, mode=[0, 1]),
+                (self.tile_n, self.tile_hdim),
+            )
+        else:
+            tma_atom_dK = tma_atom_dV = tma_tensor_dK = tma_tensor_dV = None
+
+        if const_expr(mCuSeqlensK is not None or mSeqUsedK is not None):
+            TileScheduler = SingleTileVarlenScheduler
+        elif const_expr(self.deterministic):
+            TileScheduler = SingleTileLPTBwdScheduler
+        else:
+            TileScheduler = SingleTileScheduler
+        self.spt = (self.is_causal or self.is_local) and self.deterministic
+        tile_sched_args = TileSchedulerArguments(
+            cute.ceil_div(cute.size(mK.shape[0]), self.tile_n),
+            cute.size(mQ.shape[2]),
+            cute.size(mK.shape[3])
+            if const_expr(mCuSeqlensK is None)
+            else cute.size(mCuSeqlensK.shape[0] - 1),  # num_batch
+            1,  # num_splits
+            cute.size(mQ.shape[0]),  # pass seqlen_q or total_q for seqlen_k
+            mQ.shape[1],  # headdim
+            total_q=cute.size(mK.shape[0])
+            if const_expr(mCuSeqlensK is not None)
+            else cute.size(mK.shape[0]) * cute.size(mK.shape[3]),
+            tile_shape_mn=(self.tile_n, self.tile_m),  # Swapping the role of Q & K
+            mCuSeqlensQ=mCuSeqlensK,
+            mSeqUsedQ=mSeqUsedK,
+            qhead_per_kvhead_packgqa=1,
+            element_size=self.dtype.width // 8,
+            is_persistent=False,
+            lpt=self.spt,
+            head_swizzle=self.deterministic,
+        )
+
+        tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
+        grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
+
+        LOG2_E = math.log2(math.e)
+        if const_expr(self.score_mod is None):
+            softmax_scale_log2 = softmax_scale * LOG2_E
+        else:
+            softmax_scale_log2 = LOG2_E
+
+        fastdiv_mods = None
+        if const_expr(aux_data.tensors is not None):
+            seqlen_q = cute.size(mQ.shape[0])
+            seqlen_k = cute.size(mK.shape[0])
+            seqlen_q_divmod = FastDivmodDivisor(seqlen_q)
+            seqlen_k_divmod = FastDivmodDivisor(seqlen_k)
+            fastdiv_mods = (seqlen_q_divmod, seqlen_k_divmod)
+
+        qhead_per_kvhead_divmod = None
+        if const_expr(self.qhead_per_kvhead > 1):
+            qhead_per_kvhead_divmod = FastDivmodDivisor(self.qhead_per_kvhead)
+
+        self.use_block_sparsity = cutlass.const_expr(blocksparse_tensors is not None)
+
+        if const_expr(window_size_left is not None):
+            window_size_left = Int32(window_size_left)
+        if const_expr(window_size_right is not None):
+            window_size_right = Int32(window_size_right)
+
+        self.kernel(
+            tma_tensor_Q,
+            tma_tensor_K,
+            tma_tensor_V,
+            tma_tensor_dO,
+            tma_tensor_dK if const_expr(self.qhead_per_kvhead == 1) else mdK,
+            tma_tensor_dV if const_expr(self.qhead_per_kvhead == 1) else mdV,
+            tma_atom_Q,
+            tma_atom_K,
+            tma_atom_V,
+            tma_atom_dO,
+            tma_atom_dK,
+            tma_atom_dV,
+            mLSE,
+            mdPsum,
+            mdQaccum,
+            mCuSeqlensQ,
+            mCuSeqlensK,
+            mSeqUsedQ,
+            mSeqUsedK,
+            self.sQ_layout,
+            self.sK_layout,
+            self.sV_layout,
+            self.sPdS_layout,
+            self.sdO_layout,
+            self.sdQaccum_layout,
+            self.r2s_tiled_copy_dQaccum,
+            tiled_mma_SdP,
+            tiled_mma_dK,
+            tiled_mma_dV,
+            tiled_mma_dQ,
+            softmax_scale_log2,
+            softmax_scale,
+            tile_sched_params,
+            TileScheduler,
+            SharedStorage,
+            aux_data,
+            fastdiv_mods,
+            blocksparse_tensors,
+            qhead_per_kvhead_divmod,
+            mdQ_semaphore,
+            mdK_semaphore,
+            mdV_semaphore,
+            window_size_left,
+            window_size_right,
+        ).launch(
+            grid=grid_dim,
+            block=[self.num_threads, 1, 1],
+            stream=stream,
+            min_blocks_per_mp=1,
+            use_pdl=True,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mdO: cute.Tensor,
+        mdK: cute.Tensor,
+        mdV: cute.Tensor,
+        tma_atom_Q: cute.CopyAtom,
+        tma_atom_K: cute.CopyAtom,
+        tma_atom_V: cute.CopyAtom,
+        tma_atom_dO: cute.CopyAtom,
+        tma_atom_dK: cute.CopyAtom,
+        tma_atom_dV: cute.CopyAtom,
+        mLSE: cute.Tensor,
+        mdPsum: cute.Tensor,
+        mdQaccum: cute.Tensor,
+        mCuSeqlensQ: Optional[cute.Tensor],
+        mCuSeqlensK: Optional[cute.Tensor],
+        mSeqUsedQ: Optional[cute.Tensor],
+        mSeqUsedK: Optional[cute.Tensor],
+        sQ_layout: cute.ComposedLayout,
+        sK_layout: cute.ComposedLayout,
+        sV_layout: cute.ComposedLayout,
+        sPdS_layout: cute.ComposedLayout,
+        sdO_layout: cute.ComposedLayout,
+        sdQaccum_layout: cute.Layout,
+        r2s_tiled_copy_dQaccum: cute.TiledCopy,
+        tiled_mma_SdP: cute.TiledMma,
+        tiled_mma_dK: cute.TiledMma,
+        tiled_mma_dV: cute.TiledMma,
+        tiled_mma_dQ: cute.TiledMma,
+        softmax_scale_log2,
+        softmax_scale,
+        tile_sched_params: ParamsBase,
+        TileScheduler: cutlass.Constexpr[Callable],
+        SharedStorage: cutlass.Constexpr[Callable],
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=(None, None),
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        qhead_per_kvhead_divmod: Optional[FastDivmodDivisor] = None,
+        mdQ_semaphore: Optional[cute.Tensor] = None,
+        mdK_semaphore: Optional[cute.Tensor] = None,
+        mdV_semaphore: Optional[cute.Tensor] = None,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ):
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        # prefetch TMA descriptors
+        if warp_idx == 0:
+            for atom in [tma_atom_Q, tma_atom_K, tma_atom_V, tma_atom_dO, tma_atom_dK, tma_atom_dV]:
+                if const_expr(atom is not None):
+                    cpasync.prefetch_descriptor(atom)
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+
+        pipeline_producer_group = cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread)
+        pipeline_consumer_group = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, self.num_mma_threads // cute.arch.WARP_SIZE
+        )
+        pipeline_Q = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.mbar_ptr_Q.data_ptr(),
+            num_stages=self.Q_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group,
+            tx_count=self.tma_copy_bytes["Q"] + self.tma_copy_bytes["LSE"],
+            defer_sync=True,
+        )
+        pipeline_dO = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.mbar_ptr_dO.data_ptr(),
+            num_stages=self.dO_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group,
+            tx_count=self.tma_copy_bytes["dO"] + self.tma_copy_bytes["dPsum"],
+            defer_sync=False,
+        )
+
+        sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
+        sdO = storage.sdO.get_tensor(sdO_layout.outer, swizzle=sdO_layout.inner)
+        sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
+        sV = storage.sV.get_tensor(sV_layout.outer, swizzle=sV_layout.inner)
+        sP = None
+        if const_expr(not self.mma_dkv_is_rs):
+            sP = storage.sP.get_tensor(sPdS_layout.outer, swizzle=sPdS_layout.inner)
+        sdS = storage.sdS.get_tensor(sPdS_layout.outer, swizzle=sPdS_layout.inner)
+        sLSE = storage.sLSE.get_tensor(
+            cute.make_layout(
+                (self.tile_m, self.Q_stage),
+                stride=(1, cute.round_up(self.tile_m, 64)),
+            )
+        )
+        sdPsum = storage.sdPsum.get_tensor(
+            cute.make_layout(
+                (self.tile_m, self.dO_stage),
+                stride=(1, cute.round_up(self.tile_m, 64)),
+            )
+        )
+        sdQaccum = storage.sdQaccum.get_tensor(sdQaccum_layout)
+
+        block_info = BlockInfo(
+            self.tile_m,
+            self.tile_n,
+            self.is_causal,
+            self.is_local,
+            False,  # is_split_kv
+            window_size_left,
+            window_size_right,
+            qhead_per_kvhead_packgqa=1,
+        )
+        SeqlenInfoCls = partial(
+            SeqlenInfoQK.create,
+            seqlen_q_static=mQ.shape[0],
+            seqlen_k_static=mK.shape[0],
+            mCuSeqlensQ=mCuSeqlensQ,
+            mCuSeqlensK=mCuSeqlensK,
+            mSeqUsedQ=mSeqUsedQ,
+            mSeqUsedK=mSeqUsedK,
+            tile_m=self.tile_m,
+            tile_n=self.tile_n,
+        )
+        AttentionMaskCls = partial(
+            AttentionMask,
+            self.tile_m,
+            self.tile_n,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+            swap_AB=self.SdP_swapAB,
+        )
+        TileSchedulerCls = partial(TileScheduler.create, tile_sched_params)
+
+        if warp_idx < 4:
+            cute.arch.setmaxregister_decrease(self.num_producer_regs)
+            if warp_idx == 0:
+                self.load(
+                    mQ,
+                    mK,
+                    mV,
+                    mdO,
+                    mLSE,
+                    mdPsum,
+                    sQ,
+                    sK,
+                    sV,
+                    sdO,
+                    sLSE,
+                    sdPsum,
+                    tma_atom_Q,
+                    tma_atom_K,
+                    tma_atom_V,
+                    tma_atom_dO,
+                    pipeline_Q,
+                    pipeline_dO,
+                    block_info,
+                    SeqlenInfoCls,
+                    TileSchedulerCls,
+                    blocksparse_tensors,
+                    qhead_per_kvhead_divmod,
+                )
+            if warp_idx == 1:
+                self.dQaccum_store(
+                    mdQaccum,
+                    sdQaccum,
+                    block_info,
+                    TileSchedulerCls,
+                    SeqlenInfoCls,
+                    blocksparse_tensors,
+                    mdQ_semaphore,
+                )
+        else:
+            tidx, _, _ = cute.arch.thread_idx()
+            tidx = tidx - 128
+            mma_args = (
+                tiled_mma_SdP,
+                tiled_mma_dK,
+                tiled_mma_dV,
+                tiled_mma_dQ,
+                mdK,
+                mdV,
+                mdK_semaphore,
+                mdV_semaphore,
+                mdQaccum,
+                sQ,
+                sK,
+                sV,
+                sdO,
+                sP,
+                sdS,
+                sLSE,
+                sdPsum,
+                sdQaccum,
+                pipeline_Q,
+                pipeline_dO,
+                tidx,
+                tma_atom_dK,
+                tma_atom_dV,
+                r2s_tiled_copy_dQaccum,
+                softmax_scale_log2,
+                softmax_scale,
+                block_info,
+                SeqlenInfoCls,
+                AttentionMaskCls,
+                TileSchedulerCls,
+                aux_data,
+                fastdiv_mods,
+                blocksparse_tensors,
+                qhead_per_kvhead_divmod,
+            )
+            if const_expr(self.num_wg_dQ == self.num_wg_mma):
+                # Both WGs compute dQ
+                cute.arch.setmaxregister_increase(self.num_mma_regs_wg0)
+                self.mma(*mma_args, is_dQ_wg=True)
+            else:
+                # WG0 computes dQ, WG1 skips it
+                warp_idx_in_mma = cute.arch.make_warp_uniform(cute.arch.warp_idx()) - 4
+                if warp_idx_in_mma < 4:
+                    cute.arch.setmaxregister_increase(self.num_mma_regs_wg0)
+                    self.mma(*mma_args, is_dQ_wg=True)
+                else:
+                    cute.arch.setmaxregister_increase(self.num_mma_regs_wg1)
+                    self.mma(*mma_args, is_dQ_wg=False)
+
+    @cute.jit
+    def load(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mdO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mdPsum: cute.Tensor,
+        sQ: cute.Tensor,
+        sK: cute.Tensor,
+        sV: cute.Tensor,
+        sdO: cute.Tensor,
+        sLSE: cute.Tensor,
+        sdPsum: cute.Tensor,
+        tma_atom_Q: cute.CopyAtom,
+        tma_atom_K: cute.CopyAtom,
+        tma_atom_V: cute.CopyAtom,
+        tma_atom_dO: cute.CopyAtom,
+        pipeline_Q: cutlass.pipeline.PipelineAsync,
+        pipeline_dO: cutlass.pipeline.PipelineAsync,
+        block_info: BlockInfo,
+        SeqlenInfoCls: Callable,
+        TileSchedulerCls: Callable,
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        qhead_per_kvhead_divmod: Optional[FastDivmodDivisor] = None,
+    ):
+        warp_idx_in_wg = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
+
+        if warp_idx_in_wg == 0:
+            producer_state_Q = cutlass.pipeline.make_pipeline_state(
+                cutlass.pipeline.PipelineUserType.Producer, self.Q_stage
+            )
+            producer_state_dO = cutlass.pipeline.make_pipeline_state(
+                cutlass.pipeline.PipelineUserType.Producer, self.dO_stage
+            )
+            tile_scheduler = TileSchedulerCls()
+            work_tile = tile_scheduler.initial_work_tile_info()
+            while work_tile.is_valid_tile:
+                n_block, head_idx, batch_idx, _ = work_tile.tile_idx
+                seqlen = SeqlenInfoCls(batch_idx)
+                head_idx_kv = (
+                    head_idx
+                    if const_expr(self.qhead_per_kvhead == 1)
+                    else head_idx // qhead_per_kvhead_divmod
+                )
+                mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[None, None, head_idx_kv]
+                mV_cur = seqlen.offset_batch_K(mV, batch_idx, dim=3)[None, None, head_idx_kv]
+                gK = cute.local_tile(mK_cur, (self.tile_n, self.tile_hdim), (n_block, 0))
+                gV = cute.local_tile(mV_cur, (self.tile_n, self.tile_hdim), (n_block, 0))
+
+                mQ_cur = seqlen.offset_batch_Q(mQ, batch_idx, dim=3)[None, None, head_idx]
+                mLSE_cur = seqlen.offset_batch_Q(mLSE, batch_idx, dim=2, padded=True)[
+                    None, head_idx
+                ]
+                mdO_cur = seqlen.offset_batch_Q(mdO, batch_idx, dim=3)[None, None, head_idx]
+                mdPsum_cur = seqlen.offset_batch_Q(mdPsum, batch_idx, dim=2, padded=True)[
+                    None, head_idx
+                ]
+                gQ = cute.local_tile(mQ_cur, (self.tile_m, self.tile_hdim), (None, 0))
+                gdO = cute.local_tile(mdO_cur, (self.tile_m, self.tile_hdim), (None, 0))
+                gLSE = cute.local_tile(mLSE_cur, (self.tile_m,), (None,))
+                gdPsum = cute.local_tile(mdPsum_cur, (self.tile_m,), (None,))
+
+                load_K, _, _ = copy_utils.tma_get_copy_fn(
+                    tma_atom_K, 0, cute.make_layout(1), gK, sK, single_stage=True
+                )
+                load_V, _, _ = copy_utils.tma_get_copy_fn(
+                    tma_atom_V, 0, cute.make_layout(1), gV, sV, single_stage=True
+                )
+                load_Q, _, _ = copy_utils.tma_get_copy_fn(
+                    tma_atom_Q, 0, cute.make_layout(1), gQ, sQ
+                )
+                load_Q = copy_utils.tma_producer_copy_fn(load_Q, pipeline_Q)
+                load_dO, _, _ = copy_utils.tma_get_copy_fn(
+                    tma_atom_dO, 0, cute.make_layout(1), gdO, sdO
+                )
+                load_dO = copy_utils.tma_producer_copy_fn(load_dO, pipeline_dO)
+                load_LSE = copy_utils.cpasync_bulk_get_copy_fn(gLSE, sLSE)
+                load_LSE = copy_utils.tma_producer_copy_fn(load_LSE, pipeline_Q)
+                load_dPsum = copy_utils.cpasync_bulk_get_copy_fn(gdPsum, sdPsum)
+                load_dPsum = copy_utils.tma_producer_copy_fn(load_dPsum, pipeline_dO)
+
+                m_block_min, m_block_max = block_info.get_m_block_min_max(seqlen, n_block)
+
+                if const_expr(not self.use_block_sparsity):
+                    total_m_block_cnt = m_block_max - m_block_min
+                    process_tile = (
+                        const_expr(not self.is_local and not self.is_varlen_q)
+                        or m_block_min < m_block_max
+                    )
+                else:
+                    total_m_block_cnt = get_total_q_block_count_bwd(
+                        blocksparse_tensors,
+                        batch_idx,
+                        head_idx,
+                        n_block,
+                        q_subtile_factor=self.q_subtile_factor,
+                        m_block_max=m_block_max,
+                    )
+                    process_tile = total_m_block_cnt > Int32(0)
+
+                if process_tile:
+                    if const_expr(not self.use_block_sparsity):
+                        first_m_block = m_block_min
+                        pipeline_Q.producer_acquire(
+                            producer_state_Q, extra_tx_count=self.tma_copy_bytes["K"]
+                        )
+                        load_K(tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q))
+                        load_Q(first_m_block, producer_state=producer_state_Q)
+                        # Wait for bwd preprocess to finish writing LSE and dPsum
+                        cute.arch.griddepcontrol_wait()
+                        load_LSE(first_m_block, producer_state=producer_state_Q)
+                        producer_state_dO_cur = (
+                            producer_state_dO
+                            if const_expr(self.Q_stage != self.dO_stage)
+                            else producer_state_Q
+                        )
+                        pipeline_dO.producer_acquire(
+                            producer_state_dO_cur, extra_tx_count=self.tma_copy_bytes["V"]
+                        )
+                        load_V(tma_bar_ptr=pipeline_dO.producer_get_barrier(producer_state_dO_cur))
+                        load_dO(first_m_block, producer_state=producer_state_dO_cur)
+                        load_dPsum(first_m_block, producer_state=producer_state_dO_cur)
+                        producer_state_Q.advance()
+                        producer_state_dO.advance()
+
+                        for m_block in cutlass.range(m_block_min + 1, m_block_max, unroll=1):
+                            pipeline_Q.producer_acquire(producer_state_Q)
+                            load_Q(m_block, producer_state=producer_state_Q)
+                            load_LSE(m_block, producer_state=producer_state_Q)
+                            producer_state_dO_cur = (
+                                producer_state_dO
+                                if const_expr(self.Q_stage != self.dO_stage)
+                                else producer_state_Q
+                            )
+                            pipeline_dO.producer_acquire(producer_state_dO_cur)
+                            load_dO(m_block, producer_state=producer_state_dO_cur)
+                            load_dPsum(m_block, producer_state=producer_state_dO_cur)
+                            producer_state_Q.advance()
+                            producer_state_dO.advance()
+                    else:
+                        producer_state_Q, producer_state_dO = produce_block_sparse_q_loads_bwd_sm90(
+                            blocksparse_tensors,
+                            batch_idx,
+                            head_idx,
+                            n_block,
+                            producer_state_Q,
+                            producer_state_dO,
+                            pipeline_Q,
+                            pipeline_dO,
+                            load_K,
+                            load_V,
+                            load_Q,
+                            load_dO,
+                            load_LSE,
+                            load_dPsum,
+                            self.tma_copy_bytes["K"],
+                            self.tma_copy_bytes["V"],
+                            Q_stage_eq_dO_stage=(self.Q_stage == self.dO_stage),
+                            q_subtile_factor=self.q_subtile_factor,
+                            m_block_max=m_block_max,
+                        )
+
+                tile_scheduler.prefetch_next_work()
+                tile_scheduler.advance_to_next_work()
+                work_tile = tile_scheduler.get_current_work()
+
+    @cute.jit
+    def apply_score_mod(
+        self,
+        acc_S: cute.Tensor,
+        thr_mma_SdP: cute.ThrMma,
+        batch_idx,
+        head_idx,
+        m_block,
+        n_block,
+        softmax_scale,
+        seqlen_info: SeqlenInfoQK,
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=(None, None),
+    ):
+        # [NOTE] SdP_swapAB: swapAB transposes the tile, so use (n, m) indexing
+        cS = cute.make_identity_tensor(
+            (self.tile_n, self.tile_m) if self.SdP_swapAB else (self.tile_m, self.tile_n)
+        )
+        cS = cute.domain_offset(
+            (n_block * self.tile_n, m_block * self.tile_m)
+            if self.SdP_swapAB
+            else (m_block * self.tile_m, n_block * self.tile_n),
+            cS,
+        )
+        tScS = thr_mma_SdP.partition_C(cS)
+
+        apply_score_mod_inner(
+            acc_S,
+            tScS,
+            self.score_mod,
+            batch_idx,
+            head_idx,
+            softmax_scale,
+            self.vec_size,
+            self.qk_acc_dtype,
+            aux_data,
+            fastdiv_mods,
+            seqlen_info,
+            constant_q_idx=None,
+            qhead_per_kvhead=self.qhead_per_kvhead,
+            transpose_indices=self.SdP_swapAB,
+        )
+
+    @cute.jit
+    def apply_score_mod_bwd(
+        self,
+        grad_tensor: cute.Tensor,
+        score_tensor: cute.Tensor,
+        thr_mma_SdP: cute.ThrMma,
+        batch_idx,
+        head_idx,
+        m_block,
+        n_block,
+        softmax_scale,
+        seqlen_info: SeqlenInfoQK,
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=(None, None),
+    ):
+        cS = cute.make_identity_tensor(
+            (self.tile_n, self.tile_m) if self.SdP_swapAB else (self.tile_m, self.tile_n)
+        )
+        cS = cute.domain_offset(
+            (n_block * self.tile_n, m_block * self.tile_m)
+            if self.SdP_swapAB
+            else (m_block * self.tile_m, n_block * self.tile_n),
+            cS,
+        )
+        tScS = thr_mma_SdP.partition_C(cS)
+
+        apply_score_mod_bwd_inner(
+            grad_tensor,
+            score_tensor,
+            tScS,
+            self.score_mod_bwd,
+            batch_idx,
+            head_idx,
+            softmax_scale,
+            self.vec_size,
+            self.qk_acc_dtype,
+            aux_data,
+            fastdiv_mods,
+            seqlen_info,
+            constant_q_idx=None,
+            qhead_per_kvhead=self.qhead_per_kvhead,
+            transpose_indices=self.SdP_swapAB,
+        )
+
+    @cute.jit
+    def mma(
+        self,
+        tiled_mma_SdP: cute.TiledMma,
+        tiled_mma_dK: cute.TiledMma,
+        tiled_mma_dV: cute.TiledMma,
+        tiled_mma_dQ: cute.TiledMma,
+        mdK: cute.Tensor,
+        mdV: cute.Tensor,
+        mdK_semaphore: Optional[cute.Tensor],
+        mdV_semaphore: Optional[cute.Tensor],
+        mdQaccum: cute.Tensor,
+        sQ: cute.Tensor,
+        sK: cute.Tensor,
+        sV: cute.Tensor,
+        sdO: cute.Tensor,
+        sP: Optional[cute.Tensor],
+        sdS: cute.Tensor,
+        sLSE: cute.Tensor,
+        sdPsum: cute.Tensor,
+        sdQaccum: cute.Tensor,
+        pipeline_Q: cutlass.pipeline.PipelineAsync,
+        pipeline_dO: cutlass.pipeline.PipelineAsync,
+        tidx: Int32,
+        tma_atom_dK: cute.CopyAtom,
+        tma_atom_dV: cute.CopyAtom,
+        r2s_tiled_copy_dQaccum: cute.TiledCopy,
+        softmax_scale_log2: Float32,
+        softmax_scale: Float32,
+        block_info: BlockInfo,
+        SeqlenInfoCls: Callable,
+        AttentionMaskCls: Callable,
+        TileSchedulerCls: Callable,
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=(None, None),
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        qhead_per_kvhead_divmod: Optional[FastDivmodDivisor] = None,
+        is_dQ_wg: cutlass.Constexpr[bool] = True,
+    ):
+        warp_group_idx = cute.arch.make_warp_uniform(tidx // self.num_threads_per_warp_group)
+        warp_group_thread_layout = cute.make_layout(
+            self.num_wg_mma, stride=self.num_threads_per_warp_group
+        )
+        thr_mma_SdP = tiled_mma_SdP.get_slice(tidx)
+        wg_mma_SdP = tiled_mma_SdP.get_slice(warp_group_thread_layout(warp_group_idx))
+        wg_mma_dK = tiled_mma_dK.get_slice(warp_group_thread_layout(warp_group_idx))
+        wg_mma_dV = tiled_mma_dV.get_slice(warp_group_thread_layout(warp_group_idx))
+        wg_mma_dQ = None
+        if const_expr(is_dQ_wg):
+            wg_idx_dQ = warp_group_idx if const_expr(self.num_wg_dQ > 1) else 0
+            wg_mma_dQ = tiled_mma_dQ.get_slice(warp_group_thread_layout(wg_idx_dQ))
+        # S = Q @ K.T
+        shape_mnk_S = (self.tile_m, self.tile_n, self.tile_hdim)
+        _, tSrQ, tSrK = sm90_utils.partition_fragment_ABC(
+            wg_mma_SdP, shape_mnk_S, sQ, sK, swap_AB=self.SdP_swapAB
+        )
+        mma_qk_fn = partial(
+            gemm_zero_init, tiled_mma_SdP, shape_mnk_S[:2], tSrQ, tSrK, swap_AB=self.SdP_swapAB
+        )
+        # dP = dO @ V.T
+        shape_mnk_dP = (self.tile_m, self.tile_n, self.tile_hdim)
+        _, tdPrdO, tdPrV = sm90_utils.partition_fragment_ABC(
+            wg_mma_SdP, shape_mnk_dP, sdO, sV, swap_AB=self.SdP_swapAB
+        )
+        mma_dov_fn = partial(
+            gemm_zero_init, tiled_mma_SdP, shape_mnk_dP[:2], tdPrdO, tdPrV, swap_AB=self.SdP_swapAB
+        )
+        # dV += P.T @ dO
+        sPt = layout_utils.transpose_view(sP) if sP is not None else None
+        sdOt = layout_utils.transpose_view(sdO)
+        shape_mnk_dV = (self.tile_n, self.tile_hdim, self.tile_m)
+        acc_dV, tdVrPt, tdVrdOt = sm90_utils.partition_fragment_ABC(
+            wg_mma_dV, shape_mnk_dV, sPt, sdOt, swap_AB=self.dKV_swapAB
+        )
+        if const_expr(not self.mma_dkv_is_rs):
+            mma_pdo_fn = partial(
+                gemm_w_idx, tiled_mma_dV, acc_dV, tdVrPt, tdVrdOt, swap_AB=self.dKV_swapAB
+            )
+        else:
+            mma_pdo_fn = partial(gemm_w_idx, tiled_mma_dV, acc_dV, tCrB=tdVrdOt)
+        # dK += dS.T @ Q
+        sdSt = layout_utils.transpose_view(sdS)
+        sQt = layout_utils.transpose_view(sQ)
+        shape_mnk_dK = (self.tile_n, self.tile_hdim, self.tile_m)
+        acc_dK, tdKrdSt, tdKrQt = sm90_utils.partition_fragment_ABC(
+            wg_mma_dK, shape_mnk_dK, sdSt, sQt, swap_AB=self.dKV_swapAB
+        )
+        if const_expr(not self.mma_dkv_is_rs):
+            mma_dsq_fn = partial(
+                gemm_w_idx, tiled_mma_dK, acc_dK, tdKrdSt, tdKrQt, swap_AB=self.dKV_swapAB
+            )
+        else:
+            mma_dsq_fn = partial(gemm_w_idx, tiled_mma_dK, acc_dK, tCrB=tdKrQt)
+        # dQ = dS @ K
+        sKt = layout_utils.transpose_view(sK)
+        shape_mnk_dQ = (self.tile_m, self.tile_hdim, self.tile_n)
+        mma_dsk_fn = None
+        if const_expr(is_dQ_wg):
+            _, tdQrdS, tdQrKt = sm90_utils.partition_fragment_ABC(
+                wg_mma_dQ, shape_mnk_dQ, sdS, sKt, swap_AB=self.dQ_swapAB
+            )
+            mma_dsk_fn = partial(
+                gemm_zero_init,
+                tiled_mma_dQ,
+                shape_mnk_dQ[:2],
+                tdQrdS,
+                tdQrKt,
+                swap_AB=self.dQ_swapAB,
+            )
+
+        # Smem copy atom tiling for P/dS R2S
+        copy_P_r2s = None
+        mms_PdS = self.tile_n // (self.num_wg_mma // self.AtomLayoutMSdP)
+        if const_expr(sP is not None):
+            sP_cpy = sP if const_expr(not self.SdP_swapAB) else sPt
+            copy_P_r2s, _, _ = copy_utils.get_smem_store_C(
+                tiled_mma_SdP,
+                sP_cpy,
+                tidx,
+                transpose=self.SdP_swapAB,
+                position_independent=True,
+                major_mode_size=mms_PdS,
+            )
+        sdS_cpy = sdS if const_expr(not self.SdP_swapAB) else sdSt
+        copy_dS_r2s, _, _ = copy_utils.get_smem_store_C(
+            tiled_mma_SdP,
+            sdS_cpy,
+            tidx,
+            transpose=self.SdP_swapAB,
+            position_independent=True,
+            major_mode_size=mms_PdS,
+        )
+
+        tLSEsLSE = layout_utils.mma_partition_C_vec(
+            sLSE, thr_mma_SdP, expand_shape=self.tile_n, is_colvec=not self.SdP_swapAB
+        )
+        tLSEsdPsum = layout_utils.mma_partition_C_vec(
+            sdPsum, thr_mma_SdP, expand_shape=self.tile_n, is_colvec=not self.SdP_swapAB
+        )
+        # When shuffle=True, rows are distributed across 8 quads (4 threads each) within a warp.
+        # Each thread loads only ceil(num_rows/8) values;
+        shfl_copy = copy_utils.tiled_copy_1d(sLSE.element_type, num_threads=8, num_copy_elems=2)
+        if const_expr(self.shuffle_LSE):
+            tLSEsLSE = shfl_copy.get_slice(cute.arch.lane_idx() // 4).partition_S(tLSEsLSE)
+            # ((2, 1), 1, 2) -> (((2, 1), 1), 2)
+            tLSEsLSE = cute.group_modes(tLSEsLSE, 0, 2)
+        if const_expr(self.shuffle_dPsum):
+            tLSEsdPsum = shfl_copy.get_slice(cute.arch.lane_idx() // 4).partition_S(tLSEsdPsum)
+            tLSEsdPsum = cute.group_modes(tLSEsdPsum, 0, 2)
+
+        tdQsdQaccum = None
+        if const_expr(is_dQ_wg):
+            smem_thr_copy_dQaccum = r2s_tiled_copy_dQaccum.get_slice(tidx)
+            tdQsdQaccum = smem_thr_copy_dQaccum.partition_D(sdQaccum)
+
+        PdS_barrier = cutlass.pipeline.NamedBarrier(
+            barrier_id=int(NamedBarrierBwd.PdS), num_threads=self.num_mma_threads
+        )
+        score_mod_fn = partial(
+            self.apply_score_mod,
+            thr_mma_SdP=thr_mma_SdP,
+            softmax_scale=softmax_scale,
+            aux_data=aux_data,
+            fastdiv_mods=fastdiv_mods,
+        )
+        score_mod_bwd_fn = partial(
+            self.apply_score_mod_bwd,
+            thr_mma_SdP=thr_mma_SdP,
+            softmax_scale=softmax_scale,
+            aux_data=aux_data,
+            fastdiv_mods=fastdiv_mods,
+        )
+
+        mma_one_m_block_all = partial(
+            self.mma_one_m_block,
+            warp_group_idx=warp_group_idx,
+            mma_qk_fn=mma_qk_fn,
+            mma_dov_fn=mma_dov_fn,
+            mma_pdo_fn=mma_pdo_fn,
+            mma_dsq_fn=mma_dsq_fn,
+            mma_dsk_fn=mma_dsk_fn,
+            copy_P_r2s=copy_P_r2s,
+            copy_dS_r2s=copy_dS_r2s,
+            pipeline_Q=pipeline_Q,
+            pipeline_dO=pipeline_dO,
+            tLSEsLSE=tLSEsLSE,
+            tLSEsdPsum=tLSEsdPsum,
+            tdQsdQaccum=tdQsdQaccum,
+            softmax_scale_log2=softmax_scale_log2,
+            PdS_barrier=PdS_barrier,
+            # acc_dV=acc_dV,
+            # acc_dK=acc_dK,
+            is_dQ_wg=is_dQ_wg,
+        )
+
+        consumer_state_Q = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.Q_stage
+        )
+        consumer_state_dO = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.dO_stage
+        )
+        tile_scheduler = TileSchedulerCls()
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            n_block, head_idx, batch_idx, _ = work_tile.tile_idx
+            seqlen = SeqlenInfoCls(batch_idx)
+            mask = AttentionMaskCls(seqlen)
+            score_mod_fn_cur = partial(
+                score_mod_fn,
+                batch_idx=batch_idx,
+                head_idx=head_idx,
+                n_block=n_block,
+                seqlen_info=seqlen,
+            )
+            score_mod_bwd_fn_cur = partial(
+                score_mod_bwd_fn,
+                batch_idx=batch_idx,
+                head_idx=head_idx,
+                n_block=n_block,
+                seqlen_info=seqlen,
+            )
+            m_block_min, m_block_max = block_info.get_m_block_min_max(seqlen, n_block)
+
+            if const_expr(not self.use_block_sparsity):
+                process_tile = (
+                    const_expr(not self.is_local and not self.is_varlen_q)
+                    or m_block_min < m_block_max
+                )
+            else:
+                total_m_block_cnt = get_total_q_block_count_bwd(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    n_block,
+                    q_subtile_factor=self.q_subtile_factor,
+                    m_block_max=m_block_max,
+                )
+                process_tile = total_m_block_cnt > Int32(0)
+
+            if process_tile:
+                if const_expr(not self.use_block_sparsity):
+                    mask_fn = partial(
+                        mask.apply_mask,
+                        batch_idx=batch_idx,
+                        head_idx=head_idx,
+                        n_block=n_block,
+                        thr_mma=thr_mma_SdP,
+                        mask_seqlen=True,
+                        mask_causal=self.is_causal,
+                        mask_local=self.is_local,
+                        mask_mod=self.mask_mod,
+                        aux_data=aux_data,
+                        fastdiv_mods=fastdiv_mods,
+                    )
+                    dKV_accumulate = False
+                    for m_block in cutlass.range(m_block_min, m_block_max, unroll=1):
+                        consumer_state_Q, consumer_state_dO = mma_one_m_block_all(
+                            m_block,
+                            consumer_state_Q,
+                            consumer_state_dO,
+                            mask_fn=mask_fn,
+                            score_mod_fn=score_mod_fn_cur,
+                            score_mod_bwd_fn=score_mod_bwd_fn_cur,
+                            dKV_accumulate=dKV_accumulate,
+                        )
+                        dKV_accumulate = True
+                else:
+                    consumer_state_Q, consumer_state_dO = consume_block_sparse_mma_bwd_sm90(
+                        blocksparse_tensors,
+                        batch_idx,
+                        head_idx,
+                        n_block,
+                        consumer_state_Q,
+                        consumer_state_dO,
+                        mma_one_m_block_all,
+                        mask,
+                        self.mask_mod,
+                        is_causal=self.is_causal,
+                        is_local=self.is_local,
+                        thr_mma_SdP=thr_mma_SdP,
+                        score_mod_fn=score_mod_fn_cur,
+                        score_mod_bwd_fn=score_mod_bwd_fn_cur,
+                        q_subtile_factor=self.q_subtile_factor,
+                        m_block_max=m_block_max,
+                        aux_data=aux_data,
+                        fastdiv_mods=fastdiv_mods,
+                    )
+
+                if const_expr(self.qhead_per_kvhead == 1):
+                    acc_dK.store(acc_dK.load() * softmax_scale)
+                self.epilogue_dKV(
+                    acc_dV,
+                    mdV,
+                    sV,
+                    acc_dK,
+                    mdK,
+                    sK,
+                    seqlen,
+                    tma_atom_dK,
+                    tma_atom_dV,
+                    tiled_mma_dK,
+                    tiled_mma_dV,
+                    tidx,
+                    n_block,
+                    head_idx,
+                    batch_idx,
+                    qhead_per_kvhead_divmod,
+                    mdK_semaphore,
+                    mdV_semaphore,
+                )
+            else:
+                # KV tile with zero Q blocks produces no dK/dV; write zeros.
+                if const_expr(self.use_block_sparsity or self.is_local or self.is_varlen_q):
+                    acc_dK.fill(0.0)
+                    acc_dV.fill(0.0)
+                    self.epilogue_dKV(
+                        acc_dV,
+                        mdV,
+                        sV,
+                        acc_dK,
+                        mdK,
+                        sK,
+                        seqlen,
+                        tma_atom_dK,
+                        tma_atom_dV,
+                        tiled_mma_dK,
+                        tiled_mma_dV,
+                        tidx,
+                        n_block,
+                        head_idx,
+                        batch_idx,
+                        qhead_per_kvhead_divmod,
+                        mdK_semaphore,
+                        mdV_semaphore,
+                    )
+
+            tile_scheduler.advance_to_next_work()
+            work_tile = tile_scheduler.get_current_work()
+
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        if warp_idx == 4:
+            cute.arch.cp_async_bulk_wait_group(0, read=True)
+
+    @staticmethod
+    @cute.jit
+    def _get_stat(tSrS: cute.Tensor, row: Int32, lane: Int32, shuffle: bool) -> Float32:
+        """Retrieve the statistic for a given accumulator row.
+
+        When shuffle=False, direct register indexing.
+        When shuffle=True, warp shuffle from the thread group that holds the value.
+        """
+        if const_expr(not shuffle):
+            return tSrS[row]
+        # tSrS: (((2, 1), 1), 1)), distributed across 8 threads in the warp
+        vecsize = cute.size(tSrS, mode=[0, 0])  # 2
+        idx0, off, idx1 = cute.idx2crd(row, (vecsize, 8, cute.shape(tSrS, mode=[0, 1])))
+        # register index: 0, 1, 0, 1, ..., 2, 3, 2, 3, ...
+        return utils.shuffle_sync(tSrS[idx0 + idx1 * vecsize], offset=off * 4 + (lane % 4))
+
+    @cute.jit
+    def mma_one_m_block(
+        self,
+        m_block: Int32,
+        consumer_state_Q: cutlass.pipeline.PipelineState | pipeline.PipelineStateSimple,
+        consumer_state_dO: cutlass.pipeline.PipelineState | pipeline.PipelineStateSimple,
+        warp_group_idx: Int32,
+        mma_qk_fn: Callable,
+        mma_dov_fn: Callable,
+        mma_pdo_fn: Callable,
+        mma_dsq_fn: Callable,
+        mma_dsk_fn: Callable,
+        copy_P_r2s: Optional[Callable],
+        copy_dS_r2s: Callable,
+        pipeline_Q: cutlass.pipeline.PipelineAsync,
+        pipeline_dO: cutlass.pipeline.PipelineAsync,
+        tLSEsLSE: cute.Tensor,
+        tLSEsdPsum: cute.Tensor,
+        tdQsdQaccum: Optional[cute.Tensor],
+        softmax_scale_log2: Float32,
+        PdS_barrier: cutlass.pipeline.NamedBarrier,
+        is_dQ_wg: cutlass.Constexpr[bool] = True,
+        mask_fn: Optional[Callable] = None,
+        score_mod_fn: Optional[Callable] = None,
+        score_mod_bwd_fn: Optional[Callable] = None,
+        dKV_accumulate: Boolean = True,
+    ):
+        consumer_state_dO_cur = (
+            consumer_state_Q if const_expr(self.Q_stage == self.dO_stage) else consumer_state_dO
+        )
+        smem_idx_Q = consumer_state_Q.index
+        smem_idx_dO = consumer_state_dO_cur.index if const_expr(self.dO_stage > 1) else 0
+        smem_idx_PdS = smem_idx_Q if const_expr(self.PdS_stage > 1) else 0
+        # (1) [GEMM 1] S = Q @ K^T
+        pipeline_Q.consumer_wait(consumer_state_Q, pipeline_Q.consumer_try_wait(consumer_state_Q))
+        acc_S = mma_qk_fn(A_idx=smem_idx_Q, wg_wait=-1)
+        # If shuffle_LSE, OOB reads are OK since sLSE is already padded
+        tLSErLSE = copy_utils.load_s2r(tLSEsLSE[None, smem_idx_Q])
+        # (2) [GEMM 2] dP = dO @ V.T
+        pipeline_dO.consumer_wait(
+            consumer_state_dO_cur, pipeline_dO.consumer_try_wait(consumer_state_dO_cur)
+        )
+        acc_dP = mma_dov_fn(A_idx=smem_idx_Q, wg_wait=1)
+
+        if const_expr(self.score_mod_bwd is not None):
+            acc_S_pre = cute.make_fragment_like(acc_S)
+            cute.autovec_copy(acc_S, acc_S_pre)
+
+        if const_expr(self.score_mod is not None):
+            score_mod_fn(acc_S, m_block=m_block)
+
+        # (3) [Pointwise 1] P = exp(S - LSE)
+        if cutlass.const_expr(mask_fn is not None):
+            mask_fn(acc_S, m_block=m_block)
+        acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S, transpose=self.SdP_swapAB)
+        lane_idx = cute.arch.lane_idx()
+        for r in cutlass.range_constexpr(cute.size(acc_S_mn, mode=[0])):
+            lse_val = self._get_stat(tLSErLSE, r, lane_idx, shuffle=self.shuffle_LSE)
+            for c in cutlass.range(cute.size(acc_S_mn, mode=[1]), unroll_full=True):
+                acc_S_mn[r, c] = cute.math.exp2(
+                    acc_S_mn[r, c] * softmax_scale_log2 - lse_val, fastmath=True
+                )
+        tLSErdPsum = copy_utils.load_s2r(tLSEsdPsum[None, smem_idx_dO])
+
+        # Convert P from f32 -> f16
+        tdVrP = utils.cvt_f16(layout_utils.reshape_acc_to_frgA(acc_S), self.dtype)
+        # R2S for P
+        if const_expr(not self.mma_dkv_is_rs):
+            # sync to ensure P has already been used in the previous iteration before overwriting
+            if const_expr(self.PdS_stage == 1):
+                PdS_barrier.arrive_and_wait()
+            copy_P_r2s(tdVrP, dst_idx=smem_idx_PdS)
+
+        # (4) [Pointwise 2] dS = P*(dP-dPsum)
+        warpgroup.wait_group(0)
+        acc_dP_mn = layout_utils.reshape_acc_to_mn(acc_dP, transpose=self.SdP_swapAB)
+        for r in cutlass.range_constexpr(cute.size(acc_dP_mn, mode=[0])):
+            dpsum_val = self._get_stat(tLSErdPsum, r, lane_idx, shuffle=self.shuffle_dPsum)
+            for c in cutlass.range(cute.size(acc_dP_mn, mode=[1]), unroll_full=True):
+                acc_dP_mn[r, c] = acc_S_mn[r, c] * (acc_dP_mn[r, c] - dpsum_val)
+
+        if const_expr(self.score_mod_bwd is not None):
+            score_mod_bwd_fn(acc_dP, acc_S_pre, m_block=m_block)
+
+        # Convert dS from f32 -> f16
+        tdKrdS = utils.cvt_f16(layout_utils.reshape_acc_to_frgA(acc_dP), self.dtype)
+
+        # If there's double buffering on dS, we don't need to sync here.
+        # Otherwise we might have WG1 writing to dS before WG2 is done reading from it during MmadQ.
+        # But because both WGs have to sync at the end of the loop and double buffering,
+        # this race condition is not possible.
+        # This sync is to ensure (1) P is written in case of !mma_dkv_is_rs and
+        # (2) dS is already read by the Mma in the previous iteration in case of mma_dkv_is_rs.
+        if const_expr(not self.mma_dkv_is_rs or (self.PdS_stage == 1 and self.mma_dkv_is_rs)):
+            cute.arch.fence_view_async_shared()
+            PdS_barrier.arrive_and_wait()
+
+        # R2S for dS
+        copy_dS_r2s(tdKrdS, dst_idx=smem_idx_PdS)
+
+        # (5) [GEMM 3] dV += P.T @ dO
+        if const_expr(not self.mma_dkv_is_rs):
+            mma_pdo_fn(
+                A_idx=smem_idx_PdS, B_idx=smem_idx_dO, zero_init=not dKV_accumulate, wg_wait=-1
+            )
+        else:
+            mma_pdo_fn(tCrA=tdVrP, B_idx=smem_idx_dO, zero_init=not dKV_accumulate, wg_wait=-1)
+
+        # smem fence to make sure sdS is written before it's read by WGMMA
+        cute.arch.fence_view_async_shared()
+        PdS_barrier.arrive_and_wait()
+
+        if const_expr(is_dQ_wg):
+            # (6) [GEMM 4] dQ = dS @ K
+            acc_dQ = mma_dsk_fn(A_idx=smem_idx_PdS, wg_wait=1)
+            pipeline_dO.consumer_release(consumer_state_dO_cur)  # release dO as dV mma is done
+
+            # (7) [GEMM 5] dK += dS.T @ Q
+            if const_expr(not self.mma_dkv_is_rs):
+                mma_dsq_fn(
+                    A_idx=smem_idx_PdS, B_idx=smem_idx_Q, zero_init=not dKV_accumulate, wg_wait=1
+                )
+            else:
+                mma_dsq_fn(tCrA=tdKrdS, B_idx=smem_idx_Q, zero_init=not dKV_accumulate, wg_wait=1)
+
+            # dQ R2S: wait for dQaccum_store to free the smem buffer, then write dQ to smem
+            # When dQ_single_wg, only WG0 enters here so warp_group_idx == 0
+            cute.arch.barrier(
+                barrier_id=int(NamedBarrierBwd.dQEmptyWG0) + warp_group_idx,
+                number_of_threads=self.num_threads_per_warp_group + cute.arch.WARP_SIZE,
+            )
+            tdQrdQaccum_flat = cute.make_tensor(
+                acc_dQ.iterator, cute.make_layout(tdQsdQaccum.shape)
+            )
+            cute.autovec_copy(tdQrdQaccum_flat, tdQsdQaccum)
+            cute.arch.fence_view_async_shared()
+            cute.arch.barrier_arrive(
+                barrier_id=int(NamedBarrierBwd.dQFullWG0) + warp_group_idx,
+                number_of_threads=self.num_threads_per_warp_group + cute.arch.WARP_SIZE,
+            )
+
+            warpgroup.wait_group(0)
+            pipeline_Q.consumer_release(consumer_state_Q)
+        else:
+            # dQ_single_wg: WG1 skips dQ, only does dV wait + dK
+            # (7) [GEMM 5] dK += dS.T @ Q
+            if const_expr(not self.mma_dkv_is_rs):
+                mma_dsq_fn(
+                    A_idx=smem_idx_PdS, B_idx=smem_idx_Q, zero_init=not dKV_accumulate, wg_wait=1
+                )
+            else:
+                mma_dsq_fn(tCrA=tdKrdS, B_idx=smem_idx_Q, zero_init=not dKV_accumulate, wg_wait=1)
+            pipeline_dO.consumer_release(consumer_state_dO_cur)
+            warpgroup.wait_group(0)
+            pipeline_Q.consumer_release(consumer_state_Q)
+
+        consumer_state_Q.advance()
+        consumer_state_dO.advance()
+        return consumer_state_Q, consumer_state_dO
+
+    @cute.jit
+    def epilogue_dKV(
+        self,
+        acc_dV: cute.Tensor,
+        mdV: cute.Tensor,
+        sV: cute.Tensor,
+        acc_dK: cute.Tensor,
+        mdK: cute.Tensor,
+        sK: cute.Tensor,
+        seqlen: SeqlenInfoQK,
+        tma_atom_dK: cute.CopyAtom,
+        tma_atom_dV: cute.CopyAtom,
+        tiled_mma_dK: cute.TiledMma,
+        tiled_mma_dV: cute.TiledMma,
+        tidx: Int32,
+        n_block: Int32,
+        head_idx: Int32,
+        batch_idx: Int32,
+        qhead_per_kvhead_divmod: Optional[FastDivmodDivisor] = None,
+        mdK_semaphore: Optional[cute.Tensor] = None,
+        mdV_semaphore: Optional[cute.Tensor] = None,
+    ):
+        epi_barrier = cutlass.pipeline.NamedBarrier(
+            barrier_id=int(NamedBarrierBwd.Epilogue), num_threads=self.num_mma_threads
+        )
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        if const_expr(self.qhead_per_kvhead == 1):
+            mdK_cur = seqlen.offset_batch_K(mdK, batch_idx, dim=3, ragged=self.varlen_k)[
+                None, None, head_idx
+            ]
+            mdV_cur = seqlen.offset_batch_K(mdV, batch_idx, dim=3, ragged=self.varlen_k)[
+                None, None, head_idx
+            ]
+            gdK = cute.local_tile(mdK_cur, (self.tile_n, self.tile_hdim), (n_block, 0))
+            gdV = cute.local_tile(mdV_cur, (self.tile_n, self.tile_hdim), (n_block, 0))
+            store_dK, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_dK, 0, cute.make_layout(1), sK, gdK, single_stage=True
+            )
+            store_dV, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_dV, 0, cute.make_layout(1), sV, gdV, single_stage=True
+            )
+            sdV = sV if const_expr(not self.dKV_swapAB) else layout_utils.transpose_view(sV)
+            sdK = sK if const_expr(not self.dKV_swapAB) else layout_utils.transpose_view(sK)
+            copy_dV_r2s, _, _ = copy_utils.get_smem_store_C(
+                tiled_mma_dV,
+                sdV,
+                tidx,
+                transpose=self.dKV_swapAB,
+                position_independent=True,
+            )
+            copy_dK_r2s, _, _ = copy_utils.get_smem_store_C(
+                tiled_mma_dK,
+                sdK,
+                tidx,
+                transpose=self.dKV_swapAB,
+                position_independent=True,
+            )
+            cute.arch.cp_async_bulk_wait_group(1, read=True)
+            epi_barrier.arrive_and_wait()
+            copy_dV_r2s(acc_dV, dst_idx=None)
+            cute.arch.fence_view_async_shared()
+            epi_barrier.arrive_and_wait()
+            if warp_idx == 4:
+                store_dV()
+                cute.arch.cp_async_bulk_commit_group()
+            cute.arch.cp_async_bulk_wait_group(1, read=True)
+            epi_barrier.arrive_and_wait()
+            copy_dK_r2s(acc_dK, dst_idx=None)
+            cute.arch.fence_view_async_shared()
+            epi_barrier.arrive_and_wait()
+            if warp_idx == 4:
+                store_dK()
+                cute.arch.cp_async_bulk_commit_group()
+        else:
+            deterministic_KV = self.deterministic and self.qhead_per_kvhead > 1
+            sdKaccum_shape0 = self.tile_n * self.tile_hdim // self.num_wg_mma
+            sdVaccum_shape0 = self.tile_n * self.tile_hdim // self.num_wg_mma
+            sdKaccum_layout = cute.make_layout((sdKaccum_shape0, self.num_wg_mma))
+            sdVaccum_layout = cute.make_layout((sdVaccum_shape0, self.num_wg_mma))
+            head_idx_kv = head_idx // qhead_per_kvhead_divmod
+            if const_expr(deterministic_KV):
+                assert mdK_semaphore is not None
+                assert mdV_semaphore is not None
+                mdK_semaphore_cur = mdK_semaphore[n_block, None, head_idx_kv, batch_idx]
+                mdV_semaphore_cur = mdV_semaphore[n_block, None, head_idx_kv, batch_idx]
+                lock_value = head_idx % self.qhead_per_kvhead
+            mdKaccum_cur = seqlen.offset_batch_K(
+                mdK, batch_idx, dim=2, padded=True, multiple=self.tile_hdim
+            )[None, head_idx_kv]
+            mdVaccum_cur = seqlen.offset_batch_K(
+                mdV, batch_idx, dim=2, padded=True, multiple=self.tile_hdim
+            )[None, head_idx_kv]
+            gdKaccum_ = cute.local_tile(mdKaccum_cur, (self.tile_n * self.tile_hdim,), (n_block,))
+            gdKaccum = cute.flat_divide(gdKaccum_, (sdKaccum_shape0,))
+            gdVaccum_ = cute.local_tile(mdVaccum_cur, (self.tile_n * self.tile_hdim,), (n_block,))
+            gdVaccum = cute.flat_divide(gdVaccum_, (sdVaccum_shape0,))
+            # These two overlap each other
+            sVaccum_ptr = cute.recast_ptr(sV.iterator, dtype=Float32)
+            sdKaccum = cute.make_tensor(sVaccum_ptr, sdKaccum_layout)
+            sdVaccum = cute.make_tensor(sVaccum_ptr, sdVaccum_layout)
+            tiled_copy_dKVaccum_r2s = cute.make_tiled_copy_tv(
+                cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), Float32, num_bits_per_copy=128),
+                cute.make_layout((self.num_threads_per_warp_group, self.num_wg_mma)),
+                cute.make_layout(128 // Float32.width),
+            )
+            thr_copy_dKVaccum_r2s = tiled_copy_dKVaccum_r2s.get_slice(tidx)
+            tdKsdKaccum = thr_copy_dKVaccum_r2s.partition_D(sdKaccum)
+            tdVsdVaccum = thr_copy_dKVaccum_r2s.partition_D(sdVaccum)
+
+            read_flag = const_expr(not deterministic_KV)
+            cute.arch.cp_async_bulk_wait_group(0, read=read_flag)
+            if const_expr(deterministic_KV):
+                barrier.wait_eq(mdK_semaphore_cur.iterator, tidx, 0, lock_value)
+            epi_barrier.arrive_and_wait()
+            tdKrdKaccum_flat = cute.make_tensor(acc_dK.iterator, tdKsdKaccum.shape)
+            cute.autovec_copy(tdKrdKaccum_flat, tdKsdKaccum)
+            cute.arch.fence_view_async_shared()
+            epi_barrier.arrive_and_wait()
+            if warp_idx == 4:
+                with cute.arch.elect_one():
+                    for wg_idx in cutlass.range_constexpr(self.num_wg_mma):
+                        copy_utils.cpasync_reduce_bulk_add_f32(
+                            sdKaccum[None, wg_idx].iterator,
+                            gdKaccum[None, wg_idx].iterator,
+                            self.tma_copy_bytes["dKacc"] // self.num_wg_mma,
+                        )
+                cute.arch.cp_async_bulk_commit_group()
+
+            cute.arch.cp_async_bulk_wait_group(0, read=read_flag)
+            if const_expr(deterministic_KV):
+                barrier.arrive_inc(mdK_semaphore_cur.iterator, tidx, 0, 1)
+                barrier.wait_eq(mdV_semaphore_cur.iterator, tidx, 0, lock_value)
+            epi_barrier.arrive_and_wait()
+            tdVrdVaccum_flat = cute.make_tensor(acc_dV.iterator, tdVsdVaccum.shape)
+            cute.autovec_copy(tdVrdVaccum_flat, tdVsdVaccum)
+            cute.arch.fence_view_async_shared()
+            epi_barrier.arrive_and_wait()
+            if warp_idx == 4:
+                with cute.arch.elect_one():
+                    for wg_idx in cutlass.range_constexpr(self.num_wg_mma):
+                        copy_utils.cpasync_reduce_bulk_add_f32(
+                            sdVaccum[None, wg_idx].iterator,
+                            gdVaccum[None, wg_idx].iterator,
+                            self.tma_copy_bytes["dVacc"] // self.num_wg_mma,
+                        )
+                cute.arch.cp_async_bulk_commit_group()
+            if const_expr(deterministic_KV):
+                cute.arch.cp_async_bulk_wait_group(0, read=read_flag)
+                barrier.arrive_inc(mdV_semaphore_cur.iterator, tidx, 0, 1)
+
+    @cute.jit
+    def dQaccum_store(
+        self,
+        mdQaccum: cute.Tensor,
+        sdQaccum: cute.Tensor,
+        block_info: BlockInfo,
+        TileSchedulerCls: cutlass.Constexpr[Callable],
+        SeqlenInfoCls: cutlass.Constexpr[Callable],
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        mdQ_semaphore: Optional[cute.Tensor] = None,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        # warp-local thread index (dQaccum_store runs on warp 1, global tidx 32-63)
+        warp_local_tidx = tidx % cute.arch.WARP_SIZE
+        read_flag = const_expr(not self.deterministic)
+
+        tile_scheduler = TileSchedulerCls()
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            n_block, head_idx, batch_idx, _ = work_tile.tile_idx
+            seqlen = SeqlenInfoCls(batch_idx)
+            if const_expr(not seqlen.has_cu_seqlens_q):
+                mdQaccum_cur = mdQaccum[None, head_idx, batch_idx]
+            else:
+                mdQaccum_cur = cute.domain_offset(
+                    (seqlen.padded_offset_q * self.tile_hdim,), mdQaccum[None, head_idx]
+                )
+            # ((M * K / num_wg_dQ, num_wg_dQ), num_m_blocks)
+            gdQaccum = cute.local_tile(
+                mdQaccum_cur,
+                (
+                    cute.make_layout(
+                        (self.tile_m * self.tile_hdim // self.num_wg_dQ, self.num_wg_dQ)
+                    ),
+                ),
+                (None,),
+            )
+
+            if const_expr(mdQ_semaphore is not None):
+                # mdQ_semaphore is (num_m_blocks, cluster_size, num_head, batch) after transpose
+                mdQ_semaphore_cur = mdQ_semaphore[None, None, head_idx, batch_idx]
+
+            m_block_min, m_block_max = block_info.get_m_block_min_max(seqlen, n_block)
+            if const_expr(not self.use_block_sparsity):
+                process_tile = (
+                    const_expr(not self.is_local and not self.is_varlen_q)
+                    or m_block_min < m_block_max
+                )
+                loop_count = m_block_max - m_block_min
+            else:
+                total_block_cnt = get_total_q_block_count_bwd(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    n_block,
+                    q_subtile_factor=self.q_subtile_factor,
+                    m_block_max=m_block_max,
+                )
+                process_tile = total_block_cnt > Int32(0)
+
+            if process_tile:
+                if const_expr(not self.use_block_sparsity):
+                    for iter_idx in cutlass.range(loop_count, unroll=1):
+                        m_block = m_block_min + iter_idx
+                        m_block_safe = m_block
+
+                        num_dQ_chunks = self.num_wg_dQ
+                        for warp_group_idx in cutlass.range_constexpr(num_dQ_chunks):
+                            if const_expr(not self.deterministic):
+                                # If deterministic, we already waited at the end of the prev iter
+                                cute.arch.cp_async_bulk_wait_group(
+                                    num_dQ_chunks - 1 - warp_group_idx, read=read_flag
+                                )
+                            cute.arch.barrier_arrive(
+                                barrier_id=int(NamedBarrierBwd.dQEmptyWG0) + warp_group_idx,
+                                number_of_threads=self.num_threads_per_warp_group
+                                + cute.arch.WARP_SIZE,
+                            )
+
+                        # Semaphore acquire: wait for prior n_blocks to finish writing this m_block
+                        if const_expr(self.deterministic):
+                            if const_expr(self.spt):
+                                _, n_block_max_for_m_block = block_info.get_n_block_min_max(
+                                    seqlen, m_block_safe
+                                )
+                                lock_value = n_block_max_for_m_block - 1 - n_block
+                            else:
+                                lock_value = n_block
+                            barrier.wait_eq(
+                                mdQ_semaphore_cur[(m_block_safe, None)].iterator,
+                                warp_local_tidx,
+                                0,  # flag_offset
+                                lock_value,
+                            )
+
+                        for warp_group_idx in cutlass.range_constexpr(num_dQ_chunks):
+                            cute.arch.barrier(
+                                barrier_id=int(NamedBarrierBwd.dQFullWG0) + warp_group_idx,
+                                number_of_threads=self.num_threads_per_warp_group
+                                + cute.arch.WARP_SIZE,
+                            )
+                            with cute.arch.elect_one():
+                                copy_utils.cpasync_reduce_bulk_add_f32(
+                                    sdQaccum[None, warp_group_idx].iterator,
+                                    gdQaccum[(None, warp_group_idx), m_block_safe].iterator,
+                                    self.tma_copy_bytes["dQ"],
+                                )
+                            cute.arch.cp_async_bulk_commit_group()
+
+                        # Semaphore release: signal that this n_block is done with this m_block
+                        if const_expr(self.deterministic):
+                            cute.arch.cp_async_bulk_wait_group(0, read=read_flag)
+                            barrier.arrive_inc(
+                                mdQ_semaphore_cur[(m_block_safe, None)].iterator,
+                                warp_local_tidx,
+                                0,  # flag_offset
+                                1,
+                            )
+                else:
+                    assert not self.deterministic, (
+                        "Deterministic not implemented for block-sparse backward"
+                    )
+                    dQaccum_store_block_sparse_bwd_sm90(
+                        blocksparse_tensors,
+                        batch_idx,
+                        head_idx,
+                        n_block,
+                        sdQaccum,
+                        gdQaccum,
+                        q_subtile_factor=self.q_subtile_factor,
+                        m_block_max=m_block_max,
+                        num_dQ_warp_groups=self.num_wg_dQ,
+                        num_threads_per_warp_group=self.num_threads_per_warp_group,
+                        tma_copy_bytes_dQ=self.tma_copy_bytes["dQ"],
+                    )
+
+            # For local masking + deterministic (non-spt): signal remaining m_blocks
+            # that this n_block won't visit, so they don't deadlock waiting.
+            if const_expr(
+                self.deterministic and not self.spt and block_info.window_size_left is not None
+            ):
+                m_block_global_max = cute.ceil_div(seqlen.seqlen_q, self.tile_m)
+                for m_block in cutlass.range(m_block_max, m_block_global_max, unroll=1):
+                    barrier.arrive_inc(
+                        mdQ_semaphore_cur[(m_block, None)].iterator,
+                        warp_local_tidx,
+                        0,  # flag_offset
+                        1,
+                    )
+
+            tile_scheduler.advance_to_next_work()
+            work_tile = tile_scheduler.get_current_work()
+
+        if const_expr(not self.deterministic):
+            cute.arch.cp_async_bulk_wait_group(0, read=True)
+
+
+class FlashSparseAttentionBackwardSm90:
     arch = 90
 
     def __init__(

--- a/flash_sparse_attn/ops/cute/flash_bwd_sm90.py
+++ b/flash_sparse_attn/ops/cute/flash_bwd_sm90.py
@@ -1937,7 +1937,6 @@ class FlashSparseAttentionBackwardSm90:
         tile_m: int = 64,
         tile_n: int = 128,
         Q_stage: int = 2,
-        dO_stage: int = 2,
         PdS_stage: int = 2,
         SdP_swapAB: bool = False,
         dKV_swapAB: bool = False,
@@ -1968,9 +1967,7 @@ class FlashSparseAttentionBackwardSm90:
         self.tile_n = tile_n
         self.num_threads = num_threads
         self.Q_stage = Q_stage
-        self.dO_stage = dO_stage
         self.PdS_stage = PdS_stage
-        assert self.dO_stage in [1, self.Q_stage]
         assert self.PdS_stage in [1, self.Q_stage]
         self.SdP_swapAB = SdP_swapAB
         self.dKV_swapAB = dKV_swapAB
@@ -2085,7 +2082,7 @@ class FlashSparseAttentionBackwardSm90:
             )
             for shape, stage, mms in [
                 ((self.tile_m, self.tile_hdim), self.Q_stage, self.tile_hdim // wg_d_dKV),
-                ((self.tile_m, self.tile_hdim), self.dO_stage, self.tile_hdim // wg_d_dKV),
+                ((self.tile_m, self.tile_hdim), 1, self.tile_hdim // wg_d_dKV),
             ]
         ]
         wg_d_dQ = self.num_wg_dQ // self.AtomLayoutMdQ
@@ -2192,13 +2189,14 @@ class FlashSparseAttentionBackwardSm90:
             cute.struct.MemRange[Float32, cute.round_up(self.tile_m, 64) * self.Q_stage], 128
         ]
         sdPsum_struct = cute.struct.Align[
-            cute.struct.MemRange[Float32, cute.round_up(self.tile_m, 64) * self.dO_stage], 128
+            cute.struct.MemRange[Float32, cute.round_up(self.tile_m, 64)], 128
         ]
 
         @cute.struct
         class SharedStorageQKV:
             mbar_ptr_Q: cute.struct.MemRange[cutlass.Int64, self.Q_stage * 2]
-            mbar_ptr_dO: cute.struct.MemRange[cutlass.Int64, self.dO_stage * 2]
+            mbar_ptr_dO: cute.struct.MemRange[cutlass.Int64, 2]
+            sdQSkip: cute.struct.MemRange[Int32, self.num_wg_dQ]
             sLSE: sLSE_struct
             sdPsum: sdPsum_struct
             sQ: sQ_struct
@@ -2491,6 +2489,7 @@ class FlashSparseAttentionBackwardSm90:
             mdK_semaphore,
             mdV_semaphore,
             mWindowSizes,
+            softmax_threshold,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -2545,6 +2544,7 @@ class FlashSparseAttentionBackwardSm90:
         mdK_semaphore: Optional[cute.Tensor] = None,
         mdV_semaphore: Optional[cute.Tensor] = None,
         mWindowSizes: Optional[cute.Tensor] = None,
+        softmax_threshold: Float32 = 0.0,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
 
@@ -2556,6 +2556,7 @@ class FlashSparseAttentionBackwardSm90:
 
         smem = cutlass.utils.SmemAllocator()
         storage = smem.allocate(SharedStorage)
+        sdOLoadSkip = storage.sdS.get_tensor(cute.make_layout(2), dtype=Int32)
 
         pipeline_producer_group = cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread)
         pipeline_consumer_group = cutlass.pipeline.CooperativeGroup(
@@ -2571,11 +2572,16 @@ class FlashSparseAttentionBackwardSm90:
         )
         pipeline_dO = pipeline.PipelineTmaAsync.create(
             barrier_storage=storage.mbar_ptr_dO.data_ptr(),
-            num_stages=self.dO_stage,
+            num_stages=1,
             producer_group=pipeline_producer_group,
             consumer_group=pipeline_consumer_group,
             tx_count=self.tma_copy_bytes["dO"] + self.tma_copy_bytes["dPsum"],
             defer_sync=False,
+            sSkip=sdOLoadSkip if const_expr(not self.use_block_sparsity) else None,
+            barrier_full_id=int(NamedBarrierBwd.dOLoadFull),
+            barrier_empty_id=int(NamedBarrierBwd.dOLoadEmpty),
+            skip_num_threads=self.num_mma_threads + cute.arch.WARP_SIZE,
+            producer_skip_idx=1,
         )
 
         sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
@@ -2594,11 +2600,16 @@ class FlashSparseAttentionBackwardSm90:
         )
         sdPsum = storage.sdPsum.get_tensor(
             cute.make_layout(
-                (self.tile_m, self.dO_stage),
+                (self.tile_m, 1),
                 stride=(1, cute.round_up(self.tile_m, 64)),
             )
         )
         sdQaccum = storage.sdQaccum.get_tensor(sdQaccum_layout)
+        sdQSkip = storage.sdQSkip.get_tensor(cute.make_layout(self.num_wg_dQ))
+        sSkip = storage.sdS.get_tensor(
+            cute.make_layout((self.num_mma_threads // cute.arch.WARP_SIZE,)),
+            dtype=Float32,
+        )
 
         TileSchedulerCls = partial(TileScheduler.create, tile_sched_params)
         tile_scheduler = TileSchedulerCls()
@@ -2670,6 +2681,7 @@ class FlashSparseAttentionBackwardSm90:
                     tma_atom_dO,
                     pipeline_Q,
                     pipeline_dO,
+                    sdOLoadSkip,
                     block_info,
                     SeqlenInfoCls,
                     TileSchedulerCls,
@@ -2680,6 +2692,7 @@ class FlashSparseAttentionBackwardSm90:
                 self.dQaccum_store(
                     mdQaccum,
                     sdQaccum,
+                    sdQSkip,
                     block_info,
                     TileSchedulerCls,
                     SeqlenInfoCls,
@@ -2724,6 +2737,10 @@ class FlashSparseAttentionBackwardSm90:
                 fastdiv_mods,
                 blocksparse_tensors,
                 qhead_per_kvhead_divmod,
+                sdOLoadSkip,
+                sdQSkip,
+                sSkip,
+                softmax_threshold,
             )
             if const_expr(self.num_wg_dQ == self.num_wg_mma):
                 # Both WGs compute dQ
@@ -2760,6 +2777,7 @@ class FlashSparseAttentionBackwardSm90:
         tma_atom_dO: cute.CopyAtom,
         pipeline_Q: cutlass.pipeline.PipelineAsync,
         pipeline_dO: cutlass.pipeline.PipelineAsync,
+        sdOLoadSkip: cute.Tensor,
         block_info: BlockInfo,
         SeqlenInfoCls: Callable,
         TileSchedulerCls: Callable,
@@ -2773,7 +2791,7 @@ class FlashSparseAttentionBackwardSm90:
                 cutlass.pipeline.PipelineUserType.Producer, self.Q_stage
             )
             producer_state_dO = cutlass.pipeline.make_pipeline_state(
-                cutlass.pipeline.PipelineUserType.Producer, self.dO_stage
+                cutlass.pipeline.PipelineUserType.Producer, 1
             )
             tile_scheduler = TileSchedulerCls()
             work_tile = tile_scheduler.initial_work_tile_info()
@@ -2863,24 +2881,19 @@ class FlashSparseAttentionBackwardSm90:
                                     first_m_block = m_block_sink_min
                                     m_block_sink_min += 1
                         pipeline_Q.producer_acquire(
-                            producer_state_Q, extra_tx_count=self.tma_copy_bytes["K"]
+                            producer_state_Q,
+                            extra_tx_count=(self.tma_copy_bytes["K"] + self.tma_copy_bytes["V"]),
                         )
                         load_K(tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q))
+                        load_V(tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q))
                         load_Q(first_m_block, producer_state=producer_state_Q)
                         # Wait for bwd preprocess to finish writing LSE and dPsum
                         cute.arch.griddepcontrol_wait()
                         load_LSE(first_m_block, producer_state=producer_state_Q)
-                        producer_state_dO_cur = (
-                            producer_state_dO
-                            if const_expr(self.Q_stage != self.dO_stage)
-                            else producer_state_Q
-                        )
-                        pipeline_dO.producer_acquire(
-                            producer_state_dO_cur, extra_tx_count=self.tma_copy_bytes["V"]
-                        )
-                        load_V(tma_bar_ptr=pipeline_dO.producer_get_barrier(producer_state_dO_cur))
-                        load_dO(first_m_block, producer_state=producer_state_dO_cur)
-                        load_dPsum(first_m_block, producer_state=producer_state_dO_cur)
+                        pipeline_dO.producer_acquire(producer_state_dO)
+                        if sdOLoadSkip[1] == 0:
+                            load_dO(first_m_block, producer_state=producer_state_dO)
+                            load_dPsum(first_m_block, producer_state=producer_state_dO)
                         producer_state_Q.advance()
                         producer_state_dO.advance()
 
@@ -2888,14 +2901,10 @@ class FlashSparseAttentionBackwardSm90:
                             pipeline_Q.producer_acquire(producer_state_Q)
                             load_Q(m_block, producer_state=producer_state_Q)
                             load_LSE(m_block, producer_state=producer_state_Q)
-                            producer_state_dO_cur = (
-                                producer_state_dO
-                                if const_expr(self.Q_stage != self.dO_stage)
-                                else producer_state_Q
-                            )
-                            pipeline_dO.producer_acquire(producer_state_dO_cur)
-                            load_dO(m_block, producer_state=producer_state_dO_cur)
-                            load_dPsum(m_block, producer_state=producer_state_dO_cur)
+                            pipeline_dO.producer_acquire(producer_state_dO)
+                            if sdOLoadSkip[1] == 0:
+                                load_dO(m_block, producer_state=producer_state_dO)
+                                load_dPsum(m_block, producer_state=producer_state_dO)
                             producer_state_Q.advance()
                             producer_state_dO.advance()
 
@@ -2906,14 +2915,10 @@ class FlashSparseAttentionBackwardSm90:
                                 pipeline_Q.producer_acquire(producer_state_Q)
                                 load_Q(m_block, producer_state=producer_state_Q)
                                 load_LSE(m_block, producer_state=producer_state_Q)
-                                producer_state_dO_cur = (
-                                    producer_state_dO
-                                    if const_expr(self.Q_stage != self.dO_stage)
-                                    else producer_state_Q
-                                )
-                                pipeline_dO.producer_acquire(producer_state_dO_cur)
-                                load_dO(m_block, producer_state=producer_state_dO_cur)
-                                load_dPsum(m_block, producer_state=producer_state_dO_cur)
+                                pipeline_dO.producer_acquire(producer_state_dO)
+                                if sdOLoadSkip[1] == 0:
+                                    load_dO(m_block, producer_state=producer_state_dO)
+                                    load_dPsum(m_block, producer_state=producer_state_dO)
                                 producer_state_Q.advance()
                                 producer_state_dO.advance()
 
@@ -2923,14 +2928,10 @@ class FlashSparseAttentionBackwardSm90:
                                 pipeline_Q.producer_acquire(producer_state_Q)
                                 load_Q(m_block, producer_state=producer_state_Q)
                                 load_LSE(m_block, producer_state=producer_state_Q)
-                                producer_state_dO_cur = (
-                                    producer_state_dO
-                                    if const_expr(self.Q_stage != self.dO_stage)
-                                    else producer_state_Q
-                                )
-                                pipeline_dO.producer_acquire(producer_state_dO_cur)
-                                load_dO(m_block, producer_state=producer_state_dO_cur)
-                                load_dPsum(m_block, producer_state=producer_state_dO_cur)
+                                pipeline_dO.producer_acquire(producer_state_dO)
+                                if sdOLoadSkip[1] == 0:
+                                    load_dO(m_block, producer_state=producer_state_dO)
+                                    load_dPsum(m_block, producer_state=producer_state_dO)
                                 producer_state_Q.advance()
                                 producer_state_dO.advance()
                     else:
@@ -2951,7 +2952,7 @@ class FlashSparseAttentionBackwardSm90:
                             load_dPsum,
                             self.tma_copy_bytes["K"],
                             self.tma_copy_bytes["V"],
-                            Q_stage_eq_dO_stage=(self.Q_stage == self.dO_stage),
+                            Q_stage_eq_dO_stage=False,
                             q_subtile_factor=self.q_subtile_factor,
                             m_block_max=m_block_max,
                         )
@@ -3084,6 +3085,10 @@ class FlashSparseAttentionBackwardSm90:
         fastdiv_mods=(None, None),
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         qhead_per_kvhead_divmod: Optional[FastDivmodDivisor] = None,
+        sdOLoadSkip: Optional[cute.Tensor] = None,
+        sdQSkip: Optional[cute.Tensor] = None,
+        sSkip: Optional[cute.Tensor] = None,
+        softmax_threshold: Float32 = 0.0,
         is_dQ_wg: cutlass.Constexpr[bool] = True,
     ):
         warp_group_idx = cute.arch.make_warp_uniform(tidx // self.num_threads_per_warp_group)
@@ -3091,6 +3096,13 @@ class FlashSparseAttentionBackwardSm90:
             self.num_wg_mma, stride=self.num_threads_per_warp_group
         )
         thr_mma_SdP = tiled_mma_SdP.get_slice(tidx)
+        skip_fn = partial(
+            self.skip_softmax,
+            softmax_scale_log2=softmax_scale_log2,
+            softmax_threshold=softmax_threshold,
+            thr_mma=thr_mma_SdP,
+            sSkip=sSkip,
+        )
         wg_mma_SdP = tiled_mma_SdP.get_slice(warp_group_thread_layout(warp_group_idx))
         wg_mma_dK = tiled_mma_dK.get_slice(warp_group_thread_layout(warp_group_idx))
         wg_mma_dV = tiled_mma_dV.get_slice(warp_group_thread_layout(warp_group_idx))
@@ -3113,6 +3125,13 @@ class FlashSparseAttentionBackwardSm90:
         )
         mma_dov_fn = partial(
             gemm_zero_init, tiled_mma_SdP, shape_mnk_dP[:2], tdPrdO, tdPrV, swap_AB=self.SdP_swapAB
+        )
+        mma_dov_inplace_fn = partial(
+            gemm_w_idx,
+            tiled_mma_SdP,
+            tCrA=tdPrdO,
+            tCrB=tdPrV,
+            swap_AB=self.SdP_swapAB,
         )
         # dV += P.T @ dO
         sPt = layout_utils.transpose_view(sP) if sP is not None else None
@@ -3225,6 +3244,7 @@ class FlashSparseAttentionBackwardSm90:
             warp_group_idx=warp_group_idx,
             mma_qk_fn=mma_qk_fn,
             mma_dov_fn=mma_dov_fn,
+            mma_dov_inplace_fn=mma_dov_inplace_fn,
             mma_pdo_fn=mma_pdo_fn,
             mma_dsq_fn=mma_dsq_fn,
             mma_dsk_fn=mma_dsk_fn,
@@ -3235,6 +3255,8 @@ class FlashSparseAttentionBackwardSm90:
             tLSEsLSE=tLSEsLSE,
             tLSEsdPsum=tLSEsdPsum,
             tdQsdQaccum=tdQsdQaccum,
+            sdOLoadSkip=sdOLoadSkip,
+            sdQSkip=sdQSkip,
             softmax_scale_log2=softmax_scale_log2,
             PdS_barrier=PdS_barrier,
             # acc_dV=acc_dV,
@@ -3246,7 +3268,7 @@ class FlashSparseAttentionBackwardSm90:
             cutlass.pipeline.PipelineUserType.Consumer, self.Q_stage
         )
         consumer_state_dO = cutlass.pipeline.make_pipeline_state(
-            cutlass.pipeline.PipelineUserType.Consumer, self.dO_stage
+            cutlass.pipeline.PipelineUserType.Consumer, 1
         )
         tile_scheduler = TileSchedulerCls()
         work_tile = tile_scheduler.initial_work_tile_info()
@@ -3268,6 +3290,7 @@ class FlashSparseAttentionBackwardSm90:
                 n_block=n_block,
                 seqlen_info=seqlen,
             )
+            skip_fn_cur = partial(skip_fn, seqlen=seqlen)
             (
                 m_block_min,
                 m_block_max,
@@ -3308,9 +3331,9 @@ class FlashSparseAttentionBackwardSm90:
                         aux_data=aux_data,
                         fastdiv_mods=fastdiv_mods,
                     )
-                    dKV_accumulate = False
+                    dKV_accumulate = Boolean(False)
                     for m_block in cutlass.range(m_block_min, m_block_max, unroll=1):
-                        consumer_state_Q, consumer_state_dO = mma_one_m_block_all(
+                        consumer_state_Q, consumer_state_dO, is_skip = mma_one_m_block_all(
                             m_block,
                             consumer_state_Q,
                             consumer_state_dO,
@@ -3323,11 +3346,12 @@ class FlashSparseAttentionBackwardSm90:
                             ),
                             score_mod_fn=score_mod_fn_cur,
                             score_mod_bwd_fn=score_mod_bwd_fn_cur,
+                            skip_fn=skip_fn_cur,
                             dKV_accumulate=dKV_accumulate,
                         )
-                        dKV_accumulate = True
+                        dKV_accumulate = Boolean(dKV_accumulate or not is_skip)
                     for m_block in cutlass.range(m_block_window_min, m_block_window_max, unroll=1):
-                        consumer_state_Q, consumer_state_dO = mma_one_m_block_all(
+                        consumer_state_Q, consumer_state_dO, is_skip = mma_one_m_block_all(
                             m_block,
                             consumer_state_Q,
                             consumer_state_dO,
@@ -3340,11 +3364,12 @@ class FlashSparseAttentionBackwardSm90:
                             ),
                             score_mod_fn=score_mod_fn_cur,
                             score_mod_bwd_fn=score_mod_bwd_fn_cur,
+                            skip_fn=skip_fn_cur,
                             dKV_accumulate=dKV_accumulate,
                         )
-                        dKV_accumulate = True
+                        dKV_accumulate = Boolean(dKV_accumulate or not is_skip)
                     for m_block in cutlass.range(m_block_sink_min, m_block_sink_max, unroll=1):
-                        consumer_state_Q, consumer_state_dO = mma_one_m_block_all(
+                        consumer_state_Q, consumer_state_dO, is_skip = mma_one_m_block_all(
                             m_block,
                             consumer_state_Q,
                             consumer_state_dO,
@@ -3357,9 +3382,10 @@ class FlashSparseAttentionBackwardSm90:
                             ),
                             score_mod_fn=score_mod_fn_cur,
                             score_mod_bwd_fn=score_mod_bwd_fn_cur,
+                            skip_fn=skip_fn_cur,
                             dKV_accumulate=dKV_accumulate,
                         )
-                        dKV_accumulate = True
+                        dKV_accumulate = Boolean(dKV_accumulate or not is_skip)
                 else:
                     consumer_state_Q, consumer_state_dO = consume_block_sparse_mma_bwd_sm90(
                         blocksparse_tensors,
@@ -3382,6 +3408,10 @@ class FlashSparseAttentionBackwardSm90:
                         fastdiv_mods=fastdiv_mods,
                     )
 
+                if const_expr(not self.use_block_sparsity):
+                    if not dKV_accumulate:
+                        acc_dK.fill(0.0)
+                        acc_dV.fill(0.0)
                 if const_expr(self.qhead_per_kvhead == 1):
                     acc_dK.store(acc_dK.load() * softmax_scale)
                 self.epilogue_dKV(
@@ -3462,6 +3492,7 @@ class FlashSparseAttentionBackwardSm90:
         warp_group_idx: Int32,
         mma_qk_fn: Callable,
         mma_dov_fn: Callable,
+        mma_dov_inplace_fn: Callable,
         mma_pdo_fn: Callable,
         mma_dsq_fn: Callable,
         mma_dsk_fn: Callable,
@@ -3472,30 +3503,34 @@ class FlashSparseAttentionBackwardSm90:
         tLSEsLSE: cute.Tensor,
         tLSEsdPsum: cute.Tensor,
         tdQsdQaccum: Optional[cute.Tensor],
+        sdOLoadSkip: cute.Tensor,
+        sdQSkip: Optional[cute.Tensor],
         softmax_scale_log2: Float32,
         PdS_barrier: cutlass.pipeline.NamedBarrier,
         is_dQ_wg: cutlass.Constexpr[bool] = True,
         mask_fn: Optional[Callable] = None,
         score_mod_fn: Optional[Callable] = None,
         score_mod_bwd_fn: Optional[Callable] = None,
+        skip_fn: Optional[Callable] = None,
         dKV_accumulate: Boolean = True,
     ):
-        consumer_state_dO_cur = (
-            consumer_state_Q if const_expr(self.Q_stage == self.dO_stage) else consumer_state_dO
-        )
         smem_idx_Q = consumer_state_Q.index
-        smem_idx_dO = consumer_state_dO_cur.index if const_expr(self.dO_stage > 1) else 0
+        smem_idx_dO = 0
         smem_idx_PdS = smem_idx_Q if const_expr(self.PdS_stage > 1) else 0
         # (1) [GEMM 1] S = Q @ K^T
         pipeline_Q.consumer_wait(consumer_state_Q, pipeline_Q.consumer_try_wait(consumer_state_Q))
         acc_S = mma_qk_fn(A_idx=smem_idx_Q, wg_wait=-1)
         # If shuffle_LSE, OOB reads are OK since sLSE is already padded
         tLSErLSE = copy_utils.load_s2r(tLSEsLSE[None, smem_idx_Q])
-        # (2) [GEMM 2] dP = dO @ V.T
-        pipeline_dO.consumer_wait(
-            consumer_state_dO_cur, pipeline_dO.consumer_try_wait(consumer_state_dO_cur)
-        )
-        acc_dP = mma_dov_fn(A_idx=smem_idx_Q, wg_wait=1)
+        if const_expr(self.use_block_sparsity):
+            # (2) [GEMM 2] dP = dO @ V.T
+            pipeline_dO.consumer_wait(
+                consumer_state_dO, pipeline_dO.consumer_try_wait(consumer_state_dO)
+            )
+            acc_dP = mma_dov_fn(A_idx=smem_idx_Q, wg_wait=1)
+        else:
+            warpgroup.wait_group(0)
+            acc_dP = cute.make_fragment_like(acc_S)
 
         if const_expr(self.score_mod_bwd is not None):
             acc_S_pre = cute.make_fragment_like(acc_S)
@@ -3509,109 +3544,209 @@ class FlashSparseAttentionBackwardSm90:
             mask_fn(acc_S, m_block=m_block)
         acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S, transpose=self.SdP_swapAB)
         lane_idx = cute.arch.lane_idx()
-        for r in cutlass.range_constexpr(cute.size(acc_S_mn, mode=[0])):
-            lse_val = self._get_stat(tLSErLSE, r, lane_idx, shuffle=self.shuffle_LSE)
-            for c in cutlass.range(cute.size(acc_S_mn, mode=[1]), unroll_full=True):
-                acc_S_mn[r, c] = cute.math.exp2(
-                    acc_S_mn[r, c] * softmax_scale_log2 - lse_val, fastmath=True
+        is_skip = Boolean(False)
+        if const_expr(not self.use_block_sparsity):
+            cute.arch.barrier(
+                barrier_id=int(NamedBarrierBwd.Softmax),
+                number_of_threads=self.num_mma_threads,
+            )
+            is_skip = skip_fn(acc_S_mn, tLSErLSE, m_block)
+
+        if const_expr(not self.use_block_sparsity):
+            if cute.arch.thread_idx()[0] == self.num_threads_per_warp_group:
+                sdOLoadSkip[0] = Int32(is_skip)
+            cute.arch.fence_view_async_shared()
+            cute.arch.barrier(
+                barrier_id=int(NamedBarrierBwd.dOLoadFull),
+                number_of_threads=self.num_mma_threads + cute.arch.WARP_SIZE,
+            )
+            cute.arch.barrier(
+                barrier_id=int(NamedBarrierBwd.dOLoadEmpty),
+                number_of_threads=self.num_mma_threads + cute.arch.WARP_SIZE,
+            )
+            pipeline_dO.consumer_wait(
+                consumer_state_dO, pipeline_dO.consumer_try_wait(consumer_state_dO)
+            )
+
+        if is_skip:
+            pipeline_dO.consumer_release(consumer_state_dO)
+            if const_expr(is_dQ_wg):
+                cute.arch.barrier(
+                    barrier_id=int(NamedBarrierBwd.dQEmptyWG0) + warp_group_idx,
+                    number_of_threads=self.num_threads_per_warp_group + cute.arch.WARP_SIZE,
                 )
-        tLSErdPsum = copy_utils.load_s2r(tLSEsdPsum[None, smem_idx_dO])
+                if cute.arch.thread_idx()[0] == self.num_threads_per_warp_group * (
+                    warp_group_idx + 1
+                ):
+                    sdQSkip[warp_group_idx] = Int32(1)
+                cute.arch.fence_view_async_shared()
+                cute.arch.barrier_arrive(
+                    barrier_id=int(NamedBarrierBwd.dQFullWG0) + warp_group_idx,
+                    number_of_threads=self.num_threads_per_warp_group + cute.arch.WARP_SIZE,
+                )
+            pipeline_Q.consumer_release(consumer_state_Q)
+        else:
+            if const_expr(not self.use_block_sparsity):
+                # (2) [GEMM 2] dP = dO @ V.T
+                mma_dov_inplace_fn(acc_dP, zero_init=True, A_idx=smem_idx_Q, wg_wait=-1)
+            for r in cutlass.range_constexpr(cute.size(acc_S_mn, mode=[0])):
+                lse_val = self._get_stat(tLSErLSE, r, lane_idx, shuffle=self.shuffle_LSE)
+                for c in cutlass.range(cute.size(acc_S_mn, mode=[1]), unroll_full=True):
+                    acc_S_mn[r, c] = cute.math.exp2(
+                        acc_S_mn[r, c] * softmax_scale_log2 - lse_val, fastmath=True
+                    )
+            tLSErdPsum = copy_utils.load_s2r(tLSEsdPsum[None, smem_idx_dO])
 
-        # Convert P from f32 -> f16
-        tdVrP = utils.cvt_f16(layout_utils.reshape_acc_to_frgA(acc_S), self.dtype)
-        # R2S for P
-        if const_expr(not self.mma_dkv_is_rs):
-            # sync to ensure P has already been used in the previous iteration before overwriting
-            if const_expr(self.PdS_stage == 1):
+            # Convert P from f32 -> f16
+            tdVrP = utils.cvt_f16(layout_utils.reshape_acc_to_frgA(acc_S), self.dtype)
+            # R2S for P
+            if const_expr(not self.mma_dkv_is_rs):
+                # sync to ensure P has already been used in the previous iteration before overwriting
+                if const_expr(self.PdS_stage == 1):
+                    PdS_barrier.arrive_and_wait()
+                copy_P_r2s(tdVrP, dst_idx=smem_idx_PdS)
+
+            # (4) [Pointwise 2] dS = P*(dP-dPsum)
+            warpgroup.wait_group(0)
+            acc_dP_mn = layout_utils.reshape_acc_to_mn(acc_dP, transpose=self.SdP_swapAB)
+            for r in cutlass.range_constexpr(cute.size(acc_dP_mn, mode=[0])):
+                dpsum_val = self._get_stat(tLSErdPsum, r, lane_idx, shuffle=self.shuffle_dPsum)
+                for c in cutlass.range(cute.size(acc_dP_mn, mode=[1]), unroll_full=True):
+                    acc_dP_mn[r, c] = acc_S_mn[r, c] * (acc_dP_mn[r, c] - dpsum_val)
+
+            if const_expr(self.score_mod_bwd is not None):
+                score_mod_bwd_fn(acc_dP, acc_S_pre, m_block=m_block)
+
+            # Convert dS from f32 -> f16
+            tdKrdS = utils.cvt_f16(layout_utils.reshape_acc_to_frgA(acc_dP), self.dtype)
+
+            # If there's double buffering on dS, we don't need to sync here.
+            # Otherwise we might have WG1 writing to dS before WG2 is done reading from it during MmadQ.
+            # But because both WGs have to sync at the end of the loop and double buffering,
+            # this race condition is not possible.
+            # This sync is to ensure (1) P is written in case of !mma_dkv_is_rs and
+            # (2) dS is already read by the Mma in the previous iteration in case of mma_dkv_is_rs.
+            if const_expr(not self.mma_dkv_is_rs or (self.PdS_stage == 1 and self.mma_dkv_is_rs)):
+                cute.arch.fence_view_async_shared()
                 PdS_barrier.arrive_and_wait()
-            copy_P_r2s(tdVrP, dst_idx=smem_idx_PdS)
 
-        # (4) [Pointwise 2] dS = P*(dP-dPsum)
-        warpgroup.wait_group(0)
-        acc_dP_mn = layout_utils.reshape_acc_to_mn(acc_dP, transpose=self.SdP_swapAB)
-        for r in cutlass.range_constexpr(cute.size(acc_dP_mn, mode=[0])):
-            dpsum_val = self._get_stat(tLSErdPsum, r, lane_idx, shuffle=self.shuffle_dPsum)
-            for c in cutlass.range(cute.size(acc_dP_mn, mode=[1]), unroll_full=True):
-                acc_dP_mn[r, c] = acc_S_mn[r, c] * (acc_dP_mn[r, c] - dpsum_val)
+            # R2S for dS
+            copy_dS_r2s(tdKrdS, dst_idx=smem_idx_PdS)
 
-        if const_expr(self.score_mod_bwd is not None):
-            score_mod_bwd_fn(acc_dP, acc_S_pre, m_block=m_block)
+            # (5) [GEMM 3] dV += P.T @ dO
+            if const_expr(not self.mma_dkv_is_rs):
+                mma_pdo_fn(
+                    A_idx=smem_idx_PdS, B_idx=smem_idx_dO, zero_init=not dKV_accumulate, wg_wait=-1
+                )
+            else:
+                mma_pdo_fn(tCrA=tdVrP, B_idx=smem_idx_dO, zero_init=not dKV_accumulate, wg_wait=-1)
 
-        # Convert dS from f32 -> f16
-        tdKrdS = utils.cvt_f16(layout_utils.reshape_acc_to_frgA(acc_dP), self.dtype)
-
-        # If there's double buffering on dS, we don't need to sync here.
-        # Otherwise we might have WG1 writing to dS before WG2 is done reading from it during MmadQ.
-        # But because both WGs have to sync at the end of the loop and double buffering,
-        # this race condition is not possible.
-        # This sync is to ensure (1) P is written in case of !mma_dkv_is_rs and
-        # (2) dS is already read by the Mma in the previous iteration in case of mma_dkv_is_rs.
-        if const_expr(not self.mma_dkv_is_rs or (self.PdS_stage == 1 and self.mma_dkv_is_rs)):
+            # smem fence to make sure sdS is written before it's read by WGMMA
             cute.arch.fence_view_async_shared()
             PdS_barrier.arrive_and_wait()
 
-        # R2S for dS
-        copy_dS_r2s(tdKrdS, dst_idx=smem_idx_PdS)
+            if const_expr(is_dQ_wg):
+                # (6) [GEMM 4] dQ = dS @ K
+                acc_dQ = mma_dsk_fn(A_idx=smem_idx_PdS, wg_wait=1)
+                pipeline_dO.consumer_release(consumer_state_dO)  # release dO as dV mma is done
 
-        # (5) [GEMM 3] dV += P.T @ dO
-        if const_expr(not self.mma_dkv_is_rs):
-            mma_pdo_fn(
-                A_idx=smem_idx_PdS, B_idx=smem_idx_dO, zero_init=not dKV_accumulate, wg_wait=-1
-            )
-        else:
-            mma_pdo_fn(tCrA=tdVrP, B_idx=smem_idx_dO, zero_init=not dKV_accumulate, wg_wait=-1)
+                # (7) [GEMM 5] dK += dS.T @ Q
+                if const_expr(not self.mma_dkv_is_rs):
+                    mma_dsq_fn(
+                        A_idx=smem_idx_PdS,
+                        B_idx=smem_idx_Q,
+                        zero_init=not dKV_accumulate,
+                        wg_wait=1,
+                    )
+                else:
+                    mma_dsq_fn(
+                        tCrA=tdKrdS, B_idx=smem_idx_Q, zero_init=not dKV_accumulate, wg_wait=1
+                    )
 
-        # smem fence to make sure sdS is written before it's read by WGMMA
-        cute.arch.fence_view_async_shared()
-        PdS_barrier.arrive_and_wait()
-
-        if const_expr(is_dQ_wg):
-            # (6) [GEMM 4] dQ = dS @ K
-            acc_dQ = mma_dsk_fn(A_idx=smem_idx_PdS, wg_wait=1)
-            pipeline_dO.consumer_release(consumer_state_dO_cur)  # release dO as dV mma is done
-
-            # (7) [GEMM 5] dK += dS.T @ Q
-            if const_expr(not self.mma_dkv_is_rs):
-                mma_dsq_fn(
-                    A_idx=smem_idx_PdS, B_idx=smem_idx_Q, zero_init=not dKV_accumulate, wg_wait=1
+                # dQ R2S: wait for dQaccum_store to free the smem buffer, then write dQ to smem
+                # When dQ_single_wg, only WG0 enters here so warp_group_idx == 0
+                cute.arch.barrier(
+                    barrier_id=int(NamedBarrierBwd.dQEmptyWG0) + warp_group_idx,
+                    number_of_threads=self.num_threads_per_warp_group + cute.arch.WARP_SIZE,
                 )
-            else:
-                mma_dsq_fn(tCrA=tdKrdS, B_idx=smem_idx_Q, zero_init=not dKV_accumulate, wg_wait=1)
-
-            # dQ R2S: wait for dQaccum_store to free the smem buffer, then write dQ to smem
-            # When dQ_single_wg, only WG0 enters here so warp_group_idx == 0
-            cute.arch.barrier(
-                barrier_id=int(NamedBarrierBwd.dQEmptyWG0) + warp_group_idx,
-                number_of_threads=self.num_threads_per_warp_group + cute.arch.WARP_SIZE,
-            )
-            tdQrdQaccum_flat = cute.make_tensor(
-                acc_dQ.iterator, cute.make_layout(tdQsdQaccum.shape)
-            )
-            cute.autovec_copy(tdQrdQaccum_flat, tdQsdQaccum)
-            cute.arch.fence_view_async_shared()
-            cute.arch.barrier_arrive(
-                barrier_id=int(NamedBarrierBwd.dQFullWG0) + warp_group_idx,
-                number_of_threads=self.num_threads_per_warp_group + cute.arch.WARP_SIZE,
-            )
-
-            warpgroup.wait_group(0)
-            pipeline_Q.consumer_release(consumer_state_Q)
-        else:
-            # dQ_single_wg: WG1 skips dQ, only does dV wait + dK
-            # (7) [GEMM 5] dK += dS.T @ Q
-            if const_expr(not self.mma_dkv_is_rs):
-                mma_dsq_fn(
-                    A_idx=smem_idx_PdS, B_idx=smem_idx_Q, zero_init=not dKV_accumulate, wg_wait=1
+                tdQrdQaccum_flat = cute.make_tensor(
+                    acc_dQ.iterator, cute.make_layout(tdQsdQaccum.shape)
                 )
+                cute.autovec_copy(tdQrdQaccum_flat, tdQsdQaccum)
+                if cute.arch.thread_idx()[0] == self.num_threads_per_warp_group * (
+                    warp_group_idx + 1
+                ):
+                    sdQSkip[warp_group_idx] = Int32(0)
+                cute.arch.fence_view_async_shared()
+                cute.arch.barrier_arrive(
+                    barrier_id=int(NamedBarrierBwd.dQFullWG0) + warp_group_idx,
+                    number_of_threads=self.num_threads_per_warp_group + cute.arch.WARP_SIZE,
+                )
+
+                warpgroup.wait_group(0)
+                pipeline_Q.consumer_release(consumer_state_Q)
             else:
-                mma_dsq_fn(tCrA=tdKrdS, B_idx=smem_idx_Q, zero_init=not dKV_accumulate, wg_wait=1)
-            pipeline_dO.consumer_release(consumer_state_dO_cur)
-            warpgroup.wait_group(0)
-            pipeline_Q.consumer_release(consumer_state_Q)
+                # dQ_single_wg: WG1 skips dQ, only does dV wait + dK
+                # (7) [GEMM 5] dK += dS.T @ Q
+                if const_expr(not self.mma_dkv_is_rs):
+                    mma_dsq_fn(
+                        A_idx=smem_idx_PdS,
+                        B_idx=smem_idx_Q,
+                        zero_init=not dKV_accumulate,
+                        wg_wait=1,
+                    )
+                else:
+                    mma_dsq_fn(
+                        tCrA=tdKrdS, B_idx=smem_idx_Q, zero_init=not dKV_accumulate, wg_wait=1
+                    )
+                pipeline_dO.consumer_release(consumer_state_dO)
+                warpgroup.wait_group(0)
+                pipeline_Q.consumer_release(consumer_state_Q)
 
         consumer_state_Q.advance()
         consumer_state_dO.advance()
-        return consumer_state_Q, consumer_state_dO
+        return consumer_state_Q, consumer_state_dO, is_skip
+
+    @cute.jit
+    def skip_softmax(
+        self,
+        acc_S_mn: cute.Tensor,
+        tLSErLSE: cute.Tensor,
+        m_block: Int32,
+        softmax_scale_log2: Float32,
+        softmax_threshold: Float32,
+        seqlen: SeqlenInfoQK,
+        thr_mma: cute.ThrMma,
+        sSkip: cute.Tensor,
+    ) -> Boolean:
+        threshold_fragment = cute.make_rmem_tensor(cute.size(acc_S_mn, mode=[0]), Float32)
+        softmax_threshold_log2 = seqlen.get_softmax_threshold(
+            softmax_threshold,
+            m_block,
+            threshold_fragment,
+            thr_mma,
+            self.tile_m,
+            self.tile_n,
+            self.is_causal,
+            transpose=self.SdP_swapAB,
+        )
+        lane_idx = cute.arch.lane_idx()
+        thread_max = -Float32.inf
+        for r in cutlass.range_constexpr(cute.size(acc_S_mn, mode=[0])):
+            row_max_local = utils.fmax_reduce(acc_S_mn[r, None].load(), arch=90)
+            lse_val = self._get_stat(tLSErLSE, r, lane_idx, shuffle=self.shuffle_LSE)
+            metric = row_max_local * softmax_scale_log2 - lse_val - softmax_threshold_log2[r]
+            thread_max = cutlass.max(thread_max, metric)
+        cta_max = utils.cta_reduce(
+            thread_max,
+            sSkip,
+            cutlass.max,
+            -Float32.inf,
+            self.num_mma_threads // cute.arch.WARP_SIZE,
+            self.num_threads_per_warp_group,
+            int(NamedBarrierBwd.Softmax),
+        )
+        return Boolean(cta_max < 0.0)
 
     @cute.jit
     def epilogue_dKV(
@@ -3769,6 +3904,7 @@ class FlashSparseAttentionBackwardSm90:
         self,
         mdQaccum: cute.Tensor,
         sdQaccum: cute.Tensor,
+        sdQSkip: cute.Tensor,
         block_info: BlockInfo,
         TileSchedulerCls: cutlass.Constexpr[Callable],
         SeqlenInfoCls: cutlass.Constexpr[Callable],
@@ -3919,11 +4055,12 @@ class FlashSparseAttentionBackwardSm90:
                                 + cute.arch.WARP_SIZE,
                             )
                             with cute.arch.elect_one():
-                                copy_utils.cpasync_reduce_bulk_add_f32(
-                                    sdQaccum[None, warp_group_idx].iterator,
-                                    gdQaccum[(None, warp_group_idx), m_block_safe].iterator,
-                                    self.tma_copy_bytes["dQ"],
-                                )
+                                if sdQSkip[warp_group_idx] == 0:
+                                    copy_utils.cpasync_reduce_bulk_add_f32(
+                                        sdQaccum[None, warp_group_idx].iterator,
+                                        gdQaccum[(None, warp_group_idx), m_block_safe].iterator,
+                                        self.tma_copy_bytes["dQ"],
+                                    )
                             cute.arch.cp_async_bulk_commit_group()
 
                         # Semaphore release: signal that this n_block is done with this m_block

--- a/flash_sparse_attn/ops/cute/flash_fwd.py
+++ b/flash_sparse_attn/ops/cute/flash_fwd.py
@@ -1862,6 +1862,10 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
         )
         if const_expr(mWindowSizes is not None):
             assert mWindowSizes.element_type == Int32, "mWindowSizes must have dtype Int32"
+        if const_expr(blocksparse_tensors is not None):
+            assert not self.is_local, (
+                "block sparsity and window sizes cannot be enabled at the same time"
+            )
         self._check_type(
             *(
                 t.element_type if t is not None else None
@@ -2061,7 +2065,6 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
         )
         if const_expr(self.is_local):
             n_block_max_no_mask = n_block_min
-            n_block_window_max = cutlass.min(n_block_window_max, n_block_max_no_mask)
             n_block_window_max_no_mask = block_info.get_n_block_min_causal_local_mask(
                 seqlen,
                 m_block,
@@ -2081,8 +2084,6 @@ class FlashSparseAttentionForwardSm80(FlashSparseAttentionForwardBase):
                 n_block_window_min,
             )
         else:
-            n_block_window_min = Int32(0)
-            n_block_window_max = Int32(0)
             n_block_window_min_no_mask = Int32(0)
             n_block_window_max_no_mask = Int32(0)
         # For varlen, wasted grid tiles (where batch_idx >= num_batch) will have

--- a/flash_sparse_attn/ops/cute/flash_fwd.py
+++ b/flash_sparse_attn/ops/cute/flash_fwd.py
@@ -10,6 +10,7 @@
 # Built on Cute-DSL example: https://github.com/NVIDIA/cutlass/blob/main/examples/python/CuTeDSL/ampere/flash_attention_v2.py
 
 import math
+from types import SimpleNamespace
 from typing import Type, Callable, Optional
 from functools import partial
 
@@ -48,6 +49,7 @@ from flash_sparse_attn.ops.cute.namespace import (
 )
 
 
+# NOTE: only for sync
 class FlashAttentionForwardBase:
     def __init__(
         self,
@@ -1108,6 +1110,7 @@ class FlashSparseAttentionForwardBase:
             )
 
 
+# NOTE: only for sync
 class FlashAttentionForwardSm80(FlashAttentionForwardBase):
     def _get_smem_layout_atom(self):
         sQ_layout_atom = sm80_utils.get_smem_layout_atom(self.dtype, self.tile_hdim)
@@ -1346,7 +1349,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             mSeqUsedQ=mSeqUsedQ,
             mSeqUsedK=mSeqUsedK,
         )
-        (n_block_min, n_block_max, _, _, _, _) = block_info.get_n_block_min_max(seqlen, m_block)
+        n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
         # For varlen, wasted grid tiles (where batch_idx >= num_batch) will have
         # seqlen_q=seqlen_k=0 and n_block_max=0.  Clamp to 0 so we don't use a
         # negative block index for K/V loads; the load/store predicates already
@@ -1449,7 +1452,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         softmax.reset()
 
         # group parameters for compute_one_n_block
-        mma_params = FlashFwdMmaParamsSm80(
+        mma_params = SimpleNamespace(
             thr_mma_qk=thr_mma_qk,
             thr_mma_pv=thr_mma_pv,
             tSrQ=tSrQ,
@@ -1457,7 +1460,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             tOrVt=tOrVt,
             acc_O=acc_O,
         )
-        smem_copy_params = FlashFwdSmemCopyParamsSm80(
+        smem_copy_params = SimpleNamespace(
             smem_thr_copy_Q=smem_thr_copy_Q,
             smem_thr_copy_K=smem_thr_copy_K,
             smem_thr_copy_V=smem_thr_copy_V,
@@ -1633,8 +1636,8 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         n_block: Int32,
         smem_pipe_read: Int32,
         smem_pipe_write: Int32,
-        mma_params: FlashFwdMmaParamsSm80,
-        smem_copy_params: FlashFwdSmemCopyParamsSm80,
+        mma_params: SimpleNamespace,
+        smem_copy_params: SimpleNamespace,
         softmax: Softmax,
         load_K: Callable,
         load_V: Callable,

--- a/flash_sparse_attn/ops/cute/flash_fwd_sm90.py
+++ b/flash_sparse_attn/ops/cute/flash_fwd_sm90.py
@@ -1321,8 +1321,11 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
 
         # For RescaleOBeforeGemm: initialize acc_O
         if const_expr(self.rescale_O_before_gemm):
-            acc_O.fill(0.0)
+            if const_expr(is_first_block):
+                acc_O.fill(0.0)
             scores_scale.store(row_scale.load())
+        elif const_expr(not is_first_block):
+            softmax.rescale_O(acc_O, row_scale)
 
         return kv_consumer_state
 
@@ -1661,13 +1664,13 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         mO: cute.Tensor,  # (b, s_q, h, dv) or (total_q, h, dv) if there is cu_seqlens_q
         mLSE: Optional[cute.Tensor],
         softmax_scale: Float32,
+        mWindowSizes: Optional[cute.Tensor],
+        softmax_threshold: Float32,
         mCuSeqlensQ: Optional[cute.Tensor] = None,
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
         mPageTable: Optional[cute.Tensor] = None,  # (b_k, max_num_pages_per_seq)
-        window_size_left: Int32 | int | None = None,
-        window_size_right: Int32 | int | None = None,
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_data: AuxData = AuxData(),
@@ -1679,6 +1682,16 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         mQ/mK/mV/mO has same data types(supports fp16 and bf16) and same layout:
         (batch_size, seqlen_q, num_head, head_dim):(_, _, _, 1)
         """
+
+        assert not self.is_local or mWindowSizes is not None, (
+            "mWindowSizes must be provided for local attention"
+        )
+        if const_expr(mWindowSizes is not None):
+            assert mWindowSizes.element_type == Int32, "mWindowSizes must have dtype Int32"
+        if const_expr(blocksparse_tensors is not None):
+            assert not self.is_local, (
+                "block sparsity and window sizes cannot be enabled at the same time"
+            )
 
         self._check_type(
             *(
@@ -1845,8 +1858,6 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         softmax_scale_log2, softmax_scale = utils.compute_softmax_scale_log2(
             softmax_scale, self.score_mod
         )
-        window_size_left = Int32(window_size_left) if window_size_left is not None else None
-        window_size_right = Int32(window_size_right) if window_size_right is not None else None
         fastdiv_mods = utils.compute_fastdiv_mods(
             mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_data.tensors, mPageTable
         )
@@ -1868,8 +1879,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
             tma_atom_O,
             softmax_scale_log2,
             softmax_scale,
-            window_size_left,
-            window_size_right,
+            mWindowSizes,
             learnable_sink,
             blocksparse_tensors,
             self.sQ_layout,
@@ -1914,8 +1924,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         tma_atom_O: Optional[cute.CopyAtom],
         softmax_scale_log2: Float32,
         softmax_scale: Optional[Float32],
-        window_size_left: Optional[Int32],
-        window_size_right: Optional[Int32],
+        mWindowSizes: Optional[cute.Tensor],
         learnable_sink: Optional[cute.Tensor],
         blocksparse_tensors: Optional[BlockSparseTensors],
         sQ_layout: cute.ComposedLayout,
@@ -2031,14 +2040,30 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         # reuse sQ's data iterator
         sO = storage.sQ.get_tensor(sO_layout.outer, swizzle=sO_layout.inner, dtype=self.dtype)
 
+        TileSchedulerCls = partial(TileScheduler.create, tile_sched_params)
+        tile_scheduler = TileSchedulerCls()
+        work_tile = tile_scheduler.initial_work_tile_info()
+        (
+            window_size_sink,
+            window_size_left,
+            window_size_right,
+            window_size_dist,
+        ) = work_tile.load_window_sizes(
+            mWindowSizes,
+            self.is_local,
+            self.qhead_per_kvhead,
+            self.pack_gqa,
+        )
         block_info = BlockInfo(
             self.tile_m,
             self.tile_n,
             self.is_causal,
             self.is_local,
             False,  # is_split_kv
+            window_size_sink,
             window_size_left,
             window_size_right,
+            window_size_dist,
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
         )
         SeqlenInfoCls = partial(
@@ -2065,11 +2090,12 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
             AttentionMask,
             self.tile_m,
             self.tile_n,
+            window_size_sink=window_size_sink,
             window_size_left=window_size_left,
             window_size_right=window_size_right,
+            window_size_dist=window_size_dist,
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
         )
-        TileSchedulerCls = partial(TileScheduler.create, tile_sched_params)
 
         # Cluster wait before starting
         pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
@@ -2259,7 +2285,14 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                     )
 
                 if const_expr(not self.use_block_sparsity):
-                    n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
+                    (
+                        n_block_min,
+                        n_block_max,
+                        n_block_window_min,
+                        n_block_window_max,
+                        n_block_sink_min,
+                        n_block_sink_max,
+                    ) = block_info.get_n_block_min_max(seqlen, m_block)
                     # if cute.arch.thread_idx()[0] == 0:
                     #     cute.printf("m_block = %d, n_block_min: %d, n_block_max: %d", m_block, n_block_min, n_block_max)
                     # Clamp n_block to 0 when n_block_max == 0 (can happen with causal
@@ -2326,6 +2359,55 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                                     page_idx=page_idx,
                                 )
                                 kv_producer_state.advance()
+                            if const_expr(self.is_local):
+                                for i in cutlass.range(
+                                    n_block_window_max - n_block_window_min, unroll=1
+                                ):
+                                    n_block = n_block_window_max - i - 1
+                                    page_idx = (
+                                        mPageTable[batch_idx, n_block]
+                                        if const_expr(mPageTable is not None and self.use_tma_KV)
+                                        else None
+                                    )
+                                    if const_expr(not self.use_tma_KV):
+                                        paged_kv_manager.load_page_table(n_block)
+                                    pipeline_k.producer_acquire(kv_producer_state)
+                                    load_K(
+                                        block=n_block,
+                                        producer_state=kv_producer_state,
+                                        page_idx=page_idx,
+                                    )
+                                    pipeline_v.producer_acquire(kv_producer_state)
+                                    load_V(
+                                        block=n_block,
+                                        producer_state=kv_producer_state,
+                                        page_idx=page_idx,
+                                    )
+                                    kv_producer_state.advance()
+                                for i in cutlass.range(
+                                    n_block_sink_max - n_block_sink_min, unroll=1
+                                ):
+                                    n_block = n_block_sink_max - i - 1
+                                    page_idx = (
+                                        mPageTable[batch_idx, n_block]
+                                        if const_expr(mPageTable is not None and self.use_tma_KV)
+                                        else None
+                                    )
+                                    if const_expr(not self.use_tma_KV):
+                                        paged_kv_manager.load_page_table(n_block)
+                                    pipeline_k.producer_acquire(kv_producer_state)
+                                    load_K(
+                                        block=n_block,
+                                        producer_state=kv_producer_state,
+                                        page_idx=page_idx,
+                                    )
+                                    pipeline_v.producer_acquire(kv_producer_state)
+                                    load_V(
+                                        block=n_block,
+                                        producer_state=kv_producer_state,
+                                        page_idx=page_idx,
+                                    )
+                                    kv_producer_state.advance()
                         else:
                             for i in cutlass.range(n_block_max - 1 - n_block_min, unroll=1):
                                 n_block_prev = n_block_max - i - 1
@@ -2365,6 +2447,119 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                                 block=n_block, producer_state=kv_producer_state, page_idx=page_idx
                             )
                             kv_producer_state.advance()
+                            if const_expr(self.is_local):
+                                if n_block_window_max > n_block_window_min:
+                                    n_block = n_block_window_max - 1
+                                    page_idx = (
+                                        mPageTable[batch_idx, n_block]
+                                        if const_expr(mPageTable is not None)
+                                        else None
+                                    )
+                                    pipeline_k.producer_acquire(kv_producer_state)
+                                    load_K(
+                                        block=n_block,
+                                        producer_state=kv_producer_state,
+                                        page_idx=page_idx,
+                                    )
+                                    for i in cutlass.range(
+                                        n_block_window_max - 1 - n_block_window_min,
+                                        unroll=1,
+                                    ):
+                                        n_block_prev = n_block_window_max - i - 1
+                                        n_block = n_block_prev - 1
+                                        page_idx = (
+                                            mPageTable[batch_idx, n_block]
+                                            if const_expr(mPageTable is not None)
+                                            else None
+                                        )
+                                        page_idx_prev = (
+                                            mPageTable[batch_idx, n_block_prev]
+                                            if const_expr(mPageTable is not None)
+                                            else None
+                                        )
+                                        kv_producer_state_prev = kv_producer_state.clone()
+                                        kv_producer_state.advance()
+                                        pipeline_k.producer_acquire(kv_producer_state)
+                                        load_K(
+                                            block=n_block,
+                                            producer_state=kv_producer_state,
+                                            page_idx=page_idx,
+                                        )
+                                        pipeline_v.producer_acquire(kv_producer_state_prev)
+                                        load_V(
+                                            block=n_block_prev,
+                                            producer_state=kv_producer_state_prev,
+                                            page_idx=page_idx_prev,
+                                        )
+                                    n_block = n_block_window_min
+                                    page_idx = (
+                                        mPageTable[batch_idx, n_block]
+                                        if const_expr(mPageTable is not None)
+                                        else None
+                                    )
+                                    pipeline_v.producer_acquire(kv_producer_state)
+                                    load_V(
+                                        block=n_block,
+                                        producer_state=kv_producer_state,
+                                        page_idx=page_idx,
+                                    )
+                                    kv_producer_state.advance()
+                                if n_block_sink_max > n_block_sink_min:
+                                    n_block = n_block_sink_max - 1
+                                    page_idx = (
+                                        mPageTable[batch_idx, n_block]
+                                        if const_expr(mPageTable is not None)
+                                        else None
+                                    )
+                                    pipeline_k.producer_acquire(kv_producer_state)
+                                    load_K(
+                                        block=n_block,
+                                        producer_state=kv_producer_state,
+                                        page_idx=page_idx,
+                                    )
+                                    for i in cutlass.range(
+                                        n_block_sink_max - 1 - n_block_sink_min,
+                                        unroll=1,
+                                    ):
+                                        n_block_prev = n_block_sink_max - i - 1
+                                        n_block = n_block_prev - 1
+                                        page_idx = (
+                                            mPageTable[batch_idx, n_block]
+                                            if const_expr(mPageTable is not None)
+                                            else None
+                                        )
+                                        page_idx_prev = (
+                                            mPageTable[batch_idx, n_block_prev]
+                                            if const_expr(mPageTable is not None)
+                                            else None
+                                        )
+                                        kv_producer_state_prev = kv_producer_state.clone()
+                                        kv_producer_state.advance()
+                                        pipeline_k.producer_acquire(kv_producer_state)
+                                        load_K(
+                                            block=n_block,
+                                            producer_state=kv_producer_state,
+                                            page_idx=page_idx,
+                                        )
+                                        pipeline_v.producer_acquire(kv_producer_state_prev)
+                                        load_V(
+                                            block=n_block_prev,
+                                            producer_state=kv_producer_state_prev,
+                                            page_idx=page_idx_prev,
+                                        )
+                                    n_block = n_block_sink_min
+                                    page_idx = (
+                                        mPageTable[batch_idx, n_block]
+                                        if const_expr(mPageTable is not None)
+                                        else None
+                                    )
+                                    pipeline_v.producer_acquire(kv_producer_state)
+                                    load_V(
+                                        block=n_block,
+                                        producer_state=kv_producer_state,
+                                        page_idx=page_idx,
+                                    )
+                                    kv_producer_state.advance()
                 else:
                     # Block sparsity: use TMA closures directly (not paged)
                     # Load Q on pipeline_q, separate from K/V pipeline
@@ -2591,7 +2786,40 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
             mma_one_n_block = partial(
                 mma_one_n_block_all, seqlen=seqlen, softmax=softmax, score_mod_fn=score_mod_fn
             )
-            n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
+            (
+                n_block_min,
+                n_block_max,
+                n_block_window_min,
+                n_block_window_max,
+                n_block_sink_min,
+                n_block_sink_max,
+            ) = block_info.get_n_block_min_max(seqlen, m_block)
+            n_block_max_no_mask = block_info.get_n_block_min_causal_local_mask(
+                seqlen,
+                m_block,
+                n_block_min,
+                is_local=False,
+            )
+            if const_expr(self.is_local):
+                n_block_max_no_mask = n_block_min
+                n_block_window_max_no_mask = block_info.get_n_block_min_causal_local_mask(
+                    seqlen,
+                    m_block,
+                    n_block_window_min,
+                )
+                n_block_window_min_no_mask = block_info.get_n_block_min_before_local_mask(
+                    seqlen,
+                    m_block,
+                    n_block_window_min,
+                )
+                n_block_window_max_no_mask = cutlass.max(
+                    cutlass.min(n_block_window_max_no_mask, n_block_window_max),
+                    n_block_window_min,
+                )
+                n_block_window_min_no_mask = cutlass.max(
+                    cutlass.min(n_block_window_min_no_mask, n_block_window_max_no_mask),
+                    n_block_window_min,
+                )
             pipeline_q.consumer_wait_w_index_phase(0, q_consumer_phase)
             # For performance reason, we separate out two kinds of iterations:
             # those that need masking on S, and those that don't.
@@ -2613,7 +2841,13 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                         n_block=n_block_max - 1,
                         seqlen=seqlen,
                         kv_consumer_state=kv_consumer_state,
-                        mask_fn=partial(mask_fn, mask_mod=self.mask_mod),
+                        mask_fn=partial(
+                            mask_fn,
+                            mask_mod=self.mask_mod,
+                            mask_seqlen=True,
+                            mask_causal=self.is_causal and not self.is_local,
+                            mask_local=self.is_local,
+                        ),
                         score_mod_fn=score_mod_fn,
                         is_first_block=True,
                     )
@@ -2625,65 +2859,182 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                         seqlen=seqlen,
                         mma_pv_fn=partial(mma_pv_fn, zero_init=True),
                         is_first_n_block=True,
-                        mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=True),
+                        mask_fn=partial(
+                            mask_fn,
+                            mask_mod=self.mask_mod,
+                            mask_seqlen=True,
+                            mask_causal=self.is_causal and not self.is_local,
+                            mask_local=self.is_local,
+                        ),
                     )
                     O_should_accumulate = True
                 # if cute.arch.thread_idx()[0] == 128: cute.printf("m_block = {}, n_block_max = {}, n_block_min = {}", m_block, n_block_max, n_block_min)
                 n_block_max -= 1
+                n_block_max_no_mask = cutlass.min(n_block_max_no_mask, n_block_max)
                 # Next couple of iterations with causal masking
-                if const_expr(self.is_causal or self.is_local):
-                    n_block_min_causal_local_mask = block_info.get_n_block_min_causal_local_mask(
-                        seqlen, m_block, n_block_min
-                    )
-                    # if cute.arch.thread_idx()[0] == 128: cute.printf("n_block_min_causal_local_mask = {}", n_block_min_causal_local_mask)
-                    for n_tile in cutlass.range(
-                        n_block_max - n_block_min_causal_local_mask, unroll=1
-                    ):
-                        kv_consumer_state = mma_one_n_block(
-                            kv_consumer_state,
-                            n_block=n_block_max - 1 - n_tile,
-                            seqlen=seqlen,
-                            mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
-                            mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False),
-                        )
-                        O_should_accumulate = True
-                    n_block_max = cutlass.min(n_block_max, n_block_min_causal_local_mask)
-                # The remaining iterations have no masking
-                n_block_min_before_local_mask = block_info.get_n_block_min_before_local_mask(
-                    seqlen, m_block, n_block_min
-                )
-                # if cute.arch.thread_idx()[0] == 128: cute.printf("n_block_min_before_local_mask = {}, n_block_min = {}", n_block_min_before_local_mask, n_block_min)
-                for n_tile in cutlass.range(n_block_max - n_block_min_before_local_mask, unroll=1):
+                for n_tile in cutlass.range(n_block_max - n_block_max_no_mask, unroll=1):
                     kv_consumer_state = mma_one_n_block(
                         kv_consumer_state,
                         n_block=n_block_max - 1 - n_tile,
                         seqlen=seqlen,
                         mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
-                        mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False),
+                        mask_fn=partial(
+                            mask_fn,
+                            mask_mod=self.mask_mod,
+                            mask_seqlen=True,
+                            mask_causal=self.is_causal and not self.is_local,
+                            mask_local=self.is_local,
+                        ),
                     )
                     O_should_accumulate = True
-                # Separate iterations with local masking on the left
-                if const_expr(self.is_local and block_info.window_size_left is not None):
-                    n_block_max = cutlass.min(n_block_max, n_block_min_before_local_mask)
-                    for n_tile in cutlass.range(n_block_max - n_block_min, unroll=1):
-                        kv_consumer_state = mma_one_n_block(
-                            kv_consumer_state,
-                            n_block=n_block_max - 1 - n_tile,
-                            seqlen=seqlen,
-                            mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
-                            mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False),
-                        )
-                        O_should_accumulate = True
-                # Release Q pipeline so the producer can load the next tile's Q
-                pipeline_q.consumer_release_w_index(0)
-                # Last "half" iteration
+                # The remaining iterations have no masking
+                for n_tile in cutlass.range(n_block_max_no_mask - n_block_min, unroll=1):
+                    kv_consumer_state = mma_one_n_block(
+                        kv_consumer_state,
+                        n_block=n_block_max_no_mask - 1 - n_tile,
+                        seqlen=seqlen,
+                        mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                        mask_fn=partial(
+                            mask_fn,
+                            mask_mod=self.mask_mod,
+                            mask_seqlen=False,
+                            mask_causal=False,
+                            mask_local=False,
+                        ),
+                    )
+                    O_should_accumulate = True
                 if const_expr(self.intra_wg_overlap):
                     kv_consumer_state = process_last_half_block(
                         kv_consumer_state=kv_consumer_state,
                         zero_init=not O_should_accumulate,
                     )
                     O_should_accumulate = True
-                else:
+                # Separate iterations with local masking
+                if const_expr(self.is_local):
+                    if n_block_window_max > n_block_window_min:
+                        if const_expr(self.intra_wg_overlap):
+                            kv_consumer_state = process_first_half_block(
+                                n_block=n_block_window_max - 1,
+                                seqlen=seqlen,
+                                kv_consumer_state=kv_consumer_state,
+                                mask_fn=partial(
+                                    mask_fn,
+                                    mask_mod=self.mask_mod,
+                                    mask_seqlen=False,
+                                    mask_causal=False,
+                                    mask_local=True,
+                                ),
+                                score_mod_fn=score_mod_fn,
+                                is_first_block=False,
+                            )
+                            n_block_window_max -= 1
+                            n_block_window_max_no_mask = cutlass.min(
+                                n_block_window_max_no_mask, n_block_window_max
+                            )
+                            n_block_window_min_no_mask = cutlass.min(
+                                n_block_window_min_no_mask, n_block_window_max_no_mask
+                            )
+                        for n_tile in cutlass.range(
+                            n_block_window_max - n_block_window_max_no_mask, unroll=1
+                        ):
+                            kv_consumer_state = mma_one_n_block(
+                                kv_consumer_state,
+                                n_block=n_block_window_max - 1 - n_tile,
+                                seqlen=seqlen,
+                                mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                                mask_fn=partial(
+                                    mask_fn,
+                                    mask_mod=self.mask_mod,
+                                    mask_seqlen=False,
+                                    mask_causal=False,
+                                    mask_local=True,
+                                ),
+                            )
+                            O_should_accumulate = True
+                        for n_tile in cutlass.range(
+                            n_block_window_max_no_mask - n_block_window_min_no_mask, unroll=1
+                        ):
+                            kv_consumer_state = mma_one_n_block(
+                                kv_consumer_state,
+                                n_block=n_block_window_max_no_mask - 1 - n_tile,
+                                seqlen=seqlen,
+                                mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                                mask_fn=partial(
+                                    mask_fn,
+                                    mask_mod=self.mask_mod,
+                                    mask_seqlen=False,
+                                    mask_causal=False,
+                                    mask_local=False,
+                                ),
+                            )
+                            O_should_accumulate = True
+                        for n_tile in cutlass.range(
+                            n_block_window_min_no_mask - n_block_window_min, unroll=1
+                        ):
+                            kv_consumer_state = mma_one_n_block(
+                                kv_consumer_state,
+                                n_block=n_block_window_min_no_mask - 1 - n_tile,
+                                seqlen=seqlen,
+                                mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                                mask_fn=partial(
+                                    mask_fn,
+                                    mask_mod=self.mask_mod,
+                                    mask_seqlen=False,
+                                    mask_causal=False,
+                                    mask_local=True,
+                                ),
+                            )
+                            O_should_accumulate = True
+                        if const_expr(self.intra_wg_overlap):
+                            kv_consumer_state = process_last_half_block(
+                                kv_consumer_state=kv_consumer_state,
+                                zero_init=not O_should_accumulate,
+                            )
+                            O_should_accumulate = True
+                    # Separate iterations with local sink masking
+                    if n_block_sink_max > n_block_sink_min:
+                        if const_expr(self.intra_wg_overlap):
+                            kv_consumer_state = process_first_half_block(
+                                n_block=n_block_sink_max - 1,
+                                seqlen=seqlen,
+                                kv_consumer_state=kv_consumer_state,
+                                mask_fn=partial(
+                                    mask_fn,
+                                    mask_mod=self.mask_mod,
+                                    mask_seqlen=True,
+                                    mask_causal=False,
+                                    mask_local=True,
+                                    mask_sink=True,
+                                ),
+                                score_mod_fn=score_mod_fn,
+                                is_first_block=False,
+                            )
+                            n_block_sink_max -= 1
+                        for n_tile in cutlass.range(n_block_sink_max - n_block_sink_min, unroll=1):
+                            kv_consumer_state = mma_one_n_block(
+                                kv_consumer_state,
+                                n_block=n_block_sink_max - 1 - n_tile,
+                                seqlen=seqlen,
+                                mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                                mask_fn=partial(
+                                    mask_fn,
+                                    mask_mod=self.mask_mod,
+                                    mask_seqlen=True,
+                                    mask_causal=False,
+                                    mask_local=True,
+                                    mask_sink=True,
+                                ),
+                            )
+                            O_should_accumulate = True
+                        if const_expr(self.intra_wg_overlap):
+                            kv_consumer_state = process_last_half_block(
+                                kv_consumer_state=kv_consumer_state,
+                                zero_init=not O_should_accumulate,
+                            )
+                            O_should_accumulate = True
+                # Release Q pipeline so the producer can load the next tile's Q
+                pipeline_q.consumer_release_w_index(0)
+                if const_expr(not self.intra_wg_overlap):
                     self.warp_scheduler_barrier_arrive()
 
             else:
@@ -2813,8 +3164,11 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
 
         # For RescaleOBeforeGemm: initialize acc_O
         if const_expr(self.rescale_O_before_gemm):
-            acc_O.fill(0.0)
+            if const_expr(is_first_block):
+                acc_O.fill(0.0)
             scores_scale.store(row_scale.load())
+        elif const_expr(not is_first_block):
+            softmax.rescale_O(acc_O, row_scale)
 
         return kv_consumer_state
 

--- a/flash_sparse_attn/ops/cute/flash_fwd_sm90.py
+++ b/flash_sparse_attn/ops/cute/flash_fwd_sm90.py
@@ -49,11 +49,1506 @@ from flash_sparse_attn.ops.cute.tile_scheduler import (
 )
 from cutlass.cute import FastDivmodDivisor
 
-from flash_sparse_attn.ops.cute.flash_fwd import FlashAttentionForwardBase
+from flash_sparse_attn.ops.cute.flash_fwd import (
+    FlashAttentionForwardBase,
+    FlashSparseAttentionForwardBase,
+)
 from flash_sparse_attn.ops.cute.utils import AuxData
 
 
 class FlashAttentionForwardSm90(FlashAttentionForwardBase):
+    def __init__(
+        self,
+        *args,
+        intra_wg_overlap: bool = True,
+        mma_pv_is_rs: bool = True,
+        paged_kv_non_tma: bool = False,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.intra_wg_overlap = intra_wg_overlap
+        self.mma_pv_is_rs = mma_pv_is_rs
+        self.buffer_align_bytes = 1024
+        self.use_tma_KV = not paged_kv_non_tma
+        assert self.use_tma_KV or not self.check_hdim_oob, (
+            "Paged KV does not support irregular head dim"
+        )
+        self.cluster_shape_mn = (1, 1)
+        assert self.arch.is_family_of(Arch.sm_90a), "Only SM 9.x is supported"
+
+    def _get_smem_layout_atom(self):
+        sQ_layout_atom = warpgroup.make_smem_layout_atom(
+            sm90_utils_basic.get_smem_layout_atom(LayoutEnum.ROW_MAJOR, self.dtype, self.tile_hdim),
+            self.dtype,
+        )
+        sK_layout_atom = sQ_layout_atom
+        sV_layout_atom = warpgroup.make_smem_layout_atom(
+            sm90_utils_basic.get_smem_layout_atom(LayoutEnum.ROW_MAJOR, self.dtype, self.tile_hdim),
+            self.dtype,
+        )
+        sO_layout_atom = sV_layout_atom
+        if not self.mma_pv_is_rs:
+            sP_layout_atom = warpgroup.make_smem_layout_atom(
+                sm90_utils_basic.get_smem_layout_atom(
+                    LayoutEnum.ROW_MAJOR, self.dtype, self.tile_n
+                ),
+                self.dtype,
+            )
+        else:
+            sP_layout_atom = None
+        return sQ_layout_atom, sK_layout_atom, sV_layout_atom, sO_layout_atom, sP_layout_atom
+
+    def _get_tiled_mma(self):
+        tiled_mma_qk = sm90_utils_basic.make_trivial_tiled_mma(
+            self.dtype,
+            self.dtype,
+            warpgroup.OperandMajorMode.K,
+            warpgroup.OperandMajorMode.K,
+            Float32,
+            atom_layout_mnk=(self.tile_m // 64, 1, 1),
+            tiler_mn=(64, self.tile_n),
+        )
+        tiled_mma_pv = sm90_utils_basic.make_trivial_tiled_mma(
+            self.dtype,
+            self.dtype,
+            warpgroup.OperandMajorMode.K,
+            warpgroup.OperandMajorMode.MN,
+            Float32,
+            atom_layout_mnk=(self.tile_m // 64, 1, 1),  # Might need (1, 2, 1) for hdim 512
+            tiler_mn=(64, self.tile_hdim),
+            a_source=warpgroup.OperandSource.RMEM
+            if self.mma_pv_is_rs
+            else warpgroup.OperandSource.SMEM,
+        )
+        return tiled_mma_qk, tiled_mma_pv
+
+    def _get_shared_storage_cls(self):
+        sQ_struct, sK_struct, sV_struct = [
+            cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(layout)], self.buffer_align_bytes
+            ]
+            for layout in (self.sQ_layout, self.sK_layout, self.sV_layout)
+        ]
+        cosize_sQV = max(cute.cosize(self.sQ_layout), cute.cosize(self.sV_layout))
+        sQV_struct = cute.struct.Align[cute.struct.MemRange[self.dtype, cosize_sQV], 1024]
+        cosize_sP = cute.cosize(self.sP_layout) if const_expr(self.sP_layout is not None) else 0
+        sP_struct = cute.struct.Align[cute.struct.MemRange[self.dtype, cosize_sP], 1024]
+        # 1 stage * 2 for Q pipeline (full + empty), self.num_stages*2 for K, self.num_stages*2 for V,
+        mbar_ptr_Q_struct = cute.struct.MemRange[cutlass.Int64, 1 * 2]
+        mbar_ptr_K_struct = cute.struct.MemRange[cutlass.Int64, self.num_stages * 2]
+        mbar_ptr_V_struct = cute.struct.MemRange[cutlass.Int64, self.num_stages * 2]
+
+        @cute.struct
+        class SharedStorageQKV:
+            mbar_ptr_Q: mbar_ptr_Q_struct
+            mbar_ptr_K: mbar_ptr_K_struct
+            mbar_ptr_V: mbar_ptr_V_struct
+            sV: sV_struct
+            sQ: sQ_struct
+            sK: sK_struct
+            sP: sP_struct
+
+        @cute.struct
+        class SharedStorageSharedQV:
+            mbar_ptr_Q: mbar_ptr_Q_struct
+            mbar_ptr_K: mbar_ptr_K_struct
+            mbar_ptr_V: mbar_ptr_V_struct
+            sQ: sQV_struct
+            sK: sK_struct
+            sP: sP_struct
+
+        return SharedStorageQKV if const_expr(not self.Q_in_regs) else SharedStorageSharedQV
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,  # (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_q
+        mK: cute.Tensor,  # (b_k, s_k, h_k, d) or (total_k, h_k, d) if there is cu_seqlens_k or (num_pages, page_size, h_k, d) if there is page_table
+        mV: cute.Tensor,  # (b_k, s_k, h_k, dv) or (total_k, h_k, dv) if there is cu_seqlens_k or (num_pages, page_size, h_k, dv) if there is page_table
+        mO: cute.Tensor,  # (b, s_q, h, dv) or (total_q, h, dv) if there is cu_seqlens_q
+        mLSE: Optional[cute.Tensor],
+        softmax_scale: Float32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        mSeqUsedQ: Optional[cute.Tensor] = None,
+        mSeqUsedK: Optional[cute.Tensor] = None,
+        mPageTable: Optional[cute.Tensor] = None,  # (b_k, max_num_pages_per_seq)
+        window_size_left: Int32 | int | None = None,
+        window_size_right: Int32 | int | None = None,
+        learnable_sink: Optional[cute.Tensor] = None,
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        aux_data: AuxData = AuxData(),
+        # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
+        stream: cuda.CUstream = None,
+    ):
+        """Configures and launches the flash attention kernel.
+
+        mQ/mK/mV/mO has same data types(supports fp16 and bf16) and same layout:
+        (batch_size, seqlen_q, num_head, head_dim):(_, _, _, 1)
+        """
+
+        self._check_type(
+            *(
+                t.element_type if t is not None else None
+                for t in (mQ, mK, mV, mO, mLSE, mCuSeqlensQ, mCuSeqlensK, mSeqUsedQ, mSeqUsedK)
+            )
+        )
+
+        self.varlen_q = mCuSeqlensQ is not None or mSeqUsedQ is not None
+
+        mQ, mK, mV, mO = [assume_tensor_aligned(t) for t in (mQ, mK, mV, mO)]
+        QO_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]
+        mQ, mO = [layout_utils.select(t, QO_layout_transpose) for t in (mQ, mO)]
+        KV_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensK is None) else [0, 2, 1]
+        mK, mV = [layout_utils.select(t, KV_layout_transpose) for t in (mK, mV)]
+        LSE_layout_transpose = [2, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 0]
+        mLSE = (
+            layout_utils.select(mLSE, LSE_layout_transpose)
+            if const_expr(mLSE is not None)
+            else None
+        )
+
+        tiled_mma_qk, tiled_mma_pv = self._get_tiled_mma()
+        self.num_mma_threads = tiled_mma_qk.size
+        self.num_threads_per_warp_group = 128
+        self.num_wg_mma = self.num_mma_threads // self.num_threads_per_warp_group
+        assert self.num_wg_mma in [1, 2, 3]
+        self.num_threads = self.num_threads_per_warp_group * (self.num_wg_mma + 1)
+        self.num_producer_threads = 32
+        self.num_Q_load_threads = self.num_threads_per_warp_group  # If not TMA_Q
+        self.num_epilogue_threads = self.num_mma_threads
+        self.num_mma_regs, self.num_producer_regs = {1: (256, 56), 2: (240, 24), 3: (160, 32)}[
+            self.num_wg_mma
+        ]
+        self.use_block_sparsity = cutlass.const_expr(blocksparse_tensors is not None)
+
+        self.use_scheduler_barrier = (
+            (self.num_wg_mma >= 2 and self.tile_hdim <= 128)
+            if const_expr(self.intra_wg_overlap)
+            else (self.num_wg_mma == 2)
+        )
+        self.use_tma_Q = self.arch >= Arch.sm_90 and not (
+            self.pack_gqa and self.tile_m % self.qhead_per_kvhead != 0
+        )
+        self.use_tma_O = self.use_tma_Q
+        # Producer needs more registers when doing cp.async Q or KV loads
+        if const_expr(self.num_wg_mma == 2 and (not self.use_tma_Q or not self.use_tma_KV)):
+            self.num_mma_regs, self.num_producer_regs = 224, 40
+        self.rescale_O_before_gemm = self.tile_hdim > 128 and self.intra_wg_overlap
+        self._setup_attributes()
+        # TODO: we prob don't need most of what's in _setup_attributes
+        self.sQ_layout, self.sK_layout, self.sV_layout, self.sO_layout = [
+            sm90_utils.make_smem_layout(mX.element_type, LayoutEnum.ROW_MAJOR, shape, stage)
+            for mX, shape, stage in [
+                (mQ, (self.tile_m, self.tile_hdim), None),
+                (mK, (self.tile_n, self.tile_hdim), self.num_stages),
+                (mV, (self.tile_n, self.tile_hdim), self.num_stages),
+                (mO, (self.tile_m, self.tile_hdim), None),
+            ]
+        ]
+        self.sP_layout = None
+        if const_expr(not self.mma_pv_is_rs):
+            self.sP_layout = sm90_utils.make_smem_layout(
+                mV.element_type, LayoutEnum.ROW_MAJOR, (self.tile_m, self.tile_n)
+            )
+
+        SharedStorage = self._get_shared_storage_cls()
+
+        mQ_og, mO_og = mQ, mO
+        if const_expr(self.pack_gqa):
+            nheads_kv = mK.shape[2]
+            mQ = pack_gqa_layout(mQ, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            mO = pack_gqa_layout(mO, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            if const_expr(mLSE is not None):
+                mLSE = pack_gqa_layout(mLSE, self.qhead_per_kvhead, nheads_kv, head_idx=1)
+
+        # TMA
+        gmem_tiled_copy_Q = cpasync.CopyBulkTensorTileG2SOp()
+        gmem_tiled_copy_KV = cpasync.CopyBulkTensorTileG2SOp()  # Might multicast
+        gmem_tiled_copy_O = cpasync.CopyBulkTensorTileS2GOp()
+        self.tma_copy_bytes = {
+            name: cute.size_in_bytes(mX.element_type, cute.select(layout, mode=[0, 1]))
+            for name, mX, layout in [
+                ("Q", mQ, self.sQ_layout),
+                ("K", mK, self.sK_layout),
+                ("V", mV, self.sV_layout),
+            ]
+        }
+        make_tiled_tma_atom_fn = (
+            partial(make_packgqa_tiled_tma_atom, qhead_per_kvhead=self.qhead_per_kvhead, head_idx=2)
+            if const_expr(self.pack_gqa)
+            else cpasync.make_tiled_tma_atom
+        )
+        tma_atom_Q, tma_tensor_Q = None, None
+        if const_expr(self.use_tma_Q):
+            tma_atom_Q, tma_tensor_Q = make_tiled_tma_atom_fn(
+                gmem_tiled_copy_Q,
+                mQ_og if const_expr(self.pack_gqa) else mQ,
+                self.sQ_layout,
+                (self.tile_m, self.tile_hdim),  # No mcast
+            )
+        tma_atom_K, tma_tensor_K = None, None
+        tma_atom_V, tma_tensor_V = None, None
+        if const_expr(self.use_tma_KV):
+            tma_atom_K, tma_tensor_K = cpasync.make_tiled_tma_atom(
+                gmem_tiled_copy_KV,
+                mK,
+                cute.select(self.sK_layout, mode=[0, 1]),
+                (self.tile_n, self.tile_hdim),
+                1,  # No mcast for now
+            )
+            tma_atom_V, tma_tensor_V = cpasync.make_tiled_tma_atom(
+                gmem_tiled_copy_KV,
+                mV,
+                cute.select(self.sV_layout, mode=[0, 1]),
+                (self.tile_n, self.tile_hdim),
+                1,  # No mcast for now
+            )
+        tma_atom_O, tma_tensor_O = None, None
+        if const_expr(self.use_tma_O):
+            mO_tma = mO_og if const_expr(self.pack_gqa) else mO
+            if const_expr(self.varlen_q):
+                mO_tma = copy_utils.create_ragged_tensor_for_tma(
+                    mO_tma, ragged_dim=0, ptr_shift=True
+                )
+            tma_atom_O, tma_tensor_O = make_tiled_tma_atom_fn(
+                gmem_tiled_copy_O,
+                mO_tma,
+                self.sO_layout,
+                (self.tile_m, self.tile_hdim),  # No mcast
+            )
+        if const_expr(mCuSeqlensQ is not None or mSeqUsedQ is not None):
+            TileScheduler = SingleTileVarlenScheduler
+        else:
+            TileScheduler = (
+                SingleTileScheduler
+                if const_expr(not self.is_causal or self.is_local)
+                else SingleTileLPTScheduler
+            )
+        tile_sched_args = TileSchedulerArguments(
+            cute.ceil_div(cute.size(mQ.shape[0]), self.tile_m),
+            cute.size(mQ.shape[2]),
+            cute.size(mQ.shape[3])
+            if const_expr(mCuSeqlensQ is None)
+            else cute.size(mCuSeqlensQ.shape[0] - 1),
+            1,  # num_splits
+            cute.size(mK.shape[0])
+            if const_expr(mPageTable is None)
+            else mK.shape[0] * mPageTable.shape[1],
+            mQ.shape[1],
+            total_q=cute.size(mQ.shape[0])
+            if const_expr(mCuSeqlensQ is not None)
+            else cute.size(mQ.shape[0]) * cute.size(mQ.shape[3]),
+            tile_shape_mn=(self.tile_m, self.tile_n),
+            mCuSeqlensQ=mCuSeqlensQ,
+            mSeqUsedQ=mSeqUsedQ,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            element_size=self.dtype.width // 8,
+            is_persistent=False,
+            lpt=self.is_causal or self.is_local,
+        )
+        tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
+        grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
+        softmax_scale_log2, softmax_scale = utils.compute_softmax_scale_log2(
+            softmax_scale, self.score_mod
+        )
+        window_size_left = Int32(window_size_left) if window_size_left is not None else None
+        window_size_right = Int32(window_size_right) if window_size_right is not None else None
+        fastdiv_mods = utils.compute_fastdiv_mods(
+            mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_data.tensors, mPageTable
+        )
+
+        self.kernel(
+            tma_tensor_Q if const_expr(self.use_tma_Q) else mQ,
+            tma_tensor_K if const_expr(self.use_tma_KV) else mK,
+            tma_tensor_V if const_expr(self.use_tma_KV) else mV,
+            tma_tensor_O if const_expr(self.use_tma_O) else mO,
+            mLSE,
+            mCuSeqlensQ,
+            mCuSeqlensK,
+            mSeqUsedQ,
+            mSeqUsedK,
+            mPageTable,
+            tma_atom_Q,
+            tma_atom_K,
+            tma_atom_V,
+            tma_atom_O,
+            softmax_scale_log2,
+            softmax_scale,
+            window_size_left,
+            window_size_right,
+            learnable_sink,
+            blocksparse_tensors,
+            self.sQ_layout,
+            self.sK_layout,
+            self.sV_layout,
+            self.sO_layout,
+            self.sP_layout,
+            self.gmem_tiled_copy_Q,
+            self.gmem_tiled_copy_K,
+            self.gmem_tiled_copy_V,
+            self.gmem_tiled_copy_O,
+            tiled_mma_qk,
+            tiled_mma_pv,
+            tile_sched_params,
+            TileScheduler,
+            SharedStorage,
+            aux_data,
+            fastdiv_mods,
+        ).launch(
+            grid=grid_dim,
+            block=[self.num_threads, 1, 1],
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        mCuSeqlensQ: Optional[cute.Tensor],
+        mCuSeqlensK: Optional[cute.Tensor],
+        mSeqUsedQ: Optional[cute.Tensor],
+        mSeqUsedK: Optional[cute.Tensor],
+        mPageTable: Optional[cute.Tensor],
+        tma_atom_Q: Optional[cute.CopyAtom],
+        tma_atom_K: Optional[cute.CopyAtom],
+        tma_atom_V: Optional[cute.CopyAtom],
+        tma_atom_O: Optional[cute.CopyAtom],
+        softmax_scale_log2: Float32,
+        softmax_scale: Optional[Float32],
+        window_size_left: Optional[Int32],
+        window_size_right: Optional[Int32],
+        learnable_sink: Optional[cute.Tensor],
+        blocksparse_tensors: Optional[BlockSparseTensors],
+        sQ_layout: cute.ComposedLayout,
+        sK_layout: cute.ComposedLayout,
+        sV_layout: cute.ComposedLayout,
+        sO_layout: cute.ComposedLayout,
+        sP_layout: cute.ComposedLayout | None,
+        gmem_tiled_copy_Q: cute.TiledCopy,
+        gmem_tiled_copy_K: cute.TiledCopy,
+        gmem_tiled_copy_V: cute.TiledCopy,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tiled_mma_qk: cute.TiledMma,
+        tiled_mma_pv: cute.TiledMma,
+        tile_sched_params: ParamsBase,
+        TileScheduler: cutlass.Constexpr[Callable],
+        SharedStorage: cutlass.Constexpr[Callable],
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=None,
+    ):
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        # Prefetch tma descriptor
+        if warp_idx == 0:
+            for tma_atom in (tma_atom_Q, tma_atom_K, tma_atom_V, tma_atom_O):
+                if const_expr(tma_atom is not None):
+                    cpasync.prefetch_descriptor(tma_atom)
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+
+        # Mbarrier / pipeline init
+        mbar_ptr_Q = storage.mbar_ptr_Q.data_ptr()
+
+        ThreadCooperativeGroup = partial(pipeline.CooperativeGroup, pipeline.Agent.Thread)
+        tma_warp = ThreadCooperativeGroup(1)
+        load_threads = ThreadCooperativeGroup(self.num_threads_per_warp_group)
+        mma_warps = ThreadCooperativeGroup(self.num_mma_threads // cute.arch.WARP_SIZE)
+        if const_expr(self.use_tma_Q):
+            pipeline_q = pipeline_custom.PipelineTmaAsync.create(
+                barrier_storage=mbar_ptr_Q,
+                num_stages=1,
+                producer_group=tma_warp,
+                consumer_group=mma_warps,
+                tx_count=self.tma_copy_bytes["Q"],
+                defer_sync=True,
+            )
+        else:
+            pipeline_q = pipeline_custom.PipelineCpAsync.create(
+                barrier_storage=mbar_ptr_Q,
+                num_stages=1,
+                producer_group=load_threads,
+                consumer_group=mma_warps,
+                defer_sync=True,
+                elect_one_release=True,
+                syncwarp_before_release=False,
+            )
+
+        if const_expr(self.use_tma_KV):
+            pipeline_k = pipeline_custom.PipelineTmaAsync.create(
+                barrier_storage=storage.mbar_ptr_K.data_ptr(),
+                num_stages=self.num_stages,
+                producer_group=tma_warp,
+                consumer_group=mma_warps,
+                tx_count=self.tma_copy_bytes["K"],
+                defer_sync=True,
+            )
+            pipeline_v = pipeline_custom.PipelineTmaAsync.create(
+                barrier_storage=storage.mbar_ptr_V.data_ptr(),
+                num_stages=self.num_stages,
+                producer_group=tma_warp,
+                consumer_group=mma_warps,
+                tx_count=self.tma_copy_bytes["V"],
+                defer_sync=True,
+            )
+        else:
+            pipeline_k = pipeline_custom.PipelineCpAsync.create(
+                barrier_storage=storage.mbar_ptr_K.data_ptr(),
+                num_stages=self.num_stages,
+                producer_group=load_threads,
+                consumer_group=mma_warps,
+                defer_sync=True,
+                elect_one_release=True,
+                syncwarp_before_release=False,
+            )
+            pipeline_v = pipeline_custom.PipelineCpAsync.create(
+                barrier_storage=storage.mbar_ptr_V.data_ptr(),
+                num_stages=self.num_stages,
+                producer_group=load_threads,
+                consumer_group=mma_warps,
+                defer_sync=True,
+                elect_one_release=True,
+                syncwarp_before_release=False,
+            )
+
+        # Cluster arrive after barrier init
+        pipeline_init_arrive(cluster_shape_mn=self.cluster_shape_mn, is_relaxed=True)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Get shared memory buffer
+        # ///////////////////////////////////////////////////////////////////////////////
+        sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
+        sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
+        if const_expr(not self.Q_in_regs):
+            sV = storage.sV.get_tensor(sV_layout.outer, swizzle=sV_layout.inner)
+        else:
+            sV = storage.sQ.get_tensor(
+                sV_layout.outer, swizzle=sV_layout.inner, dtype=mV.element_type
+            )
+        # Transpose view of V to tensor with layout (head_dim, tile_n) for tiled mma
+        sVt = layout_utils.transpose_view(sV)
+        sP = None
+        if const_expr(sP_layout is not None):
+            sP = storage.sP.get_tensor(sP_layout.outer, swizzle=sP_layout.inner)
+        # reuse sQ's data iterator
+        sO = storage.sQ.get_tensor(sO_layout.outer, swizzle=sO_layout.inner, dtype=self.dtype)
+
+        block_info = BlockInfo(
+            self.tile_m,
+            self.tile_n,
+            self.is_causal,
+            self.is_local,
+            False,  # is_split_kv
+            window_size_left,
+            window_size_right,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+        SeqlenInfoCls = partial(
+            SeqlenInfoQK.create,
+            seqlen_q_static=mQ.shape[0] if const_expr(not self.pack_gqa) else mQ.shape[0][1],
+            seqlen_k_static=mK.shape[0]
+            if const_expr(mPageTable is None)
+            else mK.shape[0] * mPageTable.shape[1],
+            mCuSeqlensQ=mCuSeqlensQ,
+            mCuSeqlensK=mCuSeqlensK,
+            mSeqUsedQ=mSeqUsedQ,
+            mSeqUsedK=mSeqUsedK,
+            mCuTotalMBlocks=(
+                blocksparse_tensors.cu_total_m_blocks if blocksparse_tensors is not None else None
+            ),
+            mCuBlockIdxOffsets=(
+                blocksparse_tensors.cu_block_idx_offsets
+                if blocksparse_tensors is not None
+                else None
+            ),
+            # Don't need to pass in tile_mn because we won't access offset_padded
+        )
+        AttentionMaskCls = partial(
+            AttentionMask,
+            self.tile_m,
+            self.tile_n,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+        TileSchedulerCls = partial(TileScheduler.create, tile_sched_params)
+
+        # Cluster wait before starting
+        pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
+
+        if warp_idx < 4:  # Producer
+            cute.arch.setmaxregister_decrease(self.num_producer_regs)
+            self.load(
+                mQ,
+                mK,
+                mV,
+                sQ,
+                sK,
+                sV,
+                tma_atom_Q,
+                tma_atom_K,
+                tma_atom_V,
+                pipeline_k,
+                pipeline_v,
+                pipeline_q,
+                gmem_tiled_copy_Q,
+                mPageTable,
+                blocksparse_tensors,
+                block_info,
+                SeqlenInfoCls,
+                TileSchedulerCls,
+            )
+
+        else:  # Consumer
+            cute.arch.setmaxregister_increase(self.num_mma_regs)
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Tile MMA compute thread partitions and allocate accumulators
+            # ///////////////////////////////////////////////////////////////////////////////
+            tidx, _, _ = cute.arch.thread_idx()
+            tidx = tidx - 128
+            self.mma(
+                tiled_mma_qk,
+                tiled_mma_pv,
+                mO,
+                mLSE,
+                sQ,
+                sK,
+                sVt,
+                sP,
+                sO,
+                learnable_sink,
+                pipeline_k,
+                pipeline_v,
+                pipeline_q,
+                gmem_tiled_copy_O,
+                tma_atom_O,
+                tidx,
+                softmax_scale_log2,
+                softmax_scale,
+                block_info,
+                SeqlenInfoCls,
+                AttentionMaskCls,
+                TileSchedulerCls,
+                blocksparse_tensors,
+                aux_data,
+                fastdiv_mods,
+            )
+
+    @cute.jit
+    def load(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        sQ: cute.Tensor,
+        sK: cute.Tensor,
+        sV: cute.Tensor,
+        tma_atom_Q: Optional[cute.CopyAtom],
+        tma_atom_K: Optional[cute.CopyAtom],
+        tma_atom_V: Optional[cute.CopyAtom],
+        pipeline_k: pipeline.PipelineAsync,
+        pipeline_v: pipeline.PipelineAsync,
+        pipeline_q: pipeline.PipelineAsync,
+        gmem_tiled_copy_Q: cute.TiledCopy,
+        mPageTable: Optional[cute.Tensor],
+        blocksparse_tensors: Optional[BlockSparseTensors],
+        block_info: BlockInfo,
+        SeqlenInfoCls: Callable,
+        TileSchedulerCls: Callable,
+    ):
+        warp_idx_in_wg = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
+        tidx, _, _ = cute.arch.thread_idx()
+
+        # TMA: only warp 0 loads. cp_async: all warps load.
+        # When not use_tma_Q, all 128 producer threads participate in Q loading.
+        is_load_warp = warp_idx_in_wg == 0 or const_expr(not self.use_tma_KV or not self.use_tma_Q)
+        # KV loading restricted to warp 0 for TMA, all warps for non-TMA KV
+        is_kv_load_warp = warp_idx_in_wg == 0 or const_expr(not self.use_tma_KV)
+
+        if is_load_warp:
+            q_producer_phase = Int32(1)
+            kv_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_stages
+            )
+            tile_scheduler = TileSchedulerCls()
+            work_tile = tile_scheduler.initial_work_tile_info()
+            while work_tile.is_valid_tile:
+                # if work_tile.is_valid_tile:
+                m_block, head_idx, batch_idx, _ = work_tile.tile_idx
+                seqlen = SeqlenInfoCls(batch_idx)
+                mQ_cur = seqlen.offset_batch_Q(mQ, batch_idx, dim=3)[None, None, head_idx]
+                head_idx_kv = (
+                    head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
+                )
+
+                load_Q = None
+                if const_expr(self.use_tma_Q):
+                    gQ = cute.local_tile(mQ_cur, (self.tile_m, self.tile_hdim), (m_block, 0))
+                    load_Q, _, _ = copy_utils.tma_get_copy_fn(
+                        tma_atom_Q, 0, cute.make_layout(1), gQ, sQ, single_stage=True
+                    )
+
+                paged_kv_manager = None
+                tma_load_K_fn = None
+                tma_load_V_fn = None
+                if const_expr(self.use_tma_KV):
+                    # === TMA path (non-paged and paged with page_size == n_block_size) ===
+                    if const_expr(mPageTable is not None):
+                        # Paged TMA: keep page dimension indexable
+                        mK_cur = mK[None, None, head_idx_kv, None]
+                        mV_cur = mV[None, None, head_idx_kv, None]
+                        gK = cute.local_tile(mK_cur, (self.tile_n, self.tile_hdim), (0, 0, None))
+                        gV = cute.local_tile(mV_cur, (self.tile_n, self.tile_hdim), (0, 0, None))
+                    else:
+                        # Non-paged TMA
+                        mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[
+                            None, None, head_idx_kv
+                        ]
+                        mV_cur = seqlen.offset_batch_K(mV, batch_idx, dim=3)[
+                            None, None, head_idx_kv
+                        ]
+                        gK = cute.local_tile(mK_cur, (self.tile_n, self.tile_hdim), (None, 0))
+                        gV = cute.local_tile(mV_cur, (self.tile_n, self.tile_hdim), (None, 0))
+                    # TODO: mcast
+                    tma_load_K_fn, _, _ = copy_utils.tma_get_copy_fn(
+                        tma_atom_K, 0, cute.make_layout(1), gK, sK
+                    )
+                    tma_load_K_fn = copy_utils.tma_producer_copy_fn(tma_load_K_fn, pipeline_k)
+                    tma_load_V_fn, _, _ = copy_utils.tma_get_copy_fn(
+                        tma_atom_V, 0, cute.make_layout(1), gV, sV
+                    )
+                    tma_load_V_fn = copy_utils.tma_producer_copy_fn(tma_load_V_fn, pipeline_v)
+                else:
+                    # === cp_async path (paged KV with page_size != n_block_size) ===
+                    paged_kv_manager = PagedKVManager.create(
+                        mPageTable,
+                        mK,
+                        mV,
+                        FastDivmodDivisor(mK.shape[0]),
+                        batch_idx,
+                        head_idx_kv,
+                        tidx,
+                        seqlen.seqlen_k,
+                        0,  # leftpad_k
+                        self.tile_n,
+                        self.tile_hdim,
+                        self.num_threads_per_warp_group,
+                        mK.element_type,
+                        arch=self.arch.major * 10 + self.arch.minor,
+                    )
+
+                load_K = partial(
+                    self.load_KV,
+                    tma_load_K_fn,
+                    paged_kv_manager,
+                    sK,
+                    pipeline_kv=pipeline_k,
+                    K_or_V="K",
+                )
+                load_V = partial(
+                    self.load_KV,
+                    tma_load_V_fn,
+                    paged_kv_manager,
+                    sV,
+                    pipeline_kv=pipeline_v,
+                    K_or_V="V",
+                )
+
+                pack_gqa = None
+                if const_expr(not self.use_tma_Q):
+                    pack_gqa = PackGQA(
+                        self.tile_m, self.tile_hdim, self.check_hdim_oob, self.qhead_per_kvhead
+                    )
+
+                if const_expr(not self.use_block_sparsity):
+                    n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
+                    # if cute.arch.thread_idx()[0] == 0:
+                    #     cute.printf("m_block = %d, n_block_min: %d, n_block_max: %d", m_block, n_block_min, n_block_max)
+                    # Clamp n_block to 0 when n_block_max == 0 (can happen with causal
+                    # + pack_gqa when seqlen_k < tile_n). TMA handles n_block=-1
+                    # gracefully (fills zeros), but cp.async would crash on
+                    # out-of-bounds page table access.
+                    n_block = (
+                        n_block_max - 1
+                        if const_expr(self.use_tma_KV)
+                        else cutlass.max(n_block_max - 1, 0)
+                    )
+                    page_idx = (
+                        mPageTable[batch_idx, n_block]
+                        if const_expr(mPageTable is not None and self.use_tma_KV)
+                        else None
+                    )
+
+                    # First iteration: load K on pipeline_k, Q on pipeline_q
+                    if is_kv_load_warp:
+                        pipeline_k.producer_acquire(kv_producer_state)
+                        if const_expr(not self.use_tma_KV):
+                            paged_kv_manager.load_page_table(n_block)
+                        load_K(block=n_block, producer_state=kv_producer_state, page_idx=page_idx)
+                    if const_expr(self.use_tma_Q):
+                        if warp_idx_in_wg == 0:
+                            pipeline_q.producer_acquire_w_index_phase(0, q_producer_phase)
+                            load_Q(tma_bar_ptr=pipeline_q.sync_object_full.get_barrier(0))
+                            q_producer_phase ^= 1
+                    else:
+                        pipeline_q.producer_acquire_w_index_phase(0, q_producer_phase)
+                        pack_gqa.load_Q(
+                            mQ_cur, sQ, gmem_tiled_copy_Q, tidx, m_block, seqlen.seqlen_q
+                        )
+                        cute.arch.cp_async_commit_group()
+                        pipeline_q.producer_commit_w_index(0)
+                        q_producer_phase ^= 1
+
+                    if is_kv_load_warp:
+                        if const_expr(not self.intra_wg_overlap or not self.use_tma_KV):
+                            pipeline_v.producer_acquire(kv_producer_state)
+                            load_V(
+                                block=n_block, producer_state=kv_producer_state, page_idx=page_idx
+                            )
+                            kv_producer_state.advance()
+                            for i in cutlass.range(n_block_max - 1 - n_block_min, unroll=1):
+                                n_block = n_block_max - 1 - i - 1
+                                page_idx = (
+                                    mPageTable[batch_idx, n_block]
+                                    if const_expr(mPageTable is not None and self.use_tma_KV)
+                                    else None
+                                )
+                                if const_expr(not self.use_tma_KV):
+                                    paged_kv_manager.load_page_table(n_block)
+                                pipeline_k.producer_acquire(kv_producer_state)
+                                load_K(
+                                    block=n_block,
+                                    producer_state=kv_producer_state,
+                                    page_idx=page_idx,
+                                )
+                                pipeline_v.producer_acquire(kv_producer_state)
+                                load_V(
+                                    block=n_block,
+                                    producer_state=kv_producer_state,
+                                    page_idx=page_idx,
+                                )
+                                kv_producer_state.advance()
+                        else:
+                            for i in cutlass.range(n_block_max - 1 - n_block_min, unroll=1):
+                                n_block_prev = n_block_max - i - 1
+                                n_block = n_block_prev - 1
+                                page_idx = (
+                                    mPageTable[batch_idx, n_block]
+                                    if const_expr(mPageTable is not None)
+                                    else None
+                                )
+                                page_idx_prev = (
+                                    mPageTable[batch_idx, n_block_prev]
+                                    if const_expr(mPageTable is not None)
+                                    else None
+                                )
+                                kv_producer_state_prev = kv_producer_state.clone()
+                                kv_producer_state.advance()
+                                pipeline_k.producer_acquire(kv_producer_state)
+                                load_K(
+                                    block=n_block,
+                                    producer_state=kv_producer_state,
+                                    page_idx=page_idx,
+                                )
+                                pipeline_v.producer_acquire(kv_producer_state_prev)
+                                load_V(
+                                    block=n_block_prev,
+                                    producer_state=kv_producer_state_prev,
+                                    page_idx=page_idx_prev,
+                                )
+                            n_block = n_block_min
+                            page_idx = (
+                                mPageTable[batch_idx, n_block]
+                                if const_expr(mPageTable is not None)
+                                else None
+                            )
+                            pipeline_v.producer_acquire(kv_producer_state)
+                            load_V(
+                                block=n_block, producer_state=kv_producer_state, page_idx=page_idx
+                            )
+                            kv_producer_state.advance()
+                else:
+                    # Block sparsity: use TMA closures directly (not paged)
+                    # Load Q on pipeline_q, separate from K/V pipeline
+                    if const_expr(self.use_tma_Q):
+                        if warp_idx_in_wg == 0:
+                            pipeline_q.producer_acquire_w_index_phase(0, q_producer_phase)
+                            load_Q(tma_bar_ptr=pipeline_q.sync_object_full.get_barrier(0))
+                            q_producer_phase ^= 1
+                    else:
+                        pipeline_q.producer_acquire_w_index_phase(0, q_producer_phase)
+                        pack_gqa.load_Q(
+                            mQ_cur, sQ, gmem_tiled_copy_Q, tidx, m_block, seqlen.seqlen_q
+                        )
+                        cute.arch.cp_async_commit_group()
+                        pipeline_q.producer_commit_w_index(0)
+                        q_producer_phase ^= 1
+                    if is_kv_load_warp:
+                        kv_producer_state = produce_block_sparse_loads(
+                            blocksparse_tensors,
+                            batch_idx,
+                            head_idx,
+                            m_block,
+                            seqlen,
+                            kv_producer_state,
+                            tma_load_K_fn,
+                            tma_load_V_fn,
+                            pipeline_k,
+                            pipeline_v,
+                            self.intra_wg_overlap,
+                            self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+                            self.q_subtile_factor,
+                        )
+
+                tile_scheduler.prefetch_next_work()
+                tile_scheduler.advance_to_next_work()
+                work_tile = tile_scheduler.get_current_work()
+                # End of persistent scheduler loop
+
+            # Producer tail is only useful for cluster to avoid early exit of blocks.
+            # We only need producer_tail on V since that's the last that's loaded, we don't
+            # need it for Q (no cluster) and K.
+            if is_kv_load_warp:
+                pipeline_v.producer_tail(kv_producer_state)
+
+    @cute.jit
+    def load_KV(
+        self,
+        tma_load_fn: Optional[Callable],
+        paged_kv_manager: Optional[PagedKVManager],
+        sX: cute.Tensor,
+        block: Int32,
+        pipeline_kv: pipeline.PipelineAsync,
+        producer_state: pipeline.PipelineState,
+        K_or_V: Literal["K", "V"],
+        page_idx: Optional[Int32] = None,
+    ):
+        if const_expr(self.use_tma_KV):
+            src_idx = block if const_expr(page_idx is None) else page_idx
+            tma_load_fn(src_idx=src_idx, producer_state=producer_state)
+        else:
+            paged_kv_manager.load_KV(block, sX[None, None, producer_state.index], K_or_V)
+            cute.arch.cp_async_commit_group()
+        pipeline_kv.producer_commit(producer_state)
+
+    @cute.jit
+    def mma(
+        self,
+        tiled_mma_qk: cute.TiledMma,
+        tiled_mma_pv: cute.TiledMma,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        sQ: cute.Tensor,
+        sK: cute.Tensor,
+        sVt: cute.Tensor,
+        sP: Optional[cute.Tensor],
+        sO: cute.Tensor,
+        learnable_sink: Optional[cute.Tensor],
+        pipeline_k: pipeline.PipelineAsync,
+        pipeline_v: pipeline.PipelineAsync,
+        pipeline_q: pipeline.PipelineAsync,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tma_atom_O: Optional[cute.CopyAtom],
+        tidx: Int32,
+        softmax_scale_log2: Float32,
+        softmax_scale: Optional[Float32],
+        block_info: BlockInfo,
+        SeqlenInfoCls: Callable,
+        AttentionMaskCls: Callable,
+        TileSchedulerCls: Callable,
+        blocksparse_tensors: Optional[BlockSparseTensors],
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=None,
+    ):
+        aux_tensors = aux_data.tensors
+        warp_group_idx = cute.arch.make_warp_uniform(tidx // self.num_threads_per_warp_group)
+        warp_group_thread_layout = cute.make_layout(
+            self.num_wg_mma, stride=self.num_threads_per_warp_group
+        )
+        thr_mma_qk = tiled_mma_qk.get_slice(tidx)
+        wg_mma_qk = tiled_mma_qk.get_slice(warp_group_thread_layout(warp_group_idx))
+        wg_mma_pv = tiled_mma_pv.get_slice(warp_group_thread_layout(warp_group_idx))
+        _, tSrQ, tSrK = sm90_utils.partition_fragment_ABC(
+            wg_mma_qk, (self.tile_m, self.tile_n, self.tile_hdim), sQ, sK
+        )
+        mma_qk_fn = partial(
+            sm90_utils.gemm_zero_init, tiled_mma_qk, (self.tile_m, self.tile_n), tSrQ, tSrK
+        )
+        acc_O, tOrP, tOrVt = sm90_utils.partition_fragment_ABC(
+            wg_mma_pv, (self.tile_m, self.tile_hdim, self.tile_n), sP, sVt
+        )
+        mma_pv_fn = partial(sm90_utils.gemm_w_idx, tiled_mma_pv, acc_O, tOrP, tOrVt)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Smem copy atom tiling
+        # ///////////////////////////////////////////////////////////////////////////////
+        smem_copy_atom_P = utils.get_smem_store_atom(
+            self.arch.major * 10 + self.arch.minor, self.dtype
+        )
+        smem_thr_copy_P = cute.make_tiled_copy_C(smem_copy_atom_P, tiled_mma_qk).get_slice(tidx)
+        tPsP = smem_thr_copy_P.partition_D(sP) if const_expr(sP is not None) else None
+        smem_copy_params = SimpleNamespace(smem_thr_copy_P=smem_thr_copy_P, tPsP=tPsP)
+
+        self.mma_init()
+
+        q_consumer_phase = Int32(0)
+        kv_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.num_stages
+        )
+
+        tile_scheduler = TileSchedulerCls()
+        work_tile = tile_scheduler.initial_work_tile_info()
+        softmax = Softmax.create(
+            softmax_scale_log2,
+            num_rows=acc_O.shape[0][0] * acc_O.shape[1],
+            softmax_scale=softmax_scale,
+        )
+
+        # For RescaleOBeforeGemm: persistent scores_scale across iterations
+        scores_scale = None
+        if const_expr(self.rescale_O_before_gemm):
+            scores_scale = cute.make_rmem_tensor_like(softmax.row_max, Float32)
+
+        mma_one_n_block_all = partial(
+            self.mma_one_n_block_intrawg_overlap
+            if const_expr(self.intra_wg_overlap)
+            else self.mma_one_n_block,
+            mma_qk_fn=mma_qk_fn,
+            pipeline_k=pipeline_k,
+            pipeline_v=pipeline_v,
+            acc_O=acc_O,
+            tOrP=tOrP,
+            smem_copy_params=smem_copy_params,
+            check_inf=True,
+            scores_scale=scores_scale,
+        )
+
+        process_first_half_block = partial(
+            self.first_half_block_overlap,
+            mma_qk_fn=mma_qk_fn,
+            pipeline_k=pipeline_k,
+            tOrP=tOrP,
+            smem_copy_params=smem_copy_params,
+            scores_scale=scores_scale,
+            softmax=softmax,
+            acc_O=acc_O,
+        )
+        process_last_half_block = partial(
+            self.last_half_block_overlap,
+            pipeline_v=pipeline_v,
+            mma_pv_fn=mma_pv_fn,
+            scores_scale=scores_scale,
+            softmax=softmax,
+            acc_O=acc_O,
+        )
+        while work_tile.is_valid_tile:
+            # if work_tile.is_valid_tile:
+
+            # shape: (atom_v_m * rest_m)
+            m_block, head_idx, batch_idx, _ = work_tile.tile_idx
+            seqlen = SeqlenInfoCls(batch_idx)
+
+            # Recompute fastdiv_mods if necessary for varlen with aux_tensors
+            recompute_fastdiv_mods_q = cutlass.const_expr(
+                aux_tensors is not None and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
+            )
+            recompute_fastdiv_mods_k = cutlass.const_expr(
+                aux_tensors is not None and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
+            )
+            if cutlass.const_expr(fastdiv_mods is not None):
+                seqlen_q_divmod, seqlen_k_divmod = fastdiv_mods
+                fastdiv_mods = (
+                    seqlen_q_divmod
+                    if not recompute_fastdiv_mods_q
+                    else FastDivmodDivisor(seqlen.seqlen_q),
+                    seqlen_k_divmod
+                    if not recompute_fastdiv_mods_k
+                    else FastDivmodDivisor(seqlen.seqlen_k),
+                )
+
+            mask = AttentionMaskCls(seqlen)
+            mask_fn = partial(
+                mask.apply_mask,
+                batch_idx=batch_idx,
+                head_idx=head_idx,
+                m_block=m_block,
+                thr_mma=thr_mma_qk,
+                mask_causal=self.is_causal,
+                mask_local=self.is_local,
+                aux_data=aux_data,
+                fastdiv_mods=fastdiv_mods,
+            )
+            score_mod_fn = None
+            if const_expr(self.score_mod is not None):
+                score_mod_fn = partial(
+                    self.apply_score_mod,
+                    thr_mma_qk,
+                    batch_idx,
+                    head_idx,
+                    m_block,
+                    softmax_scale=softmax_scale,
+                    aux_data=aux_data,
+                    fastdiv_mods=fastdiv_mods,
+                )
+            mma_one_n_block = partial(
+                mma_one_n_block_all, seqlen=seqlen, softmax=softmax, score_mod_fn=score_mod_fn
+            )
+            n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
+            pipeline_q.consumer_wait_w_index_phase(0, q_consumer_phase)
+            # For performance reason, we separate out two kinds of iterations:
+            # those that need masking on S, and those that don't.
+            # We need masking on S for the very last block when K and V has length not multiple of tile_n.
+            # We also need masking on S if it's causal, for the last several blocks.
+            # softmax.reset()  # Don't need reset as we explicitly call softmax w is_first=True
+            O_should_accumulate = False
+
+            # ==========================================
+            # MAINLOOP
+            # ==========================================
+            if const_expr(not self.use_block_sparsity):
+                # ==========================================
+                # No block-sparsity (original path)
+                # ==========================================
+                # First iteration with seqlen masking
+                if const_expr(self.intra_wg_overlap):
+                    kv_consumer_state = process_first_half_block(
+                        n_block=n_block_max - 1,
+                        seqlen=seqlen,
+                        kv_consumer_state=kv_consumer_state,
+                        mask_fn=partial(mask_fn, mask_mod=self.mask_mod),
+                        score_mod_fn=score_mod_fn,
+                        is_first_block=True,
+                    )
+                else:
+                    self.warp_scheduler_barrier_sync()
+                    kv_consumer_state = mma_one_n_block(
+                        kv_consumer_state,
+                        n_block=n_block_max - 1,
+                        seqlen=seqlen,
+                        mma_pv_fn=partial(mma_pv_fn, zero_init=True),
+                        is_first_n_block=True,
+                        mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=True),
+                    )
+                    O_should_accumulate = True
+                # if cute.arch.thread_idx()[0] == 128: cute.printf("m_block = {}, n_block_max = {}, n_block_min = {}", m_block, n_block_max, n_block_min)
+                n_block_max -= 1
+                # Next couple of iterations with causal masking
+                if const_expr(self.is_causal or self.is_local):
+                    n_block_min_causal_local_mask = block_info.get_n_block_min_causal_local_mask(
+                        seqlen, m_block, n_block_min
+                    )
+                    # if cute.arch.thread_idx()[0] == 128: cute.printf("n_block_min_causal_local_mask = {}", n_block_min_causal_local_mask)
+                    for n_tile in cutlass.range(
+                        n_block_max - n_block_min_causal_local_mask, unroll=1
+                    ):
+                        kv_consumer_state = mma_one_n_block(
+                            kv_consumer_state,
+                            n_block=n_block_max - 1 - n_tile,
+                            seqlen=seqlen,
+                            mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                            mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False),
+                        )
+                        O_should_accumulate = True
+                    n_block_max = cutlass.min(n_block_max, n_block_min_causal_local_mask)
+                # The remaining iterations have no masking
+                n_block_min_before_local_mask = block_info.get_n_block_min_before_local_mask(
+                    seqlen, m_block, n_block_min
+                )
+                # if cute.arch.thread_idx()[0] == 128: cute.printf("n_block_min_before_local_mask = {}, n_block_min = {}", n_block_min_before_local_mask, n_block_min)
+                for n_tile in cutlass.range(n_block_max - n_block_min_before_local_mask, unroll=1):
+                    kv_consumer_state = mma_one_n_block(
+                        kv_consumer_state,
+                        n_block=n_block_max - 1 - n_tile,
+                        seqlen=seqlen,
+                        mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                        mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False),
+                    )
+                    O_should_accumulate = True
+                # Separate iterations with local masking on the left
+                if const_expr(self.is_local and block_info.window_size_left is not None):
+                    n_block_max = cutlass.min(n_block_max, n_block_min_before_local_mask)
+                    for n_tile in cutlass.range(n_block_max - n_block_min, unroll=1):
+                        kv_consumer_state = mma_one_n_block(
+                            kv_consumer_state,
+                            n_block=n_block_max - 1 - n_tile,
+                            seqlen=seqlen,
+                            mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                            mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False),
+                        )
+                        O_should_accumulate = True
+                # Release Q pipeline so the producer can load the next tile's Q
+                pipeline_q.consumer_release_w_index(0)
+                # Last "half" iteration
+                if const_expr(self.intra_wg_overlap):
+                    kv_consumer_state = process_last_half_block(
+                        kv_consumer_state=kv_consumer_state,
+                        zero_init=not O_should_accumulate,
+                    )
+                    O_should_accumulate = True
+                else:
+                    self.warp_scheduler_barrier_arrive()
+
+            else:
+                # ==========================================
+                # Block sparsity
+                # ==========================================
+                kv_consumer_state, O_should_accumulate, processed_any = consume_block_sparse_loads(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    m_block,
+                    seqlen,
+                    kv_consumer_state,
+                    mma_pv_fn,
+                    mma_one_n_block,
+                    process_first_half_block,
+                    process_last_half_block,
+                    mask_fn,
+                    score_mod_fn,
+                    O_should_accumulate,
+                    self.mask_mod,
+                    fastdiv_mods,
+                    self.intra_wg_overlap,
+                    self.warp_scheduler_barrier_sync,
+                    self.warp_scheduler_barrier_arrive,
+                    self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+                    self.q_subtile_factor,
+                )
+
+                # Release Q pipeline so the producer can load the next tile's Q
+                pipeline_q.consumer_release_w_index(0)
+
+                # Handle empty case (when no blocks to process)
+                if not processed_any:
+                    softmax.reset()
+                    acc_O.fill(0.0)
+
+            q_consumer_phase ^= 1
+
+            sink_val = None
+            if const_expr(learnable_sink is not None):
+                if const_expr(not self.pack_gqa):
+                    sink_val = Float32(learnable_sink[head_idx])
+                else:  # Each thread might have a different sink value due to different q_head
+                    sink_val = cute.make_rmem_tensor_like(softmax.row_max, Float32)
+                    cS = cute.make_identity_tensor((self.tile_m, self.tile_n))
+                    tScS_mn = layout_utils.reshape_acc_to_mn(thr_mma_qk.partition_C(cS))
+                    for r in cutlass.range(cute.size(sink_val), unroll_full=True):
+                        row = m_block * self.tile_m + tScS_mn[r][0]
+                        q_head_idx = row % self.qhead_per_kvhead + head_idx * self.qhead_per_kvhead
+                        sink_val[r] = Float32(learnable_sink[q_head_idx])
+
+            # normalize acc_O by row_sum and calculate the lse
+            row_scale = softmax.finalize(sink_val=sink_val)
+            softmax.rescale_O(acc_O, row_scale)
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Epilogue
+            # ///////////////////////////////////////////////////////////////////////////////
+            self.epilogue(
+                acc_O,
+                softmax.row_sum,
+                mO,
+                mLSE,
+                sO,
+                seqlen,
+                gmem_tiled_copy_O,
+                tma_atom_O,
+                tiled_mma_pv,
+                tidx,
+                m_block,
+                head_idx,
+                batch_idx,
+            )
+
+            tile_scheduler.advance_to_next_work()
+            work_tile = tile_scheduler.get_current_work()
+
+    @cute.jit
+    def first_half_block_overlap(
+        self,
+        n_block: Int32,
+        mma_qk_fn: Callable,
+        kv_consumer_state,
+        pipeline_k,
+        tOrP: cute.Tensor,
+        smem_copy_params: SimpleNamespace,
+        softmax: Softmax,
+        seqlen: SeqlenInfoQK,
+        scores_scale: Optional[cute.Tensor] = None,
+        acc_O: Optional[cute.Tensor] = None,
+        mask_fn: Callable = None,
+        score_mod_fn: Optional[Callable] = None,
+        is_first_block: bool = False,
+    ):
+        """Processes the first half block when using intra-warpgroup-overlap"""
+
+        pipeline_k.consumer_wait(kv_consumer_state, pipeline_k.consumer_try_wait(kv_consumer_state))
+        acc_S = mma_qk_fn(B_idx=kv_consumer_state.index, wg_wait=0)
+        pipeline_k.consumer_release(kv_consumer_state)
+
+        # Apply score modification if present
+        if const_expr(score_mod_fn is not None):
+            score_mod_fn(acc_S, n_block=n_block, seqlen=seqlen)
+
+        # Apply mask; mask_seqlen always True for first block
+        # Caveat: if full block further right than mask block, seqlen masking is redundant;
+        # however, masking is being applied anyway, so essentially no perf hit
+        mask_fn(acc_S, n_block=n_block, mask_seqlen=True)
+
+        row_scale = softmax.online_softmax(acc_S, is_first=is_first_block)
+
+        tOrP_acc = layout_utils.reshape_acc_to_frgA(acc_S)
+        tOrP_cur = (
+            tOrP
+            if const_expr(self.mma_pv_is_rs)
+            else cute.make_rmem_tensor_like(tOrP_acc, self.dtype)
+        )
+        tOrP_cur.store(tOrP_acc.load().to(self.dtype))
+
+        if const_expr(not self.mma_pv_is_rs):
+            tPrP = smem_copy_params.smem_thr_copy_P.retile(tOrP_cur)
+            cute.copy(smem_copy_params.smem_thr_copy_P, tPrP, smem_copy_params.tPsP)
+            # Fence and barrier to make smem store visible to WGMMA
+            cute.arch.fence_view_async_shared()
+            cute.arch.sync_warp()
+
+        # For RescaleOBeforeGemm: initialize acc_O
+        if const_expr(self.rescale_O_before_gemm):
+            acc_O.fill(0.0)
+            scores_scale.store(row_scale.load())
+
+        return kv_consumer_state
+
+    @cute.jit
+    def last_half_block_overlap(
+        self,
+        kv_consumer_state,
+        pipeline_v,
+        mma_pv_fn: Callable,
+        zero_init: bool,
+        scores_scale: Optional[cute.Tensor] = None,
+        softmax: Optional[Softmax] = None,
+        acc_O: Optional[cute.Tensor] = None,
+    ):
+        """Processes the final PV GEMM when using intra-warpgroup-overlap"""
+
+        # For RescaleOBeforeGemm: rescale O before the final PV GEMM
+        if const_expr(self.rescale_O_before_gemm):
+            softmax.rescale_O(acc_O, scores_scale)
+
+        pipeline_v.consumer_wait(kv_consumer_state, pipeline_v.consumer_try_wait(kv_consumer_state))
+        mma_pv_fn(B_idx=kv_consumer_state.index, zero_init=zero_init, wg_wait=0)
+        pipeline_v.consumer_release(kv_consumer_state)
+        kv_consumer_state.advance()
+        return kv_consumer_state
+
+    @cute.jit
+    def mma_one_n_block(
+        self,
+        smem_pipe_read: pipeline.PipelineState | pipeline_custom.PipelineStateSimple,
+        n_block: Int32,
+        mma_qk_fn: Callable,
+        mma_pv_fn: Callable,
+        pipeline_k: pipeline.PipelineAsync,
+        pipeline_v: pipeline.PipelineAsync,
+        acc_O: cute.Tensor,
+        tOrP: cute.Tensor,
+        smem_copy_params: SimpleNamespace,
+        softmax: Softmax,
+        seqlen: SeqlenInfoQK,
+        scores_scale: Optional[cute.Tensor] = None,  # not used
+        score_mod_fn: Optional[Callable] = None,
+        mask_fn: Optional[Callable] = None,
+        is_first_n_block: cutlass.Constexpr = False,
+        check_inf: cutlass.Constexpr = True,
+    ):
+        pipeline_k.consumer_wait(smem_pipe_read, pipeline_k.consumer_try_wait(smem_pipe_read))
+        # S = Q @ K.T
+        acc_S = mma_qk_fn(B_idx=smem_pipe_read.index, wg_wait=-1)
+        self.warp_scheduler_barrier_arrive()
+        warpgroup.wait_group(0)
+        pipeline_k.consumer_release(smem_pipe_read)
+
+        # handle score mods and masking
+        if const_expr(score_mod_fn is not None):
+            score_mod_fn(acc_S, n_block=n_block, seqlen=seqlen)
+        if const_expr(mask_fn is not None):
+            mask_fn(acc_S=acc_S, n_block=n_block)
+
+        row_scale = softmax.online_softmax(acc_S, is_first=is_first_n_block, check_inf=check_inf)
+        # if cute.arch.thread_idx()[0] == 0: cute.print_tensor(layout_utils.reshape_acc_to_mn(acc_S))
+        tOrP_acc = layout_utils.reshape_acc_to_frgA(acc_S)
+        tOrP_cur = (
+            tOrP
+            if const_expr(self.mma_pv_is_rs)
+            else cute.make_rmem_tensor_like(tOrP_acc, self.dtype)
+        )
+        # tOrP.store(tOrP_acc.load().to(self.dtype))
+        # the "to(self.dtype)" conversion fails to vectorize for block sizes other
+        # than 128 x 128, i.e. it calls convert on 1 fp32 element at a time instead of
+        # 2 elements. So we just call ptx directly.
+        utils.cvt_f16(tOrP_acc, tOrP_cur)
+        if const_expr(not self.mma_pv_is_rs):
+            tPrP = smem_copy_params.smem_thr_copy_P.retile(tOrP_cur)
+            cute.copy(smem_copy_params.smem_thr_copy_P, tPrP, smem_copy_params.tPsP)
+        softmax.rescale_O(acc_O, row_scale)
+        if const_expr(not self.mma_pv_is_rs):
+            # Fence and barrier to make sure smem store is visible to WGMMA
+            cute.arch.fence_view_async_shared()
+            cute.arch.sync_warp()  # Only need syncwarp since each warp is using its own P values for MmaPV
+        pipeline_v.consumer_wait(smem_pipe_read, pipeline_v.consumer_try_wait(smem_pipe_read))
+        self.warp_scheduler_barrier_sync()
+        # O += P @ V
+        mma_pv_fn(B_idx=smem_pipe_read.index, wg_wait=0)
+        pipeline_v.consumer_release(smem_pipe_read)
+        smem_pipe_read.advance()
+        return smem_pipe_read
+
+    @cute.jit
+    def mma_one_n_block_intrawg_overlap(
+        self,
+        smem_pipe_read: pipeline.PipelineState | pipeline_custom.PipelineStateSimple,
+        n_block: Int32,
+        mma_qk_fn: Callable,
+        mma_pv_fn: Callable,
+        pipeline_k: pipeline.PipelineAsync,
+        pipeline_v: pipeline.PipelineAsync,
+        acc_O: cute.Tensor,
+        tOrP: cute.Tensor,
+        smem_copy_params: SimpleNamespace,
+        softmax: Softmax,
+        seqlen: SeqlenInfoQK,
+        scores_scale: Optional[cute.Tensor] = None,
+        score_mod_fn: Optional[Callable] = None,
+        mask_fn: Optional[Callable] = None,
+        check_inf: cutlass.Constexpr = True,
+    ):
+        smem_pipe_read_v = smem_pipe_read.clone()
+        smem_pipe_read.advance()
+        pipeline_k.consumer_wait(smem_pipe_read, pipeline_k.consumer_try_wait(smem_pipe_read))
+        self.warp_scheduler_barrier_sync()
+        # S = Q @ K.T
+        acc_S = mma_qk_fn(B_idx=smem_pipe_read.index, wg_wait=-1)
+        # RescaleOBeforeGemm: rescale O while QK GEMM is in flight, before PV GEMM
+        if const_expr(self.rescale_O_before_gemm):
+            softmax.rescale_O(acc_O, scores_scale)
+        pipeline_v.consumer_wait(smem_pipe_read_v, pipeline_v.consumer_try_wait(smem_pipe_read_v))
+        # O += P @ V
+        mma_pv_fn(B_idx=smem_pipe_read_v.index, wg_wait=-1)
+        self.warp_scheduler_barrier_arrive()
+        warpgroup.wait_group(1)
+        pipeline_k.consumer_release(smem_pipe_read)
+
+        # handle score mods and masking
+        if const_expr(score_mod_fn is not None):
+            score_mod_fn(acc_S, n_block=n_block, seqlen=seqlen)
+        if const_expr(mask_fn is not None):
+            mask_fn(acc_S=acc_S, n_block=n_block)
+        # if cute.arch.thread_idx()[0] == 128: cute.print_tensor(layout_utils.reshape_acc_to_mn(acc_S))
+
+        row_scale = softmax.online_softmax(acc_S, check_inf=check_inf)
+        warpgroup.wait_group(0)
+        pipeline_v.consumer_release(smem_pipe_read_v)
+        tOrP_acc = layout_utils.reshape_acc_to_frgA(acc_S)
+        tOrP_cur = (
+            tOrP
+            if const_expr(self.mma_pv_is_rs)
+            else cute.make_rmem_tensor_like(tOrP_acc, self.dtype)
+        )
+        # tOrP_cur.store(tOrP_acc.load().to(self.dtype))
+        # the "to(self.dtype)" conversion fails to vectorize for block sizes other
+        # than 128 x 128, i.e. it calls convert on 1 fp32 element at a time instead of
+        # 2 elements. So we just call ptx directly.
+        utils.cvt_f16(tOrP_acc, tOrP_cur)
+        if const_expr(not self.mma_pv_is_rs):
+            tPrP = smem_copy_params.smem_thr_copy_P.retile(tOrP_cur)
+            cute.copy(smem_copy_params.smem_thr_copy_P, tPrP, smem_copy_params.tPsP)
+        if const_expr(not self.rescale_O_before_gemm):
+            softmax.rescale_O(acc_O, row_scale)
+        if const_expr(self.rescale_O_before_gemm):
+            scores_scale.store(row_scale.load())
+        if const_expr(not self.mma_pv_is_rs):
+            # Fence and barrier to make sure smem store is visible to WGMMA
+            cute.arch.fence_view_async_shared()
+            cute.arch.sync_warp()  # Only need syncwarp since each warp is using its own P values for MmaPV
+        return smem_pipe_read
+
+    @cute.jit
+    def mma_init(self):
+        warp_group_idx = utils.canonical_warp_group_idx(sync=False)
+        if const_expr(self.use_scheduler_barrier):
+            if warp_group_idx == 1:
+                cute.arch.barrier_arrive(
+                    barrier_id=int(NamedBarrierFwd.WarpSchedulerWG1),
+                    number_of_threads=2 * self.num_threads_per_warp_group,
+                )
+
+    @cute.jit
+    def apply_score_mod(
+        self,
+        thr_mma_qk,
+        batch_idx,
+        head_idx,
+        m_block,
+        acc_S,
+        n_block,
+        softmax_scale,
+        seqlen,
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=None,
+    ):
+        # Prepare index tensor
+        cS = cute.make_identity_tensor((self.tile_m, self.tile_n))
+        cS = cute.domain_offset((m_block * self.tile_m, n_block * self.tile_n), cS)
+        tScS = thr_mma_qk.partition_C(cS)
+
+        apply_score_mod_inner(
+            acc_S,
+            tScS,
+            self.score_mod,
+            batch_idx,
+            head_idx,
+            softmax_scale,
+            self.score_vec_size,
+            self.qk_acc_dtype,
+            aux_data,
+            fastdiv_mods,
+            seqlen_info=seqlen,
+            constant_q_idx=None,
+            qhead_per_kvhead=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+
+    def warp_scheduler_barrier_sync(self):
+        if const_expr(self.use_scheduler_barrier):
+            cute.arch.barrier(
+                barrier_id=int(NamedBarrierFwd.WarpSchedulerWG1)
+                - 1
+                + utils.canonical_warp_group_idx(sync=False),
+                number_of_threads=2 * self.num_threads_per_warp_group,
+            )
+
+    def warp_scheduler_barrier_arrive(self):
+        if const_expr(self.use_scheduler_barrier):
+            assert self.num_wg_mma in [2, 3]
+            cur_wg = utils.canonical_warp_group_idx(sync=False) - 1
+            if const_expr(self.num_wg_mma == 2):
+                next_wg = 1 - cur_wg
+            else:
+                t = cur_wg + 1
+                next_wg = t % self.num_wg_mma
+            cute.arch.barrier_arrive(
+                barrier_id=int(NamedBarrierFwd.WarpSchedulerWG1) + next_wg,
+                number_of_threads=2 * self.num_threads_per_warp_group,
+            )
+
+
+class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
     def __init__(
         self,
         *args,

--- a/flash_sparse_attn/ops/cute/flash_fwd_sm90.py
+++ b/flash_sparse_attn/ops/cute/flash_fwd_sm90.py
@@ -56,6 +56,7 @@ from flash_sparse_attn.ops.cute.flash_fwd import (
 from flash_sparse_attn.ops.cute.utils import AuxData
 
 
+# NOTE: only for sync
 class FlashAttentionForwardSm90(FlashAttentionForwardBase):
     def __init__(
         self,

--- a/flash_sparse_attn/ops/cute/flash_fwd_sm90.py
+++ b/flash_sparse_attn/ops/cute/flash_fwd_sm90.py
@@ -1632,7 +1632,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         # 1 stage * 2 for Q pipeline (full + empty), self.num_stages*2 for K, self.num_stages*2 for V,
         mbar_ptr_Q_struct = cute.struct.MemRange[cutlass.Int64, 1 * 2]
         mbar_ptr_K_struct = cute.struct.MemRange[cutlass.Int64, self.num_stages * 2]
-        mbar_ptr_V_struct = cute.struct.MemRange[cutlass.Int64, self.num_stages * 2]
+        mbar_ptr_V_struct = cute.struct.MemRange[cutlass.Int64, 1 * 2]
 
         @cute.struct
         class SharedStorageQKV:
@@ -1644,6 +1644,10 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
             sK: sK_struct
             sP: sP_struct
 
+            @cute.jit
+            def get_sSkip(self, sSkip_layout: cute.Layout):
+                return self.sV.get_tensor(sSkip_layout, dtype=Int32)
+
         @cute.struct
         class SharedStorageSharedQV:
             mbar_ptr_Q: mbar_ptr_Q_struct
@@ -1652,6 +1656,10 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
             sQ: sQV_struct
             sK: sK_struct
             sP: sP_struct
+
+            @cute.jit
+            def get_sSkip(self, sSkip_layout: cute.Layout):
+                return self.sQ.get_tensor(sSkip_layout, dtype=Int32)
 
         return SharedStorageQKV if const_expr(not self.Q_in_regs) else SharedStorageSharedQV
 
@@ -1748,7 +1756,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
             for mX, shape, stage in [
                 (mQ, (self.tile_m, self.tile_hdim), None),
                 (mK, (self.tile_n, self.tile_hdim), self.num_stages),
-                (mV, (self.tile_n, self.tile_hdim), self.num_stages),
+                (mV, (self.tile_n, self.tile_hdim), 1),
                 (mO, (self.tile_m, self.tile_hdim), None),
             ]
         ]
@@ -1879,6 +1887,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
             tma_atom_O,
             softmax_scale_log2,
             softmax_scale,
+            softmax_threshold,
             mWindowSizes,
             learnable_sink,
             blocksparse_tensors,
@@ -1924,6 +1933,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         tma_atom_O: Optional[cute.CopyAtom],
         softmax_scale_log2: Float32,
         softmax_scale: Optional[Float32],
+        softmax_threshold: Float32,
         mWindowSizes: Optional[cute.Tensor],
         learnable_sink: Optional[cute.Tensor],
         blocksparse_tensors: Optional[BlockSparseTensors],
@@ -1990,13 +2000,21 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                 tx_count=self.tma_copy_bytes["K"],
                 defer_sync=True,
             )
+            sSkip = storage.get_sSkip(
+                cute.make_layout((self.num_mma_threads // cute.arch.WARP_SIZE + 1,))
+            )
             pipeline_v = pipeline_custom.PipelineTmaAsync.create(
                 barrier_storage=storage.mbar_ptr_V.data_ptr(),
-                num_stages=self.num_stages,
+                num_stages=1,
                 producer_group=tma_warp,
                 consumer_group=mma_warps,
                 tx_count=self.tma_copy_bytes["V"],
                 defer_sync=True,
+                sSkip=sSkip,
+                barrier_full_id=int(NamedBarrierFwd.PFull),
+                barrier_empty_id=int(NamedBarrierFwd.PEmpty),
+                skip_num_threads=self.num_mma_threads + cute.arch.WARP_SIZE,
+                producer_skip_idx=self.num_mma_threads // cute.arch.WARP_SIZE,
             )
         else:
             pipeline_k = pipeline_custom.PipelineCpAsync.create(
@@ -2010,7 +2028,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
             )
             pipeline_v = pipeline_custom.PipelineCpAsync.create(
                 barrier_storage=storage.mbar_ptr_V.data_ptr(),
-                num_stages=self.num_stages,
+                num_stages=1,
                 producer_group=load_threads,
                 consumer_group=mma_warps,
                 defer_sync=True,
@@ -2140,6 +2158,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                 sVt,
                 sP,
                 sO,
+                sSkip,
                 learnable_sink,
                 pipeline_k,
                 pipeline_v,
@@ -2149,6 +2168,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                 tidx,
                 softmax_scale_log2,
                 softmax_scale,
+                softmax_threshold,
                 block_info,
                 SeqlenInfoCls,
                 AttentionMaskCls,
@@ -2191,9 +2211,10 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
 
         if is_load_warp:
             q_producer_phase = Int32(1)
-            kv_producer_state = pipeline.make_pipeline_state(
+            k_producer_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Producer, self.num_stages
             )
+            v_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, 1)
             tile_scheduler = TileSchedulerCls()
             work_tile = tile_scheduler.initial_work_tile_info()
             while work_tile.is_valid_tile:
@@ -2293,6 +2314,15 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                         n_block_sink_min,
                         n_block_sink_max,
                     ) = block_info.get_n_block_min_max(seqlen, m_block)
+                    first_n_block = n_block_max - 1
+                    if const_expr(self.is_local):
+                        if n_block_min == n_block_max:
+                            if n_block_window_min < n_block_window_max:
+                                first_n_block = n_block_window_max - 1
+                                n_block_window_max -= 1
+                            else:
+                                first_n_block = n_block_sink_max - 1
+                                n_block_sink_max -= 1
                     # if cute.arch.thread_idx()[0] == 0:
                     #     cute.printf("m_block = %d, n_block_min: %d, n_block_max: %d", m_block, n_block_min, n_block_max)
                     # Clamp n_block to 0 when n_block_max == 0 (can happen with causal
@@ -2300,9 +2330,9 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                     # gracefully (fills zeros), but cp.async would crash on
                     # out-of-bounds page table access.
                     n_block = (
-                        n_block_max - 1
+                        first_n_block
                         if const_expr(self.use_tma_KV)
-                        else cutlass.max(n_block_max - 1, 0)
+                        else cutlass.max(first_n_block, 0)
                     )
                     page_idx = (
                         mPageTable[batch_idx, n_block]
@@ -2312,10 +2342,10 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
 
                     # First iteration: load K on pipeline_k, Q on pipeline_q
                     if is_kv_load_warp:
-                        pipeline_k.producer_acquire(kv_producer_state)
+                        pipeline_k.producer_acquire(k_producer_state)
                         if const_expr(not self.use_tma_KV):
                             paged_kv_manager.load_page_table(n_block)
-                        load_K(block=n_block, producer_state=kv_producer_state, page_idx=page_idx)
+                        load_K(block=n_block, producer_state=k_producer_state, page_idx=page_idx)
                     if const_expr(self.use_tma_Q):
                         if warp_idx_in_wg == 0:
                             pipeline_q.producer_acquire_w_index_phase(0, q_producer_phase)
@@ -2332,11 +2362,12 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
 
                     if is_kv_load_warp:
                         if const_expr(not self.intra_wg_overlap or not self.use_tma_KV):
-                            pipeline_v.producer_acquire(kv_producer_state)
+                            pipeline_v.producer_acquire(v_producer_state)
                             load_V(
-                                block=n_block, producer_state=kv_producer_state, page_idx=page_idx
+                                block=n_block, producer_state=v_producer_state, page_idx=page_idx
                             )
-                            kv_producer_state.advance()
+                            k_producer_state.advance()
+                            v_producer_state.advance()
                             for i in cutlass.range(n_block_max - 1 - n_block_min, unroll=1):
                                 n_block = n_block_max - 1 - i - 1
                                 page_idx = (
@@ -2346,19 +2377,20 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                                 )
                                 if const_expr(not self.use_tma_KV):
                                     paged_kv_manager.load_page_table(n_block)
-                                pipeline_k.producer_acquire(kv_producer_state)
+                                pipeline_k.producer_acquire(k_producer_state)
                                 load_K(
                                     block=n_block,
-                                    producer_state=kv_producer_state,
+                                    producer_state=k_producer_state,
                                     page_idx=page_idx,
                                 )
-                                pipeline_v.producer_acquire(kv_producer_state)
+                                pipeline_v.producer_acquire(v_producer_state)
                                 load_V(
                                     block=n_block,
-                                    producer_state=kv_producer_state,
+                                    producer_state=v_producer_state,
                                     page_idx=page_idx,
                                 )
-                                kv_producer_state.advance()
+                                k_producer_state.advance()
+                                v_producer_state.advance()
                             if const_expr(self.is_local):
                                 for i in cutlass.range(
                                     n_block_window_max - n_block_window_min, unroll=1
@@ -2371,19 +2403,20 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                                     )
                                     if const_expr(not self.use_tma_KV):
                                         paged_kv_manager.load_page_table(n_block)
-                                    pipeline_k.producer_acquire(kv_producer_state)
+                                    pipeline_k.producer_acquire(k_producer_state)
                                     load_K(
                                         block=n_block,
-                                        producer_state=kv_producer_state,
+                                        producer_state=k_producer_state,
                                         page_idx=page_idx,
                                     )
-                                    pipeline_v.producer_acquire(kv_producer_state)
+                                    pipeline_v.producer_acquire(v_producer_state)
                                     load_V(
                                         block=n_block,
-                                        producer_state=kv_producer_state,
+                                        producer_state=v_producer_state,
                                         page_idx=page_idx,
                                     )
-                                    kv_producer_state.advance()
+                                    k_producer_state.advance()
+                                    v_producer_state.advance()
                                 for i in cutlass.range(
                                     n_block_sink_max - n_block_sink_min, unroll=1
                                 ):
@@ -2395,19 +2428,20 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                                     )
                                     if const_expr(not self.use_tma_KV):
                                         paged_kv_manager.load_page_table(n_block)
-                                    pipeline_k.producer_acquire(kv_producer_state)
+                                    pipeline_k.producer_acquire(k_producer_state)
                                     load_K(
                                         block=n_block,
-                                        producer_state=kv_producer_state,
+                                        producer_state=k_producer_state,
                                         page_idx=page_idx,
                                     )
-                                    pipeline_v.producer_acquire(kv_producer_state)
+                                    pipeline_v.producer_acquire(v_producer_state)
                                     load_V(
                                         block=n_block,
-                                        producer_state=kv_producer_state,
+                                        producer_state=v_producer_state,
                                         page_idx=page_idx,
                                     )
-                                    kv_producer_state.advance()
+                                    k_producer_state.advance()
+                                    v_producer_state.advance()
                         else:
                             for i in cutlass.range(n_block_max - 1 - n_block_min, unroll=1):
                                 n_block_prev = n_block_max - i - 1
@@ -2422,31 +2456,32 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                                     if const_expr(mPageTable is not None)
                                     else None
                                 )
-                                kv_producer_state_prev = kv_producer_state.clone()
-                                kv_producer_state.advance()
-                                pipeline_k.producer_acquire(kv_producer_state)
+                                k_producer_state.advance()
+                                pipeline_k.producer_acquire(k_producer_state)
                                 load_K(
                                     block=n_block,
-                                    producer_state=kv_producer_state,
+                                    producer_state=k_producer_state,
                                     page_idx=page_idx,
                                 )
-                                pipeline_v.producer_acquire(kv_producer_state_prev)
+                                pipeline_v.producer_acquire(v_producer_state)
                                 load_V(
                                     block=n_block_prev,
-                                    producer_state=kv_producer_state_prev,
+                                    producer_state=v_producer_state,
                                     page_idx=page_idx_prev,
                                 )
-                            n_block = n_block_min
+                                v_producer_state.advance()
+                            n_block = n_block_min if n_block_min < n_block_max else first_n_block
                             page_idx = (
                                 mPageTable[batch_idx, n_block]
                                 if const_expr(mPageTable is not None)
                                 else None
                             )
-                            pipeline_v.producer_acquire(kv_producer_state)
+                            pipeline_v.producer_acquire(v_producer_state)
                             load_V(
-                                block=n_block, producer_state=kv_producer_state, page_idx=page_idx
+                                block=n_block, producer_state=v_producer_state, page_idx=page_idx
                             )
-                            kv_producer_state.advance()
+                            k_producer_state.advance()
+                            v_producer_state.advance()
                             if const_expr(self.is_local):
                                 if n_block_window_max > n_block_window_min:
                                     n_block = n_block_window_max - 1
@@ -2455,10 +2490,10 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                                         if const_expr(mPageTable is not None)
                                         else None
                                     )
-                                    pipeline_k.producer_acquire(kv_producer_state)
+                                    pipeline_k.producer_acquire(k_producer_state)
                                     load_K(
                                         block=n_block,
-                                        producer_state=kv_producer_state,
+                                        producer_state=k_producer_state,
                                         page_idx=page_idx,
                                     )
                                     for i in cutlass.range(
@@ -2477,33 +2512,34 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                                             if const_expr(mPageTable is not None)
                                             else None
                                         )
-                                        kv_producer_state_prev = kv_producer_state.clone()
-                                        kv_producer_state.advance()
-                                        pipeline_k.producer_acquire(kv_producer_state)
+                                        k_producer_state.advance()
+                                        pipeline_k.producer_acquire(k_producer_state)
                                         load_K(
                                             block=n_block,
-                                            producer_state=kv_producer_state,
+                                            producer_state=k_producer_state,
                                             page_idx=page_idx,
                                         )
-                                        pipeline_v.producer_acquire(kv_producer_state_prev)
+                                        pipeline_v.producer_acquire(v_producer_state)
                                         load_V(
                                             block=n_block_prev,
-                                            producer_state=kv_producer_state_prev,
+                                            producer_state=v_producer_state,
                                             page_idx=page_idx_prev,
                                         )
+                                        v_producer_state.advance()
                                     n_block = n_block_window_min
                                     page_idx = (
                                         mPageTable[batch_idx, n_block]
                                         if const_expr(mPageTable is not None)
                                         else None
                                     )
-                                    pipeline_v.producer_acquire(kv_producer_state)
+                                    pipeline_v.producer_acquire(v_producer_state)
                                     load_V(
                                         block=n_block,
-                                        producer_state=kv_producer_state,
+                                        producer_state=v_producer_state,
                                         page_idx=page_idx,
                                     )
-                                    kv_producer_state.advance()
+                                    k_producer_state.advance()
+                                    v_producer_state.advance()
                                 if n_block_sink_max > n_block_sink_min:
                                     n_block = n_block_sink_max - 1
                                     page_idx = (
@@ -2511,10 +2547,10 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                                         if const_expr(mPageTable is not None)
                                         else None
                                     )
-                                    pipeline_k.producer_acquire(kv_producer_state)
+                                    pipeline_k.producer_acquire(k_producer_state)
                                     load_K(
                                         block=n_block,
-                                        producer_state=kv_producer_state,
+                                        producer_state=k_producer_state,
                                         page_idx=page_idx,
                                     )
                                     for i in cutlass.range(
@@ -2533,33 +2569,34 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                                             if const_expr(mPageTable is not None)
                                             else None
                                         )
-                                        kv_producer_state_prev = kv_producer_state.clone()
-                                        kv_producer_state.advance()
-                                        pipeline_k.producer_acquire(kv_producer_state)
+                                        k_producer_state.advance()
+                                        pipeline_k.producer_acquire(k_producer_state)
                                         load_K(
                                             block=n_block,
-                                            producer_state=kv_producer_state,
+                                            producer_state=k_producer_state,
                                             page_idx=page_idx,
                                         )
-                                        pipeline_v.producer_acquire(kv_producer_state_prev)
+                                        pipeline_v.producer_acquire(v_producer_state)
                                         load_V(
                                             block=n_block_prev,
-                                            producer_state=kv_producer_state_prev,
+                                            producer_state=v_producer_state,
                                             page_idx=page_idx_prev,
                                         )
+                                        v_producer_state.advance()
                                     n_block = n_block_sink_min
                                     page_idx = (
                                         mPageTable[batch_idx, n_block]
                                         if const_expr(mPageTable is not None)
                                         else None
                                     )
-                                    pipeline_v.producer_acquire(kv_producer_state)
+                                    pipeline_v.producer_acquire(v_producer_state)
                                     load_V(
                                         block=n_block,
-                                        producer_state=kv_producer_state,
+                                        producer_state=v_producer_state,
                                         page_idx=page_idx,
                                     )
-                                    kv_producer_state.advance()
+                                    k_producer_state.advance()
+                                    v_producer_state.advance()
                 else:
                     # Block sparsity: use TMA closures directly (not paged)
                     # Load Q on pipeline_q, separate from K/V pipeline
@@ -2577,13 +2614,13 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                         pipeline_q.producer_commit_w_index(0)
                         q_producer_phase ^= 1
                     if is_kv_load_warp:
-                        kv_producer_state = produce_block_sparse_loads(
+                        k_producer_state, v_producer_state = produce_block_sparse_loads(
                             blocksparse_tensors,
                             batch_idx,
                             head_idx,
                             m_block,
                             seqlen,
-                            kv_producer_state,
+                            (k_producer_state, v_producer_state),
                             tma_load_K_fn,
                             tma_load_V_fn,
                             pipeline_k,
@@ -2602,7 +2639,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
             # We only need producer_tail on V since that's the last that's loaded, we don't
             # need it for Q (no cluster) and K.
             if is_kv_load_warp:
-                pipeline_v.producer_tail(kv_producer_state)
+                pipeline_v.producer_tail(v_producer_state)
 
     @cute.jit
     def load_KV(
@@ -2618,7 +2655,12 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
     ):
         if const_expr(self.use_tma_KV):
             src_idx = block if const_expr(page_idx is None) else page_idx
-            tma_load_fn(src_idx=src_idx, producer_state=producer_state)
+            if const_expr(K_or_V == "V"):
+                is_skip = cutlass.Boolean(pipeline_kv._sSkip[pipeline_kv._producer_skip_idx] != 0)
+                if not is_skip:
+                    tma_load_fn(src_idx=src_idx, producer_state=producer_state)
+            else:
+                tma_load_fn(src_idx=src_idx, producer_state=producer_state)
         else:
             paged_kv_manager.load_KV(block, sX[None, None, producer_state.index], K_or_V)
             cute.arch.cp_async_commit_group()
@@ -2636,6 +2678,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         sVt: cute.Tensor,
         sP: Optional[cute.Tensor],
         sO: cute.Tensor,
+        sSkip: cute.Tensor,
         learnable_sink: Optional[cute.Tensor],
         pipeline_k: pipeline.PipelineAsync,
         pipeline_v: pipeline.PipelineAsync,
@@ -2645,6 +2688,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         tidx: Int32,
         softmax_scale_log2: Float32,
         softmax_scale: Optional[Float32],
+        softmax_threshold: Float32,
         block_info: BlockInfo,
         SeqlenInfoCls: Callable,
         AttentionMaskCls: Callable,
@@ -2685,9 +2729,11 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         self.mma_init()
 
         q_consumer_phase = Int32(0)
-        kv_consumer_state = pipeline.make_pipeline_state(
+        k_consumer_state = pipeline.make_pipeline_state(
             pipeline.PipelineUserType.Consumer, self.num_stages
         )
+        v_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, 1)
+        kv_consumer_state = k_consumer_state, v_consumer_state
 
         tile_scheduler = TileSchedulerCls()
         work_tile = tile_scheduler.initial_work_tile_info()
@@ -2701,6 +2747,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         scores_scale = None
         if const_expr(self.rescale_O_before_gemm):
             scores_scale = cute.make_rmem_tensor_like(softmax.row_max, Float32)
+        rSkip = cute.make_rmem_tensor(1, Int32)
 
         mma_one_n_block_all = partial(
             self.mma_one_n_block_intrawg_overlap
@@ -2714,9 +2761,10 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
             smem_copy_params=smem_copy_params,
             check_inf=True,
             scores_scale=scores_scale,
+            rSkip=rSkip,
         )
 
-        process_first_half_block = partial(
+        process_first_half_block_all = partial(
             self.first_half_block_overlap,
             mma_qk_fn=mma_qk_fn,
             pipeline_k=pipeline_k,
@@ -2725,6 +2773,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
             scores_scale=scores_scale,
             softmax=softmax,
             acc_O=acc_O,
+            rSkip=rSkip,
         )
         process_last_half_block = partial(
             self.last_half_block_overlap,
@@ -2733,6 +2782,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
             scores_scale=scores_scale,
             softmax=softmax,
             acc_O=acc_O,
+            rSkip=rSkip,
         )
         while work_tile.is_valid_tile:
             # if work_tile.is_valid_tile:
@@ -2740,6 +2790,28 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
             # shape: (atom_v_m * rest_m)
             m_block, head_idx, batch_idx, _ = work_tile.tile_idx
             seqlen = SeqlenInfoCls(batch_idx)
+            softmax_threshold_log2 = seqlen.get_softmax_threshold(
+                softmax_threshold,
+                m_block,
+                softmax.row_max,
+                thr_mma_qk,
+                self.tile_m,
+                self.tile_n,
+                self.is_causal,
+                self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            )
+            skip_fn = partial(
+                softmax.skip,
+                softmax_threshold_log2=softmax_threshold_log2,
+                sSkip=sSkip,
+                num_warps=self.num_mma_threads // cute.arch.WARP_SIZE,
+                tidx_offset=self.num_threads_per_warp_group,
+                barrier_reduce_id=int(NamedBarrierFwd.Softmax),
+                barrier_full_id=(int(NamedBarrierFwd.PFull) if const_expr(self.use_tma_KV) else 0),
+                barrier_empty_id=(
+                    int(NamedBarrierFwd.PEmpty) if const_expr(self.use_tma_KV) else 0
+                ),
+            )
 
             # Recompute fastdiv_mods if necessary for varlen with aux_tensors
             recompute_fastdiv_mods_q = cutlass.const_expr(
@@ -2784,7 +2856,15 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                     fastdiv_mods=fastdiv_mods,
                 )
             mma_one_n_block = partial(
-                mma_one_n_block_all, seqlen=seqlen, softmax=softmax, score_mod_fn=score_mod_fn
+                mma_one_n_block_all,
+                seqlen=seqlen,
+                softmax=softmax,
+                score_mod_fn=score_mod_fn,
+                skip_fn=skip_fn,
+            )
+            process_first_half_block = partial(
+                process_first_half_block_all,
+                skip_fn=skip_fn,
             )
             (
                 n_block_min,
@@ -2794,6 +2874,15 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                 n_block_sink_min,
                 n_block_sink_max,
             ) = block_info.get_n_block_min_max(seqlen, m_block)
+            first_n_block = n_block_max - 1
+            if const_expr(self.is_local):
+                if n_block_min == n_block_max:
+                    if n_block_window_min < n_block_window_max:
+                        first_n_block = n_block_window_max - 1
+                        n_block_window_max -= 1
+                    else:
+                        first_n_block = n_block_sink_max - 1
+                        n_block_sink_max -= 1
             n_block_max_no_mask = block_info.get_n_block_min_causal_local_mask(
                 seqlen,
                 m_block,
@@ -2838,7 +2927,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                 # First iteration with seqlen masking
                 if const_expr(self.intra_wg_overlap):
                     kv_consumer_state = process_first_half_block(
-                        n_block=n_block_max - 1,
+                        n_block=first_n_block,
                         seqlen=seqlen,
                         kv_consumer_state=kv_consumer_state,
                         mask_fn=partial(
@@ -2847,6 +2936,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                             mask_seqlen=True,
                             mask_causal=self.is_causal and not self.is_local,
                             mask_local=self.is_local,
+                            mask_sink=self.is_local,
                         ),
                         score_mod_fn=score_mod_fn,
                         is_first_block=True,
@@ -2855,7 +2945,7 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                     self.warp_scheduler_barrier_sync()
                     kv_consumer_state = mma_one_n_block(
                         kv_consumer_state,
-                        n_block=n_block_max - 1,
+                        n_block=first_n_block,
                         seqlen=seqlen,
                         mma_pv_fn=partial(mma_pv_fn, zero_init=True),
                         is_first_n_block=True,
@@ -2865,11 +2955,12 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
                             mask_seqlen=True,
                             mask_causal=self.is_causal and not self.is_local,
                             mask_local=self.is_local,
+                            mask_sink=self.is_local,
                         ),
                     )
                     O_should_accumulate = True
                 # if cute.arch.thread_idx()[0] == 128: cute.printf("m_block = {}, n_block_max = {}, n_block_min = {}", m_block, n_block_max, n_block_min)
-                n_block_max -= 1
+                n_block_max = cutlass.max(n_block_max - 1, n_block_min)
                 n_block_max_no_mask = cutlass.min(n_block_max_no_mask, n_block_max)
                 # Next couple of iterations with causal masking
                 for n_tile in cutlass.range(n_block_max - n_block_max_no_mask, unroll=1):
@@ -3128,13 +3219,16 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         acc_O: Optional[cute.Tensor] = None,
         mask_fn: Callable = None,
         score_mod_fn: Optional[Callable] = None,
+        skip_fn: Optional[Callable] = None,
+        rSkip: Optional[cute.Tensor] = None,
         is_first_block: bool = False,
     ):
         """Processes the first half block when using intra-warpgroup-overlap"""
 
-        pipeline_k.consumer_wait(kv_consumer_state, pipeline_k.consumer_try_wait(kv_consumer_state))
-        acc_S = mma_qk_fn(B_idx=kv_consumer_state.index, wg_wait=0)
-        pipeline_k.consumer_release(kv_consumer_state)
+        k_consumer_state, v_consumer_state = kv_consumer_state
+        pipeline_k.consumer_wait(k_consumer_state, pipeline_k.consumer_try_wait(k_consumer_state))
+        acc_S = mma_qk_fn(B_idx=k_consumer_state.index, wg_wait=0)
+        pipeline_k.consumer_release(k_consumer_state)
 
         # Apply score modification if present
         if const_expr(score_mod_fn is not None):
@@ -3145,32 +3239,38 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         # however, masking is being applied anyway, so essentially no perf hit
         mask_fn(acc_S, n_block=n_block, mask_seqlen=True)
 
-        row_scale = softmax.online_softmax(acc_S, is_first=is_first_block)
-
         tOrP_acc = layout_utils.reshape_acc_to_frgA(acc_S)
         tOrP_cur = (
             tOrP
             if const_expr(self.mma_pv_is_rs)
             else cute.make_rmem_tensor_like(tOrP_acc, self.dtype)
         )
-        tOrP_cur.store(tOrP_acc.load().to(self.dtype))
+        tPrP = (
+            smem_copy_params.smem_thr_copy_P.retile(tOrP_cur)
+            if const_expr(not self.mma_pv_is_rs)
+            else None
+        )
+        is_skip = skip_fn(acc_S, is_first=is_first_block)
+        rSkip[0] = Int32(is_skip)
+        if not is_skip:
+            row_scale = softmax.online_softmax(acc_S, is_first=is_first_block)
+            tOrP_cur.store(tOrP_acc.load().to(self.dtype))
 
-        if const_expr(not self.mma_pv_is_rs):
-            tPrP = smem_copy_params.smem_thr_copy_P.retile(tOrP_cur)
-            cute.copy(smem_copy_params.smem_thr_copy_P, tPrP, smem_copy_params.tPsP)
-            # Fence and barrier to make smem store visible to WGMMA
-            cute.arch.fence_view_async_shared()
-            cute.arch.sync_warp()
+            if const_expr(not self.mma_pv_is_rs):
+                cute.copy(smem_copy_params.smem_thr_copy_P, tPrP, smem_copy_params.tPsP)
+                # Fence and barrier to make smem store visible to WGMMA
+                cute.arch.fence_view_async_shared()
+                cute.arch.sync_warp()
 
-        # For RescaleOBeforeGemm: initialize acc_O
-        if const_expr(self.rescale_O_before_gemm):
-            if const_expr(is_first_block):
-                acc_O.fill(0.0)
-            scores_scale.store(row_scale.load())
-        elif const_expr(not is_first_block):
-            softmax.rescale_O(acc_O, row_scale)
+            # For RescaleOBeforeGemm: initialize acc_O
+            if const_expr(self.rescale_O_before_gemm):
+                if const_expr(is_first_block):
+                    acc_O.fill(0.0)
+                scores_scale.store(row_scale.load())
+            elif const_expr(not is_first_block):
+                softmax.rescale_O(acc_O, row_scale)
 
-        return kv_consumer_state
+        return k_consumer_state, v_consumer_state
 
     @cute.jit
     def last_half_block_overlap(
@@ -3182,18 +3282,22 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         scores_scale: Optional[cute.Tensor] = None,
         softmax: Optional[Softmax] = None,
         acc_O: Optional[cute.Tensor] = None,
+        rSkip: Optional[cute.Tensor] = None,
     ):
         """Processes the final PV GEMM when using intra-warpgroup-overlap"""
 
-        # For RescaleOBeforeGemm: rescale O before the final PV GEMM
-        if const_expr(self.rescale_O_before_gemm):
-            softmax.rescale_O(acc_O, scores_scale)
-
-        pipeline_v.consumer_wait(kv_consumer_state, pipeline_v.consumer_try_wait(kv_consumer_state))
-        mma_pv_fn(B_idx=kv_consumer_state.index, zero_init=zero_init, wg_wait=0)
-        pipeline_v.consumer_release(kv_consumer_state)
-        kv_consumer_state.advance()
-        return kv_consumer_state
+        k_consumer_state, v_consumer_state = kv_consumer_state
+        pipeline_v.consumer_wait(v_consumer_state, pipeline_v.consumer_try_wait(v_consumer_state))
+        is_skip = cutlass.Boolean(rSkip[0] != 0)
+        if not is_skip:
+            # For RescaleOBeforeGemm: rescale O before the final PV GEMM
+            if const_expr(self.rescale_O_before_gemm):
+                softmax.rescale_O(acc_O, scores_scale)
+            mma_pv_fn(B_idx=v_consumer_state.index, zero_init=zero_init, wg_wait=0)
+        pipeline_v.consumer_release(v_consumer_state)
+        v_consumer_state.advance()
+        k_consumer_state.advance()
+        return k_consumer_state, v_consumer_state
 
     @cute.jit
     def mma_one_n_block(
@@ -3212,15 +3316,18 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         scores_scale: Optional[cute.Tensor] = None,  # not used
         score_mod_fn: Optional[Callable] = None,
         mask_fn: Optional[Callable] = None,
+        skip_fn: Optional[Callable] = None,
+        rSkip: Optional[cute.Tensor] = None,
         is_first_n_block: cutlass.Constexpr = False,
         check_inf: cutlass.Constexpr = True,
     ):
-        pipeline_k.consumer_wait(smem_pipe_read, pipeline_k.consumer_try_wait(smem_pipe_read))
+        smem_pipe_read_k, smem_pipe_read_v = smem_pipe_read
+        pipeline_k.consumer_wait(smem_pipe_read_k, pipeline_k.consumer_try_wait(smem_pipe_read_k))
         # S = Q @ K.T
-        acc_S = mma_qk_fn(B_idx=smem_pipe_read.index, wg_wait=-1)
+        acc_S = mma_qk_fn(B_idx=smem_pipe_read_k.index, wg_wait=-1)
         self.warp_scheduler_barrier_arrive()
         warpgroup.wait_group(0)
-        pipeline_k.consumer_release(smem_pipe_read)
+        pipeline_k.consumer_release(smem_pipe_read_k)
 
         # handle score mods and masking
         if const_expr(score_mod_fn is not None):
@@ -3228,34 +3335,45 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         if const_expr(mask_fn is not None):
             mask_fn(acc_S=acc_S, n_block=n_block)
 
-        row_scale = softmax.online_softmax(acc_S, is_first=is_first_n_block, check_inf=check_inf)
-        # if cute.arch.thread_idx()[0] == 0: cute.print_tensor(layout_utils.reshape_acc_to_mn(acc_S))
         tOrP_acc = layout_utils.reshape_acc_to_frgA(acc_S)
         tOrP_cur = (
             tOrP
             if const_expr(self.mma_pv_is_rs)
             else cute.make_rmem_tensor_like(tOrP_acc, self.dtype)
         )
-        # tOrP.store(tOrP_acc.load().to(self.dtype))
-        # the "to(self.dtype)" conversion fails to vectorize for block sizes other
-        # than 128 x 128, i.e. it calls convert on 1 fp32 element at a time instead of
-        # 2 elements. So we just call ptx directly.
-        utils.cvt_f16(tOrP_acc, tOrP_cur)
-        if const_expr(not self.mma_pv_is_rs):
-            tPrP = smem_copy_params.smem_thr_copy_P.retile(tOrP_cur)
-            cute.copy(smem_copy_params.smem_thr_copy_P, tPrP, smem_copy_params.tPsP)
-        softmax.rescale_O(acc_O, row_scale)
-        if const_expr(not self.mma_pv_is_rs):
-            # Fence and barrier to make sure smem store is visible to WGMMA
-            cute.arch.fence_view_async_shared()
-            cute.arch.sync_warp()  # Only need syncwarp since each warp is using its own P values for MmaPV
-        pipeline_v.consumer_wait(smem_pipe_read, pipeline_v.consumer_try_wait(smem_pipe_read))
+        tPrP = (
+            smem_copy_params.smem_thr_copy_P.retile(tOrP_cur)
+            if const_expr(not self.mma_pv_is_rs)
+            else None
+        )
+        is_skip = skip_fn(acc_S, is_first=is_first_n_block)
+        rSkip[0] = Int32(is_skip)
+        if not is_skip:
+            row_scale = softmax.online_softmax(
+                acc_S, is_first=is_first_n_block, check_inf=check_inf
+            )
+            # if cute.arch.thread_idx()[0] == 0: cute.print_tensor(layout_utils.reshape_acc_to_mn(acc_S))
+            # tOrP.store(tOrP_acc.load().to(self.dtype))
+            # the "to(self.dtype)" conversion fails to vectorize for block sizes other
+            # than 128 x 128, i.e. it calls convert on 1 fp32 element at a time instead of
+            # 2 elements. So we just call ptx directly.
+            utils.cvt_f16(tOrP_acc, tOrP_cur)
+            if const_expr(not self.mma_pv_is_rs):
+                cute.copy(smem_copy_params.smem_thr_copy_P, tPrP, smem_copy_params.tPsP)
+            softmax.rescale_O(acc_O, row_scale)
+            if const_expr(not self.mma_pv_is_rs):
+                # Fence and barrier to make sure smem store is visible to WGMMA
+                cute.arch.fence_view_async_shared()
+                cute.arch.sync_warp()  # Only need syncwarp since each warp is using its own P values for MmaPV
+        pipeline_v.consumer_wait(smem_pipe_read_v, pipeline_v.consumer_try_wait(smem_pipe_read_v))
         self.warp_scheduler_barrier_sync()
-        # O += P @ V
-        mma_pv_fn(B_idx=smem_pipe_read.index, wg_wait=0)
-        pipeline_v.consumer_release(smem_pipe_read)
-        smem_pipe_read.advance()
-        return smem_pipe_read
+        if not is_skip:
+            # O += P @ V
+            mma_pv_fn(B_idx=smem_pipe_read_v.index, wg_wait=0)
+        pipeline_v.consumer_release(smem_pipe_read_v)
+        smem_pipe_read_k.advance()
+        smem_pipe_read_v.advance()
+        return smem_pipe_read_k, smem_pipe_read_v
 
     @cute.jit
     def mma_one_n_block_intrawg_overlap(
@@ -3274,23 +3392,31 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
         scores_scale: Optional[cute.Tensor] = None,
         score_mod_fn: Optional[Callable] = None,
         mask_fn: Optional[Callable] = None,
+        skip_fn: Optional[Callable] = None,
+        rSkip: Optional[cute.Tensor] = None,
         check_inf: cutlass.Constexpr = True,
     ):
-        smem_pipe_read_v = smem_pipe_read.clone()
-        smem_pipe_read.advance()
-        pipeline_k.consumer_wait(smem_pipe_read, pipeline_k.consumer_try_wait(smem_pipe_read))
+        smem_pipe_read_k, smem_pipe_read_v = smem_pipe_read
+        is_prev_block_skip = cutlass.Boolean(rSkip[0] != 0)
+        smem_pipe_read_k.advance()
+        pipeline_k.consumer_wait(smem_pipe_read_k, pipeline_k.consumer_try_wait(smem_pipe_read_k))
         self.warp_scheduler_barrier_sync()
         # S = Q @ K.T
-        acc_S = mma_qk_fn(B_idx=smem_pipe_read.index, wg_wait=-1)
+        acc_S = mma_qk_fn(B_idx=smem_pipe_read_k.index, wg_wait=-1)
         # RescaleOBeforeGemm: rescale O while QK GEMM is in flight, before PV GEMM
-        if const_expr(self.rescale_O_before_gemm):
-            softmax.rescale_O(acc_O, scores_scale)
+        if not is_prev_block_skip:
+            if const_expr(self.rescale_O_before_gemm):
+                softmax.rescale_O(acc_O, scores_scale)
         pipeline_v.consumer_wait(smem_pipe_read_v, pipeline_v.consumer_try_wait(smem_pipe_read_v))
-        # O += P @ V
-        mma_pv_fn(B_idx=smem_pipe_read_v.index, wg_wait=-1)
+        if is_prev_block_skip:
+            warpgroup.wait_group(0)
+        else:
+            # O += P @ V
+            mma_pv_fn(B_idx=smem_pipe_read_v.index, wg_wait=-1)
         self.warp_scheduler_barrier_arrive()
-        warpgroup.wait_group(1)
-        pipeline_k.consumer_release(smem_pipe_read)
+        if not is_prev_block_skip:
+            warpgroup.wait_group(1)
+        pipeline_k.consumer_release(smem_pipe_read_k)
 
         # handle score mods and masking
         if const_expr(score_mod_fn is not None):
@@ -3299,32 +3425,44 @@ class FlashSparseAttentionForwardSm90(FlashSparseAttentionForwardBase):
             mask_fn(acc_S=acc_S, n_block=n_block)
         # if cute.arch.thread_idx()[0] == 128: cute.print_tensor(layout_utils.reshape_acc_to_mn(acc_S))
 
-        row_scale = softmax.online_softmax(acc_S, check_inf=check_inf)
-        warpgroup.wait_group(0)
-        pipeline_v.consumer_release(smem_pipe_read_v)
         tOrP_acc = layout_utils.reshape_acc_to_frgA(acc_S)
         tOrP_cur = (
             tOrP
             if const_expr(self.mma_pv_is_rs)
             else cute.make_rmem_tensor_like(tOrP_acc, self.dtype)
         )
-        # tOrP_cur.store(tOrP_acc.load().to(self.dtype))
-        # the "to(self.dtype)" conversion fails to vectorize for block sizes other
-        # than 128 x 128, i.e. it calls convert on 1 fp32 element at a time instead of
-        # 2 elements. So we just call ptx directly.
-        utils.cvt_f16(tOrP_acc, tOrP_cur)
-        if const_expr(not self.mma_pv_is_rs):
-            tPrP = smem_copy_params.smem_thr_copy_P.retile(tOrP_cur)
-            cute.copy(smem_copy_params.smem_thr_copy_P, tPrP, smem_copy_params.tPsP)
-        if const_expr(not self.rescale_O_before_gemm):
-            softmax.rescale_O(acc_O, row_scale)
-        if const_expr(self.rescale_O_before_gemm):
-            scores_scale.store(row_scale.load())
-        if const_expr(not self.mma_pv_is_rs):
-            # Fence and barrier to make sure smem store is visible to WGMMA
-            cute.arch.fence_view_async_shared()
-            cute.arch.sync_warp()  # Only need syncwarp since each warp is using its own P values for MmaPV
-        return smem_pipe_read
+        tPrP = (
+            smem_copy_params.smem_thr_copy_P.retile(tOrP_cur)
+            if const_expr(not self.mma_pv_is_rs)
+            else None
+        )
+        warpgroup.wait_group(0)
+        cute.arch.barrier(
+            barrier_id=int(NamedBarrierFwd.Softmax),
+            number_of_threads=self.num_mma_threads,
+        )
+        pipeline_v.consumer_release(smem_pipe_read_v)
+        is_skip = skip_fn(acc_S)
+        rSkip[0] = Int32(is_skip)
+        if not is_skip:
+            row_scale = softmax.online_softmax(acc_S, check_inf=check_inf)
+            # tOrP_cur.store(tOrP_acc.load().to(self.dtype))
+            # the "to(self.dtype)" conversion fails to vectorize for block sizes other
+            # than 128 x 128, i.e. it calls convert on 1 fp32 element at a time instead of
+            # 2 elements. So we just call ptx directly.
+            utils.cvt_f16(tOrP_acc, tOrP_cur)
+            if const_expr(not self.mma_pv_is_rs):
+                cute.copy(smem_copy_params.smem_thr_copy_P, tPrP, smem_copy_params.tPsP)
+            if const_expr(not self.rescale_O_before_gemm):
+                softmax.rescale_O(acc_O, row_scale)
+            if const_expr(self.rescale_O_before_gemm):
+                scores_scale.store(row_scale.load())
+            if const_expr(not self.mma_pv_is_rs):
+                # Fence and barrier to make sure smem store is visible to WGMMA
+                cute.arch.fence_view_async_shared()
+                cute.arch.sync_warp()  # Only need syncwarp since each warp is using its own P values for MmaPV
+        smem_pipe_read_v.advance()
+        return smem_pipe_read_k, smem_pipe_read_v
 
     @cute.jit
     def mma_init(self):

--- a/flash_sparse_attn/ops/cute/interface.py
+++ b/flash_sparse_attn/ops/cute/interface.py
@@ -331,9 +331,7 @@ def window_sizes_heuristic(
     if equal_bandwidth:
         breakpoints = distance_span * head_kv_idx / num_heads_kv_global
     else:
-        breakpoints = distance_span * (
-            1.0 - torch.sqrt(1.0 - head_kv_idx / num_heads_kv_global)
-        )
+        breakpoints = distance_span * (1.0 - torch.sqrt(1.0 - head_kv_idx / num_heads_kv_global))
     window_size_left = breakpoints[1:] - breakpoints[:-1]
     window_size_right = breakpoints[:-1]
     window_size_dist = torch.full_like(window_size_left, window_dist, dtype=torch.int32)

--- a/flash_sparse_attn/ops/cute/interface.py
+++ b/flash_sparse_attn/ops/cute/interface.py
@@ -37,7 +37,7 @@ from flash_sparse_attn.ops.cute.cute_dsl_utils import (
 from flash_sparse_attn.ops.cute.flash_fwd import (
     FlashSparseAttentionForwardSm80,
 )
-from flash_sparse_attn.ops.cute.flash_fwd_sm90 import FlashAttentionForwardSm90
+from flash_sparse_attn.ops.cute.flash_fwd_sm90 import FlashSparseAttentionForwardSm90
 from flash_sparse_attn.ops.cute.flash_fwd_sm100 import FlashAttentionForwardSm100, DescaleTensors
 from flash_sparse_attn.ops.cute.flash_fwd_sm120 import (
     FlashSparseAttentionForwardSm120,
@@ -46,7 +46,7 @@ from flash_sparse_attn.ops.cute.flash_bwd_preprocess import FlashAttentionBackwa
 from flash_sparse_attn.ops.cute.flash_bwd import (
     FlashSparseAttentionBackwardSm80,
 )
-from flash_sparse_attn.ops.cute.flash_bwd_sm90 import FlashAttentionBackwardSm90
+from flash_sparse_attn.ops.cute.flash_bwd_sm90 import FlashSparseAttentionBackwardSm90
 from flash_sparse_attn.ops.cute.flash_bwd_sm100 import FlashAttentionBackwardSm100
 from flash_sparse_attn.ops.cute.flash_bwd_sm120 import (
     FlashSparseAttentionBackwardSm120,
@@ -160,7 +160,6 @@ class BwdConfig:
     m_block_size: int
     n_block_size: int
     num_stages_Q: int
-    num_stages_dO: int
     num_stages_PdS: int
     SdP_swapAB: bool
     dKV_swapAB: bool
@@ -184,7 +183,6 @@ def _tile_size_bwd_sm90(head_dim, causal, local, sparse_block_size_q=None):
             m_block_size=128,
             n_block_size=128,
             num_stages_Q=2,
-            num_stages_dO=2,
             num_stages_PdS=2,
             SdP_swapAB=True,
             dKV_swapAB=False,
@@ -199,7 +197,6 @@ def _tile_size_bwd_sm90(head_dim, causal, local, sparse_block_size_q=None):
             m_block_size=64,
             n_block_size=128,
             num_stages_Q=2,
-            num_stages_dO=2,
             num_stages_PdS=2,
             SdP_swapAB=True,
             dKV_swapAB=False,
@@ -219,7 +216,6 @@ def _tile_size_bwd_sm90(head_dim, causal, local, sparse_block_size_q=None):
             m_block_size=m_block_size,
             n_block_size=128,
             num_stages_Q=2,
-            num_stages_dO=2,
             num_stages_PdS=2,
             SdP_swapAB=True,
             dKV_swapAB=False,
@@ -233,7 +229,6 @@ def _tile_size_bwd_sm90(head_dim, causal, local, sparse_block_size_q=None):
             m_block_size=64,
             n_block_size=96,
             num_stages_Q=2,
-            num_stages_dO=1,
             num_stages_PdS=1,
             SdP_swapAB=False,
             dKV_swapAB=True,
@@ -249,7 +244,6 @@ def _tile_size_bwd_sm90(head_dim, causal, local, sparse_block_size_q=None):
             m_block_size=64,
             n_block_size=64,
             num_stages_Q=1,
-            num_stages_dO=1,
             num_stages_PdS=1,
             SdP_swapAB=False,
             dKV_swapAB=False,
@@ -329,13 +323,15 @@ def window_sizes_heuristic(
     window_sink = min(max(window_sink, 0), max(seqlen_k - window_dist, 0))
     distance_span = max(seqlen_k - window_sink - window_dist, 0)
     if equal_bandwidth:
-        breakpoints = distance_span * head_kv_idx / num_heads_kv_global
+        breakpoints = (distance_span * head_kv_idx / num_heads_kv_global).to(torch.int32)
     else:
-        breakpoints = distance_span * (1.0 - torch.sqrt(1.0 - head_kv_idx / num_heads_kv_global))
+        breakpoints = (
+            distance_span * (1.0 - torch.sqrt(1.0 - head_kv_idx / num_heads_kv_global))
+        ).to(torch.int32)
     window_size_left = breakpoints[1:] - breakpoints[:-1]
     window_size_right = breakpoints[:-1]
-    window_size_dist = torch.full_like(window_size_left, window_dist, dtype=torch.int32)
-    window_size_sink = torch.full_like(window_size_left, window_sink, dtype=torch.int32)
+    window_size_dist = torch.full_like(window_size_left, window_dist)
+    window_size_sink = torch.full_like(window_size_left, window_sink)
     return torch.stack(
         [window_size_sink, window_size_left, window_size_right, window_size_dist], dim=1
     ).to(device)
@@ -490,9 +486,9 @@ def _flash_attn_fwd(
             )
         ), "inputs must be on CUDA device"
     arch = _get_device_arch() if _arch is None else _arch
-    # TODO: support 9.x, 10.x, 11.x for FSA
-    assert arch // 10 in [8, 12], (
-        "Unsupported compute capability. Supported: 8.x, 12.x for FlashSparseAttention yet."
+    # TODO: support 10.x, 11.x for FSA
+    assert arch // 10 in [8, 9, 12], (
+        "Unsupported compute capability. Supported: 8.x, 9.x, 12.x for FlashSparseAttention yet."
     )
     assert arch // 10 in [8, 9, 10, 11, 12], (
         "Unsupported compute capability. Supported: 8.x, 9.x, 10.x, 11.x, 12.x"
@@ -848,7 +844,7 @@ def _flash_attn_fwd(
             )
         elif arch // 10 == 9:
             assert not is_split_kv, "SplitKV not supported on SM 9.0"
-            fa_fwd = FlashAttentionForwardSm90(
+            fa_fwd = FlashSparseAttentionForwardSm90(
                 dtype,
                 head_dim,
                 qhead_per_kvhead,
@@ -1360,13 +1356,20 @@ def _flash_attn_bwd(
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     aux_scalars = tuple(aux_scalars) if aux_scalars else None
     arch = _get_device_arch()
-    # TODO: support 9.x, 10.x, 11.x for FSA
-    assert arch // 10 in [8, 12], (
-        "Unsupported compute capability. Supported: 8.x, 12.x for FlashSparseAttention yet."
+    # TODO: support 10.x and 11.x for FSA
+    assert arch // 10 in [8, 9, 12], (
+        "Unsupported compute capability. Supported: 8.x, 9.x, 12.x for FlashSparseAttention yet."
     )
     assert arch // 10 in [8, 9, 10, 11, 12], (
         "Unsupported compute capability. Supported: 8.x, 9.x, 10.x, 11.x, 12.x"
     )
+    if block_sparse_tensors is not None:
+        assert window_sizes is None, (
+            "block sparsity and window sizes cannot be enabled at the same time"
+        )
+        assert softmax_threshold is None, (
+            "block sparsity and softmax threshold cannot be enabled at the same time"
+        )
     sparse_q = None
     kv_subtile_factor = 1
     if block_sparse_tensors is not None:
@@ -1439,7 +1442,6 @@ def _flash_attn_bwd(
         m_block_size = cfg.m_block_size
         n_block_size = cfg.n_block_size
         num_stages_Q = cfg.num_stages_Q
-        num_stages_dO = cfg.num_stages_dO
         num_stages_PdS = cfg.num_stages_PdS
         SdP_swapAB = cfg.SdP_swapAB
         dKV_swapAB = cfg.dKV_swapAB
@@ -1824,7 +1826,7 @@ def _flash_attn_bwd(
             num_threads,
             pack_gqa,
             num_stages_Q,
-            None if softmax_threshold is not None else num_stages_dO,
+            None,  # num_stages_dO
             SdP_swapAB,
             dKV_swapAB,
             dQ_swapAB,
@@ -1948,7 +1950,7 @@ def _flash_attn_bwd(
                 score_mod_bwd=score_mod_bwd,
             )
         elif arch // 10 == 9:
-            fa_bwd_obj = FlashAttentionBackwardSm90(
+            fa_bwd_obj = FlashSparseAttentionBackwardSm90(
                 dtype,
                 head_dim,
                 qhead_per_kvhead,
@@ -1958,7 +1960,6 @@ def _flash_attn_bwd(
                 tile_m=m_block_size,
                 tile_n=n_block_size,
                 Q_stage=num_stages_Q,
-                dO_stage=num_stages_dO,
                 PdS_stage=num_stages_PdS,
                 SdP_swapAB=SdP_swapAB,
                 dKV_swapAB=dKV_swapAB,

--- a/flash_sparse_attn/ops/cute/named_barrier.py
+++ b/flash_sparse_attn/ops/cute/named_barrier.py
@@ -10,6 +10,7 @@ class NamedBarrierFwd(enum.IntEnum):
     WarpSchedulerWG3 = enum.auto()
     PFull = enum.auto()
     PEmpty = enum.auto()
+    Softmax = enum.auto()
 
 
 class NamedBarrierFwdSm100(enum.IntEnum):
@@ -37,6 +38,9 @@ class NamedBarrierBwd(enum.IntEnum):
     dQEmptyWG0 = enum.auto()
     dQEmptyWG1 = enum.auto()
     dQEmptyWG2 = enum.auto()
+    Softmax = enum.auto()
+    dOLoadFull = enum.auto()
+    dOLoadEmpty = enum.auto()
 
 
 class NamedBarrierBwdSm100(enum.IntEnum):

--- a/flash_sparse_attn/ops/cute/pipeline.py
+++ b/flash_sparse_attn/ops/cute/pipeline.py
@@ -301,6 +301,31 @@ class PipelineCpAsync(_PipelineIndexPhaseMixin, PipelineCpAsyncOg):
 class PipelineTmaAsync(_PipelineIndexPhaseMixin, PipelineTmaAsyncOg):
     """Override producer_acquire to take in extra_tx_count parameter."""
 
+    _sSkip: Optional[cute.Tensor] = None
+    _barrier_full_id: int = 0
+    _barrier_empty_id: int = 0
+    _skip_num_threads: int = 0
+    _producer_skip_idx: int = 0
+
+    @staticmethod
+    def create(
+        *args,
+        sSkip: Optional[cute.Tensor] = None,
+        barrier_full_id: int = 0,
+        barrier_empty_id: int = 0,
+        skip_num_threads: int = 0,
+        producer_skip_idx: int = 0,
+        **kwargs,
+    ):
+        obj = PipelineTmaAsyncOg.create(*args, **kwargs)
+        object.__setattr__(obj, "__class__", PipelineTmaAsync)
+        object.__setattr__(obj, "_sSkip", sSkip)
+        object.__setattr__(obj, "_barrier_full_id", barrier_full_id)
+        object.__setattr__(obj, "_barrier_empty_id", barrier_empty_id)
+        object.__setattr__(obj, "_skip_num_threads", skip_num_threads)
+        object.__setattr__(obj, "_producer_skip_idx", producer_skip_idx)
+        return obj
+
     @dsl_user_op
     def producer_acquire(
         self,
@@ -314,6 +339,21 @@ class PipelineTmaAsync(_PipelineIndexPhaseMixin, PipelineTmaAsyncOg):
         """
         TMA producer commit conditionally waits on buffer empty and sets the transaction barrier for leader threadblocks.
         """
+        if const_expr(self._sSkip is not None):
+            cute.arch.barrier(
+                barrier_id=self._barrier_full_id,
+                number_of_threads=self._skip_num_threads,
+            )
+            is_skip = Boolean(self._sSkip[0] != 0)
+            with cute.arch.elect_one():
+                self._sSkip[self._producer_skip_idx] = Int32(is_skip)
+            cute.arch.sync_warp()
+            cute.arch.barrier(
+                barrier_id=self._barrier_empty_id,
+                number_of_threads=self._skip_num_threads,
+            )
+        else:
+            is_skip = Boolean(False)
         if_generate(
             try_acquire_token is None or try_acquire_token == 0,
             lambda: self.sync_object_empty.wait(state.index, state.phase, loc=loc, ip=ip),
@@ -321,13 +361,41 @@ class PipelineTmaAsync(_PipelineIndexPhaseMixin, PipelineTmaAsyncOg):
             ip=ip,
         )
         if const_expr(extra_tx_count == 0):
-            self.sync_object_full.arrive(state.index, self.producer_mask, loc=loc, ip=ip)
+            if_generate(
+                is_skip,
+                lambda: self.producer_arrive_no_tma(state, loc=loc, ip=ip),
+                lambda: self.sync_object_full.arrive(
+                    state.index, self.producer_mask, loc=loc, ip=ip
+                ),
+                loc=loc,
+                ip=ip,
+            )
         else:
             tx_count = self.sync_object_full.tx_count + extra_tx_count
-            self.sync_object_full.arrive_and_expect_tx(state.index, tx_count, loc=loc, ip=ip)
+            if_generate(
+                is_skip,
+                lambda: self.producer_arrive_no_tma(state, loc=loc, ip=ip),
+                lambda: self.sync_object_full.arrive_and_expect_tx(
+                    state.index, tx_count, loc=loc, ip=ip
+                ),
+                loc=loc,
+                ip=ip,
+            )
 
+    @dsl_user_op
+    def producer_arrive_no_tma(self, state: PipelineState, *, loc=None, ip=None):
+        with cute.arch.elect_one(loc=loc, ip=ip):
+            cute.arch.mbarrier_arrive(
+                self.sync_object_full.get_barrier(state.index, loc=loc, ip=ip),
+                loc=loc,
+                ip=ip,
+            )
 
-PipelineTmaAsync.create = _override_create(PipelineTmaAsyncOg, PipelineTmaAsync)
+    @dsl_user_op
+    def producer_tail(self, state: PipelineState, *, loc=None, ip=None):
+        for _ in range(self.num_stages - 1):
+            state.advance(loc=loc, ip=ip)
+        PipelineTmaAsyncOg.producer_acquire(self, state, loc=loc, ip=ip)
 
 
 # ── PipelineTmaUmma ─────────────────────────────────────────────────────────

--- a/flash_sparse_attn/ops/cute/seqlen_info.py
+++ b/flash_sparse_attn/ops/cute/seqlen_info.py
@@ -226,10 +226,11 @@ class SeqlenInfoQK:
         tile_n: cutlass.Constexpr[int],
         is_causal: cutlass.Constexpr[bool],
         qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1,
+        transpose: cutlass.Constexpr[bool] = False,
     ):
         softmax_threshold_log2 = cute.make_fragment_like(row_fragment, Float32)
-        cS = cute.make_identity_tensor((tile_m, tile_n))
-        tScS_mn = layout_utils.reshape_acc_to_mn(thr_mma.partition_C(cS))
+        cS = cute.make_identity_tensor((tile_n, tile_m) if transpose else (tile_m, tile_n))
+        tScS_mn = layout_utils.reshape_acc_to_mn(thr_mma.partition_C(cS), transpose=transpose)
         for r in range(cute.size(softmax_threshold_log2)):
             q_idx = m_block * tile_m + tScS_mn[r, 0][0]
             if const_expr(qhead_per_kvhead_packgqa > 1):

--- a/flash_sparse_attn/ops/cute/softmax.py
+++ b/flash_sparse_attn/ops/cute/softmax.py
@@ -197,32 +197,55 @@ class Softmax(ParamsBase):
         sSkip: cute.Tensor,
         num_warps: cutlass.Constexpr[int],
         is_first: cutlass.Constexpr[bool] = False,
+        tidx_offset: cutlass.Constexpr[int] = 0,
+        barrier_reduce_id: cutlass.Constexpr[int] = 0,
+        barrier_full_id: cutlass.Constexpr[int] = 0,
+        barrier_empty_id: cutlass.Constexpr[int] = 0,
     ) -> Boolean:
         """Determine whether to skip the softmax computation for this S."""
+        num_threads = num_warps * cute.arch.WARP_SIZE
         if cutlass.const_expr(is_first):
-            cute.arch.barrier()
-            return Boolean(False)
+            if cute.arch.thread_idx()[0] == tidx_offset:
+                sSkip[0] = Int32(0)
+            is_skip = Boolean(False)
+        else:
+            acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S)
+            row_sum_reduced = utils.warp_reduce(self.row_sum.load(), operator.add, width=4)
+            warp_skip = Boolean(True)
+            for r in cutlass.range(cute.size(self.row_max), unroll_full=True):
+                acc_S_row = acc_S_mn[r, None].load()
+                row_max_cur = self._compute_row_max(acc_S_row)
+                row_max_cur = cute.arch.warp_reduction_max(row_max_cur, threads_in_group=4)
+                row_max_diff_log2 = (
+                    row_max_cur - self.row_max[r]
+                ) * self.scale_log2 - cute.math.log2(row_sum_reduced[r], fastmath=True)
+                warp_skip = warp_skip and row_max_diff_log2 < softmax_threshold_log2[r]
 
-        acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S)
-        row_sum_reduced = utils.warp_reduce(self.row_sum.load(), operator.add, width=4)
-        warp_skip = Boolean(True)
-        for r in cutlass.range(cute.size(self.row_max), unroll_full=True):
-            acc_S_row = acc_S_mn[r, None].load()
-            row_max_cur = self._compute_row_max(acc_S_row)
-            row_max_cur = cute.arch.warp_reduction_max(row_max_cur, threads_in_group=4)
-            row_max_diff_log2 = (row_max_cur - self.row_max[r]) * self.scale_log2 - cute.math.log2(
-                row_sum_reduced[r], fastmath=True
+            cta_skip = utils.cta_reduce(
+                Int32(1) if warp_skip else Int32(0),
+                sSkip,
+                operator.and_,
+                Int32(1),
+                num_warps,
+                tidx_offset,
+                barrier_reduce_id,
             )
-            warp_skip = warp_skip and row_max_diff_log2 < softmax_threshold_log2[r]
-
-        cta_skip = utils.cta_reduce(
-            Int32(1) if warp_skip else Int32(0),
-            sSkip,
-            operator.and_,
-            Int32(1),
-            num_warps,
-        )
-        is_skip = Boolean(cta_skip != 0)
+            is_skip = Boolean(cta_skip != 0)
+        if cutlass.const_expr(barrier_full_id != 0):
+            feedback_num_threads = num_threads + cute.arch.WARP_SIZE
+            cute.arch.barrier(
+                barrier_id=barrier_full_id,
+                number_of_threads=feedback_num_threads,
+            )
+            cute.arch.barrier(
+                barrier_id=barrier_empty_id,
+                number_of_threads=feedback_num_threads,
+            )
+        elif cutlass.const_expr(is_first):
+            cute.arch.barrier(
+                barrier_id=barrier_reduce_id,
+                number_of_threads=num_threads,
+            )
         return is_skip
 
     @cute.jit

--- a/flash_sparse_attn/ops/cute/utils.py
+++ b/flash_sparse_attn/ops/cute/utils.py
@@ -340,15 +340,20 @@ def cta_reduce(
     op: Callable,
     identity: cute.Numeric,
     num_warps: cutlass.Constexpr[int],
+    tidx_offset: cutlass.Constexpr[int] = 0,
+    barrier_id: cutlass.Constexpr[int] = 0,
 ) -> cute.Numeric:
     assert num_warps <= cute.arch.WARP_SIZE
     warp_val = warp_reduce(val, op)
     tidx = cute.arch.thread_idx()[0]
     lane_idx = cute.arch.lane_idx()
-    warp_idx = tidx // cute.arch.WARP_SIZE
+    warp_idx = (tidx - tidx_offset) // cute.arch.WARP_SIZE
     if lane_idx == 0:
         sReduce[warp_idx] = warp_val
-    cute.arch.barrier()
+    cute.arch.barrier(
+        barrier_id=barrier_id,
+        number_of_threads=num_warps * cute.arch.WARP_SIZE,
+    )
     if warp_idx == 0:
         cta_val = identity
         if lane_idx < num_warps:
@@ -356,7 +361,10 @@ def cta_reduce(
         cta_val = warp_reduce(cta_val, op)
         if lane_idx == 0:
             sReduce[0] = cta_val
-    cute.arch.barrier()
+    cute.arch.barrier(
+        barrier_id=barrier_id,
+        number_of_threads=num_warps * cute.arch.WARP_SIZE,
+    )
     return sReduce[0]
 
 

--- a/flash_sparse_attn/ops/triton/utils.py
+++ b/flash_sparse_attn/ops/triton/utils.py
@@ -77,15 +77,17 @@ def window_sizes_heuristic(
     window_sink = min(max(window_sink, 0), max(seqlen_k - window_dist, 0))
     distance_span = max(seqlen_k - window_sink - window_dist, 0)
     if equal_bandwidth:
-        breakpoints = distance_span * head_kv_idx / num_heads_kv_global
-    else:
-        breakpoints = distance_span * (
-            1.0 - torch.sqrt(1.0 - head_kv_idx / num_heads_kv_global)
+        breakpoints = (distance_span * head_kv_idx / num_heads_kv_global).to(
+            torch.int32
         )
+    else:
+        breakpoints = (
+            distance_span * (1.0 - torch.sqrt(1.0 - head_kv_idx / num_heads_kv_global))
+        ).to(torch.int32)
     window_size_left = breakpoints[1:] - breakpoints[:-1]
     window_size_right = breakpoints[:-1]
-    window_size_dist = torch.full_like(window_size_left, window_dist, dtype=torch.int32)
-    window_size_sink = torch.full_like(window_size_left, window_sink, dtype=torch.int32)
+    window_size_dist = torch.full_like(window_size_left, window_dist)
+    window_size_sink = torch.full_like(window_size_left, window_sink)
     return torch.stack(
         [window_size_sink, window_size_left, window_size_right, window_size_dist], dim=1
     ).to(device)


### PR DESCRIPTION
## Summary

- enable dedicated CuTe sparse forward and backward dispatch on SM90;
- add flexible per-head window-size scheduling and masking to the SM90 kernels;
- add softmax-threshold skip handling for forward and backward pipelines;
- update pipeline, barrier, reduction, sequence-length, and block-info helpers required by the new control flow;
- preserve the existing block-sparse path and reject unsupported combinations with window sizes or softmax thresholds;
- normalize generated window-size tensors to `int32`.

Closes #352

## Validation

- SM90 causal local-window forward and backward correctness was checked with `softmax_threshold=1.0` across sequence lengths from 1K to 131K.
- Forward outputs and backward gradients align with the PyTorch reference and Triton within the expected BF16 tolerance.
